### PR TITLE
added --stdout option to write downloaded video to STDOUT instead of a file

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -1005,7 +1005,7 @@ class FileDownloader(object):
 			return False
 		if self.params.get('writetostdout', False):
 			stream.close() # if we're using stdout, it was already open
-		self.report_finish()
+			self.report_finish()
 		if data_len is not None and byte_counter != data_len:
 			raise ContentTooShortError(byte_counter, long(data_len))
 		self.try_rename(tmpfilename, filename)


### PR DESCRIPTION
enables use of youtube-dl to stream video to vlc, mplayer etc through a pipe, e.g. 

`youtube-dl --stdout http://some.url | vlc -`
