### PR TITLE
Added uploaded date for Dailymotion

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -683,11 +683,16 @@ class DailymotionIE(InfoExtractor):
 			return
 		video_uploader = mobj.group(1)
 
+		video_upload_date = u'NA'
+		mobj = re.search(r'<div class="[^"]*uploaded_cont[^"]*" title="[^"]*">([0-9]{2})-([0-9]{2})-([0-9]{4})</div>', webpage)
+		if mobj is not None:
+			video_upload_date = mobj.group(3) + mobj.group(2) + mobj.group(1)
+
 		return [{
 			'id':		video_id.decode('utf-8'),
 			'url':		video_url.decode('utf-8'),
 			'uploader':	video_uploader.decode('utf-8'),
-			'upload_date':	u'NA',
+			'upload_date':	video_upload_date,
 			'title':	video_title,
 			'ext':		video_extension.decode('utf-8'),
 			'format':	u'NA',


### PR DESCRIPTION
I like to have my videos sorted neatly by uploaded date, and I noticed Dailymotion videos have it set to "NA" no matter what. Here's a simple fix that should be able to extract the date and set it for the video so it can be used as a pattern for the filename.

I tested it on multiple videos and it seemed to work correctly. If more people could test it from their side, that would be nice, since I'm not sure the date format is consistent if Dailymotion is set to another language. I would suppose that it is, but you never know!
