### PR TITLE
add --dump-regexps option to print the regular expressions used to match supported sites

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2461,9 +2461,9 @@ if __name__ == '__main__':
 		# Dump regular expressions used to match supported sites
 		if opts.dump_regexps:
 			for ie in fd.ies:
-			    regex = ie.url_regex()
-			    if regex is not None:
-				print ie.url_regex()
+				regex = ie.url_regex()
+				if regex is not None:
+					print ie.url_regex()
 			sys.exit(0)
 
 		# Update version


### PR DESCRIPTION
I use youtube-dl as an optional downloader in a project where I don't have the luxury of invoking it on every URL to see if a site is supported. Instead, I keep a static list of the regexes used to match supported sites and manually update it by hand (well, by script and hand) periodically. Obviously this is fragile.

This patch allows youtube-dl to dump these regexes so I don't have to scrape them. Maybe someone else will find it useful.
