### PR TITLE
Fix the DailymotionIE to parse the new title of a webpage

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -1618,7 +1618,7 @@ class DailymotionIE(InfoExtractor):
 
 		video_url = mediaURL
 
-		mobj = re.search(r'(?im)<title>Dailymotion\s*-\s*(.+)\s*-\s*[^<]+?</title>', webpage)
+		mobj = re.search(r'(?im)<title>\s*(.+)\s*-\s*Video\s+Dailymotion</title>', webpage)
 		if mobj is None:
 			self._downloader.trouble(u'ERROR: unable to extract title')
 			return


### PR DESCRIPTION
Starting today, I was unable to download Dailymotion videos.
eg. http://www.dailymotion.com/video/xmn5hs_jean-luc-melenchon-sur-france-inter-2-2_news#from=embediframe

Looks like the title format changed.

Here's a commit that fixed it on my side.
