### PR TITLE
VimeoIE: Allow matches taken from embedded videos.

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2014,7 +2014,7 @@ class VimeoIE(InfoExtractor):
 	"""Information extractor for vimeo.com."""
 
 	# _VALID_URL matches Vimeo URLs
-	_VALID_URL = r'(?:https?://)?(?:(?:www|player).)?vimeo\.com/(?:groups/[^/]+/)?(?:videos?/)?([0-9]+)'
+	_VALID_URL = r'(?:https?://)?(?:(?:www|player).)?vimeo\.com/(?:groups/[^/]+/)?(?:videos?/)?(?:moogaloop.swf\?clip_id=)?([0-9]+)'
 	IE_NAME = u'vimeo'
 
 	def __init__(self, downloader=None):


### PR DESCRIPTION
With this change, I can directly cut and paste URLs embedded in 3rd-party
pages as `youtube-dl`'s arguments.

Signed-off-by: Rogério Brito rbrito@ime.usp.br
