### PR TITLE
Enable additional playlist page type

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2096,7 +2096,7 @@ class YahooSearchIE(InfoExtractor):
 class YoutubePlaylistIE(InfoExtractor):
 	"""Information Extractor for YouTube playlists."""
 
-	_VALID_URL = r'(?:http://)?(?:\w+\.)?youtube.com/(?:(?:view_play_list|my_playlists|artist)\?.*?(p|a)=|user/.*?/user/|p/)([^&]+).*'
+	_VALID_URL = r'(?:http://)?(?:\w+\.)?youtube.com/(?:(?:view_play_list|my_playlists|artist)\?.*?(p|a)=|user/.*?/user/|p/|user/.*g/c/)([^&]+).*'
 	_TEMPLATE_URL = 'http://www.youtube.com/%s?%s=%s&page=%s&gl=US&hl=en'
 	_VIDEO_INDICATOR = r'/watch\?v=(.+?)&'
 	_MORE_PAGES_INDICATOR = r'(?m)>\s*Next\s*</a>'
@@ -2130,6 +2130,7 @@ class YoutubePlaylistIE(InfoExtractor):
 		if playlist_prefix == 'a':
 			playlist_access = 'artist'
 		else:
+			playlist_prefix = 'p'
 			playlist_access = 'view_play_list'
 		playlist_id = mobj.group(2)
 		video_ids = []


### PR DESCRIPTION
Recently I was trying to download a few playlists from lectures shared by Stanford and MIT. The collections of playlists are at http://www.youtube.com/user/stanforduniversity#g/p and http://www.youtube.com/user/mit#g/p . Each of the playlists have a link in the format of http://www.youtube.com/user/stanforduniversity#g/c/9D558D49CA734A02 which is currently caught by the YoutubeUserIE and then tries to download all the videos from the user. Fixed up the URL regex, extracted the playlist id and translate the url into a view_play_list type which is already handled.

Not sure how many other user accounts have such playlist formats (probably only some of the heavy users) but this definitely would have saved me a lot of cut-and-paste earlier. :)
