### PR TITLE
Fix missing parameter after recent commit

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2135,6 +2135,7 @@ class YoutubePlaylistIE(InfoExtractor):
 		if playlist_prefix == 'a':
 			playlist_access = 'artist'
 		else:
+			playlist_prefix = 'p'
 			playlist_access = 'view_play_list'
 		playlist_id = mobj.group(2)
 		video_ids = []


### PR DESCRIPTION
Thanks for simplifying my code for the new playlist format. It's awesome, I really have a lot to learn... :)

There's one outstanding issue, that with those URLs one parameter value cannot be extracted, but it is not set explicitly either, resulting in broken query URL (eg. "....?None=something...").
