### PR TITLE
Added duration for YouTube videos

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -414,6 +414,12 @@ class YoutubeIE(InfoExtractor):
 			except Trouble as trouble:
 				self._downloader.trouble(trouble[0])
 
+		if 'length_seconds' not in video_info:
+			self._downloader.trouble(u'WARNING: unable to extract video duration')
+			video_duration = ''
+		else:
+			video_duration = urllib.unquote_plus(video_info['length_seconds'][0])
+
 		# token
 		video_token = urllib.unquote_plus(video_info['token'][0])
 
@@ -480,7 +486,8 @@ class YoutubeIE(InfoExtractor):
 				'thumbnail':	video_thumbnail.decode('utf-8'),
 				'description':	video_description,
 				'player_url':	player_url,
-				'subtitles':	video_subtitles
+				'subtitles':	video_subtitles,
+				'duration':		video_duration
 			})
 		return results
 


### PR DESCRIPTION
This should fix #474, at least for YouTube videos. It adds a "duration" field in the video infos, reflecting the length of the video in seconds, which can then be written to a file using --write-info-json  for example.
