### PR TITLE
support avconv and use ffmpeg as a fallback; closes #344

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ which means you can modify it, redistribute it or use it however you like.
 
 ### Post-processing Options:
     --extract-audio          convert video files to audio-only files (requires
-                             ffmpeg and ffprobe)
+                             ffmpeg or avconv and ffprobe or avprobe)
     --audio-format FORMAT    "best", "aac", "vorbis", "mp3", "m4a", or "wav";
                              best by default
-    --audio-quality QUALITY  ffmpeg audio bitrate specification, 128k by default
+    --audio-quality QUALITY  ffmpeg/avconv audio bitrate specification, 128k by
+                             default
     -k, --keep-video         keeps the video file on disk after the post-
                              processing; the video is erased by default
 

--- a/youtube_dl/PostProcessor.py
+++ b/youtube_dl/PostProcessor.py
@@ -99,7 +99,7 @@ class FFmpegExtractAudioPP(PostProcessor):
 
 	def run_ffmpeg(self, path, out_path, codec, more_opts):
 		if not self._exes['ffmpeg'] and not self._exes['avconv']:
-			raise AudioConversionError('ffmpeg or avconv not found. Please install avconv.')	
+			raise AudioConversionError('ffmpeg or avconv not found. Please install one.')	
 		if codec is None:
 			acodec_opts = []
 		else:
@@ -162,7 +162,7 @@ class FFmpegExtractAudioPP(PostProcessor):
 
 		prefix, sep, ext = path.rpartition(u'.') # not os.path.splitext, since the latter does not work on unicode in all setups
 		new_path = prefix + sep + extension
-		self._downloader.to_screen(u'[ffmpeg] Destination: ' + new_path)
+		self._downloader.to_screen(u'[' + self._exes['avconv'] and 'avconv' or 'ffmpeg' + '] Destination: ' + new_path)
 		try:
 			self.run_ffmpeg(path, new_path, acodec, more_opts)
 		except:
@@ -170,7 +170,7 @@ class FFmpegExtractAudioPP(PostProcessor):
 			if isinstance(e, AudioConversionError):
 				self._downloader.to_stderr(u'ERROR: audio conversion failed: ' + e.message)
 			else:
-				self._downloader.to_stderr(u'ERROR: error running ffmpeg')
+				self._downloader.to_stderr(u'ERROR: error running ' + self._exes['avconv'] and 'avconv' or 'ffmpeg')
 			return None
 
  		# Try to update the date time for extracted audio file.

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -293,11 +293,11 @@ def parseOpts():
 
 
 	postproc.add_option('--extract-audio', action='store_true', dest='extractaudio', default=False,
-			help='convert video files to audio-only files (requires ffmpeg and ffprobe)')
+			help='convert video files to audio-only files (requires ffmpeg or avconv and ffprobe or avprobe)')
 	postproc.add_option('--audio-format', metavar='FORMAT', dest='audioformat', default='best',
 			help='"best", "aac", "vorbis", "mp3", "m4a", or "wav"; best by default')
 	postproc.add_option('--audio-quality', metavar='QUALITY', dest='audioquality', default='128K',
-			help='ffmpeg audio bitrate specification, 128k by default')
+			help='ffmpeg/avconv audio bitrate specification, 128k by default')
 	postproc.add_option('-k', '--keep-video', action='store_true', dest='keepvideo', default=False,
 			help='keeps the video file on disk after the post-processing; the video is erased by default')
 


### PR DESCRIPTION
I have left `ffmpeg` everywhere as the name of the PP etc.
I wonder if we should switch it to `avconv`
