### PR TITLE
Use a supposedly "stable" User-Agent.

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -19,7 +19,7 @@ except ImportError:
 	import StringIO
 
 std_headers = {
-	'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:5.0.1) Gecko/20100101 Firefox/5.0.1',
+	'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:10.0.6) Gecko/20100101 Firefox/10.0.6',
 	'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
 	'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
 	'Accept-Encoding': 'gzip, deflate',


### PR DESCRIPTION
It is possible that some sites decide that Firefox 5 is too old.  To avoid
using the newest and greatest, let's settle on an "Extended Support Release"
of Firefox, which is less likely to have sites complaining about.

Signed-off-by: Rogério Brito rbrito@ime.usp.br
