### PR TITLE
Terser help output + slight refactoring

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2744,11 +2744,21 @@ def parseOpts():
 
 		return "".join(opts)
 
+	def _find_term_columns():
+		columns = os.environ.get('COLUMNS', None)
+		if columns: return int(columns)
+
+		if sys.platform.startswith('linux'):
+			try: columns = os.popen('stty size', 'r').read().split()[1]
+			except: pass
+
+		if columns: return int(columns)
+
 	max_width = 80
 	max_help_position = 80
 
 	# No need to wrap help messages if we're on a wide console
-	columns = os.environ.get('COLUMNS', None)
+	columns = _find_term_columns()
 	if columns: max_width = columns
 
 	fmt = optparse.IndentedHelpFormatter(width=max_width, max_help_position=max_help_position)


### PR DESCRIPTION
Greetings,

For an utility with such a wide array of command line options, `youtube-dl` could use a slightly better `--help` output than the one generated by optparse's default `IndentedHelpFormatter`.

Differences between current and proposed help output can be seen in this gist:
https://gist.github.com/1165989

In short:
- `-u USERNAME, --username=USERNAME` becomes `-u, --username USERNAME`
- Do not wrap the help message if we're on a wide terminal (determined either through the COLUMNS envvar or the output of `stty size`)

I have also done some general refactoring (you have the admit that the code is a bit messy), which consists of mostly reducing indentation and improving readability under `__main__` a bit. Functionally, nothing has changed.

Hope you find this worthwhile.

Best Regards,
G.
