### PR TITLE
Fixed youtube code due to recent changes in the site

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -941,7 +941,6 @@ class YoutubeIE(InfoExtractor):
 
 		# Decide which formats to download
 		requested_format = self._downloader.params.get('format', None)
-		get_video_template = 'http://www.youtube.com/get_video?video_id=%s&t=%s&eurl=&el=&ps=&asv=&fmt=%%s' % (video_id, video_token)
 
 		if 'fmt_url_map' in video_info:
 			url_map = dict(tuple(pair.split('|')) for pair in video_info['fmt_url_map'][0].split(','))
@@ -955,11 +954,11 @@ class YoutubeIE(InfoExtractor):
 				self._downloader.trouble(u'ERROR: no known formats available for video')
 				return
 			if requested_format is None:
-				video_url_list = [(existing_formats[0], get_video_template % existing_formats[0])] # Best quality
+				video_url_list = [(existing_formats[0], url_map[existing_formats[0]])] # Best quality
 			elif requested_format == '-1':
-				video_url_list = [(f, get_video_template % f) for f in existing_formats] # All formats
+				video_url_list = [(f, url_map[f]) for f in existing_formats] # All formats
 			else:
-				video_url_list = [(requested_format, get_video_template % requested_format)] # Specific format
+				video_url_list = [(requested_format, url_map[requested_format])] # Specific format
 
 		elif 'conn' in video_info and video_info['conn'][0].startswith('rtmp'):
 			self.report_rtmp_download()


### PR DESCRIPTION
Youtube no longer provides www.youtube.com/get_video interface and responds on these requests with HTTP 204 No Content. Native youtube flashplayer gets HTTP 204 code as well.

Video url is now extracted from fmt_map variable.
