### PR TITLE
Support for custom user agent

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -190,6 +190,8 @@ def parseOpts():
 	general.add_option('--dump-user-agent',
 			action='store_true', dest='dump_user_agent',
 			help='display the current browser identification', default=False)
+	general.add_option('--user-agent',
+			action='store', dest='useragent', help='specify a custom user agent')
 	general.add_option('--list-extractors',
 			action='store_true', dest='list_extractors',
 			help='List all supported extractors and the URLs they would handle', default=False)
@@ -368,7 +370,10 @@ def _real_main():
 				jar.load()
 		except (IOError, OSError), err:
 			sys.exit(u'ERROR: unable to open cookie file')
-
+	# Set user agent
+	if opts.useragent is not None:
+		std_headers['User-Agent'] = opts.useragent
+		
 	# Dump user agent
 	if opts.dump_user_agent:
 		print std_headers['User-Agent']


### PR DESCRIPTION
## What

A few simple lines were added to provide a "--user-agent" option to specify a custom user agent.
## How it changes the code

A new variable (opt.useragent) is introduced. No functionality breaks (I think!) As soon as possible, we update std_header['User-Agent'] with the custom user agent string.
## How it should be used

```
youtube-dl --user-agent "My Custom User Agent"  "http://www.website.com/"
```
## How it changes the HTML

Without a custom user agent, we can expect

```
prompt$  youtube-dl 'http://127.0.0.1:8080/somesite'
```

to yield the GET header

```
Host: 127.0.0.1:8080
Accept-Language: en-us,en;q=0.5
Accept-Encoding: gzip, deflate
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:5.0.1) Gecko/20100101 Firefox/5.0.1
Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
Connection: close
```

When we specify a custom agent 

```
prompt$  youtube-dl --user-agent 'My Custom User Agent' 'http://127.0.0.1:8080/somesite'
```

we get the modified request

```
Host: 127.0.0.1:8080
Accept-Language: en-us,en;q=0.5
Accept-Encoding: gzip, deflate
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
User-Agent: My Custom User Agent
Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
Connection: close
```
## Notes

My Python experience is limited. My tests all worked, but please ensure I've not done something silly.
