### PR TITLE
FacebookIE: Fix regexp to recognize videos that weren't considered.

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2709,7 +2709,7 @@ class DepositFilesIE(InfoExtractor):
 class FacebookIE(InfoExtractor):
 	"""Information Extractor for Facebook"""
 
-	_VALID_URL = r'^(?:https?://)?(?:\w+\.)?facebook\.com/video/video\.php\?(?:.*?)v=(?P<ID>\d+)(?:.*)'
+	_VALID_URL = r'^(?:https?://)?(?:\w+\.)?facebook\.com/(?:video/video|photo)\.php\?(?:.*?)v=(?P<ID>\d+)(?:.*)'
 	_LOGIN_URL = 'https://login.facebook.com/login.php?m&next=http%3A%2F%2Fm.facebook.com%2Fhome.php&'
 	_NETRC_MACHINE = 'facebook'
 	_available_formats = ['video', 'highqual', 'lowqual']


### PR DESCRIPTION
Hi.

This is, once more, another "please, maintain me" fix for youtube-dl. This makes youtube-dl recognize some other videos that weren't previously recognized.

In particular, the following video:

  https://www.facebook.com/photo.php?v=10150324413457242

now works, and I tested with other videos that I didn't break anything obvious and everything is working.

Please, consider merging.
