### PR TITLE
Fix audio bitrate quality for ffmpeg/avconv

### DIFF
--- a/youtube_dl/PostProcessor.py
+++ b/youtube_dl/PostProcessor.py
@@ -146,7 +146,7 @@ class FFmpegExtractAudioPP(PostProcessor):
 					if int(self._preferredquality) < 10:
 						more_opts += [self._exes['avconv'] and '-q:a' or '-aq', self._preferredquality]
 					else:
-						more_opts += [self._exes['avconv'] and '-b:a' or '-ab', self._preferredquality]
+						more_opts += [self._exes['avconv'] and '-b:a' or '-ab', self._preferredquality + 'k']
 		else:
 			# We convert the audio (lossy)
 			acodec = {'mp3': 'libmp3lame', 'aac': 'aac', 'm4a': 'aac', 'vorbis': 'libvorbis', 'wav': None}[self._preferredcodec]
@@ -156,7 +156,7 @@ class FFmpegExtractAudioPP(PostProcessor):
 				if int(self._preferredquality) < 10:
 					more_opts += [self._exes['avconv'] and '-q:a' or '-aq', self._preferredquality]
 				else:
-					more_opts += [self._exes['avconv'] and '-b:a' or '-ab', self._preferredquality]
+					more_opts += [self._exes['avconv'] and '-b:a' or '-ab', self._preferredquality + 'k']
 			if self._preferredcodec == 'aac':
 				more_opts += ['-f', 'adts']
 			if self._preferredcodec == 'm4a':


### PR DESCRIPTION
This should fix #487, simply by adding a "k" to the bitrate when it's set to a specific value, while leaving it alone if it's set to a VBR between 0 and 9.

This was tested on Linux with ffmpeg, but it shouldn't introduce any issue with avconv or on other systems. If someone has an avconv installation it would be nice to know if it works too, though looking at the man page they seem to take pretty much the same options.
