### PR TITLE
Extract additional playlist page type & related video link

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2096,7 +2096,8 @@ class YahooSearchIE(InfoExtractor):
 class YoutubePlaylistIE(InfoExtractor):
 	"""Information Extractor for YouTube playlists."""
 
-	_VALID_URL = r'(?:http://)?(?:\w+\.)?youtube.com/(?:(?:view_play_list|my_playlists|artist)\?.*?(p|a)=|user/.*?/user/|p/)([^&]+).*'
+	_VALID_URL = r'(?:http://)?(?:\w+\.)?youtube.com/(?:(?:view_play_list|my_playlists|artist)\?.*?(?P<Pre1>p|a)=|user/.*?/user/|p/|user/.*?#(?P<Pre2>g|p)/c/)(?P<ID>[^&]+).*'
+	_COMBO_ID = r'(?:[^&]+)/(?:[^&]+)/(?P<ID>[^&]+)'
 	_TEMPLATE_URL = 'http://www.youtube.com/%s?%s=%s&page=%s&gl=US&hl=en'
 	_VIDEO_INDICATOR = r'/watch\?v=(.+?)&'
 	_MORE_PAGES_INDICATOR = r'(?m)>\s*Next\s*</a>'
@@ -2125,17 +2126,28 @@ class YoutubePlaylistIE(InfoExtractor):
 			return
 
 		# Download playlist pages
-		# prefix is 'p' as default for playlists but there are other types that need extra care
-		playlist_prefix = mobj.group(1)
-		if playlist_prefix == 'a':
-			playlist_access = 'artist'
-		else:
-			playlist_access = 'view_play_list'
-		playlist_id = mobj.group(2)
+		playlist_prefix = mobj.group('Pre1')
+		playlist_altprefix = mobj.group('Pre2')
+		playlist_id = mobj.group('ID')
+		is_playlist = True
 		video_ids = []
 		pagenum = 1
 
-		while True:
+		# prefix is 'p' as default for playlists but there are other types that need extra care
+		if playlist_prefix == 'a':
+			playlist_access = 'artist'
+		else:
+			if playlist_altprefix == 'p':
+				# Not really a playlist but single video within the list:
+				ids = re.match(self._COMBO_ID, playlist_id)
+				if ids is not None:
+					is_playlist = False
+					video_ids = [ids.group('ID')]
+			if is_playlist:
+				playlist_prefix = 'p'
+				playlist_access = 'view_play_list'
+
+		while is_playlist:
 			self.report_download_page(playlist_id, pagenum)
 			request = urllib2.Request(self._TEMPLATE_URL % (playlist_access, playlist_prefix, playlist_id, pagenum))
 			try:
@@ -2155,9 +2167,10 @@ class YoutubePlaylistIE(InfoExtractor):
 				break
 			pagenum = pagenum + 1
 
-		playliststart = self._downloader.params.get('playliststart', 1) - 1
-		playlistend = self._downloader.params.get('playlistend', -1)
-		video_ids = video_ids[playliststart:playlistend]
+		if is_playlist:
+			playliststart = self._downloader.params.get('playliststart', 1) - 1
+			playlistend = self._downloader.params.get('playlistend', -1)
+			video_ids = video_ids[playliststart:playlistend]
 
 		for id in video_ids:
 			self._youtube_ie.extract('http://www.youtube.com/watch?v=%s' % id)


### PR DESCRIPTION
From your comments on the previous version of this pull:

> Er... wait a second. These are a few more changes. The thing is a playlist can be given in grid or play format. If you go to
> http://www.youtube.com/user/stanforduniversity#g/c/9D558D49CA734A02
> And click on the button that has a play sign in the bar with "All Uploads Favorites Playlists", the list changes to a different format, and the URL changes to
> http://www.youtube.com/user/stanforduniversity#p/c/9D558D49CA734A02
> Which is what I was trying to handle when I suggested you the previous change.

My bad, I missed it somehow, now it is done properly.

> Now, if you click on any video from the playlist, the URL turns to the form you describe here, but it's not worth handling all that and, in case of handling it, we should handle that URL form from the YoutubeIE, not from the playlist InfoExtractor, IMHO. In any case, we're not going to handle the specific video URL for now. If a user wants to download one specific video, say
> http://www.youtube.com/user/stanforduniversity#p/c/9D558D49CA734A02/1/jTSvthW34GU
> They can simply copy the video id from the address bar, or copy the video URL from the list to the right of the video. You see the current video you're watching is highlighted. If you right click on its link and copy the URL (Copy Link Location in Firefox), you get
> http://www.youtube.com/watch?v=jTSvthW34GU
> Which you can pass directly to youtube-dl, so it's a non-issue for now. Maybe we'll handle that type of URL properly, but that will be later. So let's get back to your simple change, made the small modification and be done with it for now. :)

I want to be done with this as well. :) As for the copy/paste: the very reason why I'm trying to write this code so I don't have to do that ever again.

How about a middle road? This patch handles all three formats - for now. Incorporate it at the moment and  open an issue about doing it properly. I would feel weird if there is a known case that the code _could_ understand but instead breaks on it, which would be the case if the single video link is not explicitly handled.

As I tried, if I remove the single video special case and pass it the third kind of link, it would start downloading the "newest videos" or something like that (completely unrelated to the original video/playlist), so wouldn't even malfunction properly but unexpectedly from the user's point of view. The check to make it fail the right way (as I can see) would look exactly like this patch, just returning with some excuse instead of the single video download...

What do you think? :)
