### PR TITLE
fix mto the swf file parsing and also adding of '&amp;has_verified=1' to the html fetch file

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -831,7 +831,7 @@ class YoutubeIE(InfoExtractor):
 
 		# Get video webpage
 		self.report_video_webpage_download(video_id)
-		request = urllib2.Request('http://www.youtube.com/watch?v=%s&gl=US&hl=en' % video_id, None, std_headers)
+		request = urllib2.Request('http://www.youtube.com/watch?v=%s&gl=US&hl=en&amp;has_verified=1' % video_id, None, std_headers)
 		try:
 			video_webpage = urllib2.urlopen(request).read()
 		except (urllib2.URLError, httplib.HTTPException, socket.error), err:
@@ -1027,7 +1027,7 @@ class MetacafeIE(InfoExtractor):
 		# Check if video comes from YouTube
 		mobj2 = re.match(r'^yt-(.*)$', video_id)
 		if mobj2 is not None:
-			self._youtube_ie.extract('http://www.youtube.com/watch?v=%s&amp;has_verified=1' % mobj2.group(1))
+			self._youtube_ie.extract('http://www.youtube.com/watch?v=%s' % mobj2.group(1))
 			return
 
 		# At this point we have a new video


### PR DESCRIPTION
Hi. 

1) The parsing for the SWF url was wrong (the "//" are now escaped and the initial .*match needs to be 'ungreedy'), so the -W setting to rtmpdump was not set, causing the decryption of the video to be wrong.

2) I also suggest only setting "-q" to rtmpdump if "-q" is sent to youtube-dl

3) adding '&amphas_verified=1' to the html file fetching overrides any age restriction questions
