### PR TITLE
Fix: unescape() cannot work on an utf8 string, send him an ascii one

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -1635,7 +1635,7 @@ class DailymotionIE(InfoExtractor):
 		if mobj is None:
 			self._downloader.trouble(u'ERROR: unable to extract title')
 			return
-		video_title = htmlParser.unescape(mobj.group('title')).decode('utf-8')
+		video_title = htmlParser.unescape(mobj.group('title').decode('utf-8'))
 		video_title = sanitize_title(video_title)
 		simple_title = _simplify_title(video_title)
 


### PR DESCRIPTION
youtube-dl is crashing on some utf8 pages like: http://www.dailymotion.com/video/xn3lf8_jean-luc-melenchon-sur-bfm-tv-2012_news#from=embediframe
