### PR TITLE
Change GenericIE to download all videos on a page

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -2170,26 +2170,14 @@ class GenericIE(InfoExtractor):
 
 		self.report_extraction(video_id)
 		# Start with something easy: JW Player in SWFObject
-		mobj = re.search(r'flashvars: [\'"](?:.*&)?file=(http[^\'"&]*)', webpage)
-		if mobj is None:
+		matches = [mobj for mobj in re.finditer(r'flashvars: [\'"](?:.*&)?file=(http[^\'"&]*)', webpage)]
+
+		if len(matches) == 0:
 			# Broaden the search a little bit
-			mobj = re.search(r'[^A-Za-z0-9]?(?:file|source)=(http[^\'"&]*)', webpage)
-		if mobj is None:
+			matches = [mobj for mobj in re.finditer(r'[^A-Za-z0-9]?(?:file|source)=(http[^\'"&]*)', webpage)]
+		if len(matches) == 0:
 			self._downloader.trouble(u'ERROR: Invalid URL: %s' % url)
 			return
-
-		# It's possible that one of the regexes
-		# matched, but returned an empty group:
-		if mobj.group(1) is None:
-			self._downloader.trouble(u'ERROR: Invalid URL: %s' % url)
-			return
-
-		video_url = urllib.unquote(mobj.group(1))
-		video_id = os.path.basename(video_url)
-
-		# here's a fun little line of code for you:
-		video_extension = os.path.splitext(video_id)[1][1:]
-		video_id = os.path.splitext(video_id)[0]
 
 		# it's tempting to parse this further, but you would
 		# have to take into account all the variations like
@@ -2212,21 +2200,35 @@ class GenericIE(InfoExtractor):
 			return
 		video_uploader = mobj.group(1).decode('utf-8')
 
-		try:
-			# Process video information
-			self._downloader.process_info({
-				'id':		video_id.decode('utf-8'),
-				'url':		video_url.decode('utf-8'),
-				'uploader':	video_uploader,
-				'upload_date':	u'NA',
-				'title':	video_title,
-				'stitle':	simple_title,
-				'ext':		video_extension.decode('utf-8'),
-				'format':	u'NA',
-				'player_url':	None,
-			})
-		except UnavailableVideoError, err:
-			self._downloader.trouble(u'\nERROR: unable to download video')
+		for mobj in matches:
+			# It's possible that one of the regexes
+			# matched, but returned an empty group:
+			if mobj.group(1) is None:
+				self._downloader.trouble(u'ERROR: Invalid URL: %s' % url)
+				continue
+
+			video_url = urllib.unquote(mobj.group(1))
+			video_id = os.path.basename(video_url)
+
+			# here's a fun little line of code for you:
+			video_extension = os.path.splitext(video_id)[1][1:]
+			video_id = os.path.splitext(video_id)[0]
+
+			try:
+				# Process video information
+				self._downloader.process_info({
+					'id':		video_id.decode('utf-8'),
+					'url':		video_url.decode('utf-8'),
+					'uploader':	video_uploader,
+					'upload_date':	u'NA',
+					'title':	video_title,
+					'stitle':	simple_title,
+					'ext':		video_extension.decode('utf-8'),
+					'format':	u'NA',
+					'player_url':	None,
+				})
+			except UnavailableVideoError, err:
+				self._downloader.trouble(u'\nERROR: unable to download video')
 
 
 class YoutubeSearchIE(InfoExtractor):


### PR DESCRIPTION
The GenericIE pattern match is used to download just the first video on a page. 

This patch adds an iterator around the current regexes to download all matching video urls.
