### PR TITLE
Dailymotion fix

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -1338,6 +1338,12 @@ class DailymotionIE(InfoExtractor):
 
 		# if needed add http://www.dailymotion.com/ if relative URL
 		sequenceJsonContent = urllib.unquote_plus(mobj.group(1))
+
+		# JSON does not suppot escaping of '.
+		# Replace every \' by a ' in the JSON string
+		sequenceJsonContent = sequenceJsonContent.replace("\\'", "'")
+
+		# Build the JSON object based on the string
 		try:
 			sequenceJson = json.loads(sequenceJsonContent)
 		except:


### PR DESCRIPTION
Youtube-dl is unable to download dailymotion video anymore. They switched to some JSON urlencoded dataformat.
This commit parses the dailymotion json to find the HQ mp4 video url and the ulploader name.
It adds a new import: json

It might be specific to the US version of Dailymotion as I'm in the US.
