### PR TITLE
YoutubeUserIE improvements

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2187,7 +2187,16 @@ class YoutubeUserIE(InfoExtractor):
 
 			pagenum += 1
 
-		self._downloader.to_screen("[youtube] user %s: Collected %d video ids" % (username, len(video_ids)))
+		all_ids_count = len(video_ids)
+		playliststart = self._downloader.params.get('playliststart', 1) - 1
+		playlistend = self._downloader.params.get('playlistend', -1)
+
+		if playlistend == -1:
+			video_ids = video_ids[playliststart:]
+		else:
+			video_ids = video_ids[playliststart:playlistend]
+			
+		self._downloader.to_screen("[youtube] user %s: Collected %d video ids (downloading %d of them)" % (username, all_ids_count, len(video_ids)))
 
 		for video_id in video_ids:
 			try:


### PR DESCRIPTION
This branch contains some improvements to the way specific user's videos are downloaded. Before it didn't work (at least when I tested it), probably due to the fact that YT user channel pages now use AJAX to download a list of user videos.

I changed the approach by using YT Data API to collect all video ids. Let me know what you think.

TODO:
1. Properly handle playlist start/end parameters.
2. Perhaps handle command line in the form of "ytuser:<username>" - there is no real need for giving any URL's to this InfoExtractor, username should be enough (?).
