### PR TITLE
Soundcloud

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -3978,7 +3978,7 @@ def gen_extractors():
 		EscapistIE(),
 		CollegeHumorIE(),
 		XVideosIE(),
-        SoundcloudIE(),
+		SoundcloudIE(),
 
 		GenericIE()
 	]


### PR DESCRIPTION
I integrated Soundcloud into youtube-dl.

I've tested it several times, and it seems to work. I tried to follow the general structure and coding style of the rest of source so let me know if anything is off.

What the process of scraping Soundcloud is like is that every song has a UID. For Soundcloud to serve you a song, you must extract the UID and a "stream token" from the page source. Then a media URL must be built from the UID and stream token, this is where the actual media will be served from. A cross-domain must be requested from as well in order to get through, I assume by accessing this cross-domain you are given a request cookie from Soundcloud.

Thanks!
