### PR TITLE
Fixed YouTube playlist parsing

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -1473,7 +1473,7 @@ class YoutubePlaylistIE(InfoExtractor):
 
 	_VALID_URL = r'(?:https?://)?(?:\w+\.)?youtube\.com/(?:(?:course|view_play_list|my_playlists|artist|playlist)\?.*?(p|a|list)=|user/.*?/user/|p/|user/.*?#[pg]/c/)(?:PL)?([0-9A-Za-z-_]+)(?:/.*?/([0-9A-Za-z_-]+))?.*'
 	_TEMPLATE_URL = 'http://www.youtube.com/%s?%s=%s&page=%s&gl=US&hl=en'
-	_VIDEO_INDICATOR_TEMPLATE = r'/watch\?v=(.+?)&amp;list=(PL)?%s&'
+	_VIDEO_INDICATOR_TEMPLATE = r'/watch\?v=(.+?)&amp;list=.*?%s'
 	_MORE_PAGES_INDICATOR = r'yt-uix-pager-next'
 	IE_NAME = u'youtube:playlist'
 


### PR DESCRIPTION
This was broken once again due to slight changes in the playlist page source. It now also checks if the found videos are actually part of the given playlist or just suggested videos from another playlist, which prevents downloading of unrelated videos.

Though I wonder how this kind of bug can always stay unfixed for so long, I would think this is a main feature of youtube-dl, being able to download entire playlists, or am I alone in using this feature heavily? Well no matter, it's fixed now.
