### PR TITLE
Support Unicode in file names on Windows NT

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -305,7 +305,14 @@ def _encodeFilename(s):
 	"""
 
 	assert type(s) == type(u'')
-	return s.encode(sys.getfilesystemencoding(), 'ignore')
+
+	if sys.platform == 'win32' and sys.getwindowsversion().major >= 5:
+		# Pass u'' directly to use Unicode APIs on Windows 2000 and up
+		# (Detecting Windows NT 4 is tricky because 'major >= 4' would
+		# match Windows 9x series as well. Besides, NT 4 is obsolete.)
+		return s
+	else:
+		return s.encode(sys.getfilesystemencoding(), 'ignore')
 
 class DownloadError(Exception):
 	"""Download Error exception.


### PR DESCRIPTION
Windows NT has two versions of most APIs &ndash; ANSI and Unicode. When given an `unicode()` object as the file name, Python uses the Unicode APIs, removing the need for manual filename encoding. (In fact, the manual encoding _breaks_ things in such cases as, for example, Japanese or Korean names on an English system.)
