### PR TITLE
Fixing the error "unable to extract uploader nickname" for dailymotion.

### DIFF
--- a/youtube-dl
+++ b/youtube-dl
@@ -1749,11 +1749,13 @@ class DailymotionIE(InfoExtractor):
 		video_title = _unescapeHTML(mobj.group('title').decode('utf-8'))
 		video_title = sanitize_title(video_title)
 		simple_title = _simplify_title(video_title)
-
-		mobj = re.search(r'(?im)<span class="owner[^\"]+?">[^<]+?<a [^>]+?>([^<]+?)</a></span>', webpage)
+		
+		spanowner = re.search(r'(?im)<span class="owner[^\"]+?">[^<]+?<a [^>]+?>([^<]+?)</a></span>', webpage)
+		spanname = re.search(r'(?im)<span class="name[^\"]+?"[^\>]+?>([^\>]+?)</span>', webpage)
+		mobj = spanowner if spanowner else spanname
 		if mobj is None:
 			video_uploader = "Unknown" 
-			#you need to use -i option to discard this error
+			#you need to use -i option to discard this error and continue with the download
 			self._downloader.trouble(u'WARNING: unable to extract uploader nickname')
 		else:
 			video_uploader = mobj.group(1)


### PR DESCRIPTION
Hi!

It seems that the nickname is not required to download a video on dailymotion. My first commit only remove the call to "return" in order to be able to continue with the download without exiting.

The tag <span class="owner... is not always in the html, which render the regex unusable. The following link is an example:

http://www.dailymotion.com/video/xpp4e3_la-france-solidaire-francois-bayrou-discours-du-zenith-de-paris-extrait_news

I found an alternative (span class="name) and built a regex when the first tag is not found which is the content of my second commit.

Thanks!

Pierre-Yves Langlois
