### PR TITLE
Makefile: Don't use `echo`'s `-e` option for portability.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ update-readme:
 		header=$$(sed -e '/.*## OPTIONS/,$$ d' README.md) && \
 		footer=$$(sed -e '1,/.*## FAQ/ d' README.md) && \
 		echo "$${header}" > README.md && \
-		echo -e '\n## OPTIONS' >> README.md && \
+		echo >> README.md && \
+		echo '## OPTIONS' >> README.md && \
 		echo "$${options}" >> README.md&& \
-		echo -e '\n## FAQ' >> README.md && \
+		echo >> README.md && \
+		echo '## FAQ' >> README.md && \
 		echo "$${footer}" >> README.md
 
 compile:


### PR DESCRIPTION
Many systems (including Debian, Ubuntu and derivatives like Linux Mint) use
Dash as a noninteractive version of `/bin/sh`, invoked by `make`.

Dash's `echo` command doesn't understand the `-e` option and this generates
spurious output when running `make`.  See [a bugreport](https://bugs.launchpad.net/ubuntu/+source/dash/+bug/72167) for one of the
many instances of this bug/feature in action.
