### PR TITLE
check_output is only supported by Python 2.7 onwards

### DIFF
--- a/youtube_dl/PostProcessor.py
+++ b/youtube_dl/PostProcessor.py
@@ -73,7 +73,7 @@ class FFmpegExtractAudioPP(PostProcessor):
 	def detect_executables():
 		def executable(exe):
 			try:
-				subprocess.check_output([exe, '-version'])
+				subprocess.Popen([exe, '-version'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()[0]
 			except OSError:
 				return False
 			return exe


### PR DESCRIPTION
This should fix #470, and works with both Python 2.6 and 2.7. Not tested on Windows, but it should wok just as well.

Popen also returns a OSError exception if the executable file doesn't exist so it shouldn't disrupt the rest of the code.
