### PR TITLE
My sanitize_filename proposal

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -22,13 +22,13 @@ class TestUtil(unittest.TestCase):
 
 		self.assertEqual(sanitize_filename(u'123'), u'123')
 
-		self.assertEqual(u'abc_de', sanitize_filename(u'abc/de'))
-		self.assertTrue(u'de' in sanitize_filename(u'abc/de'))
+		self.assertEqual(u'abc-de', sanitize_filename(u'abc/de'))
 		self.assertFalse(u'/' in sanitize_filename(u'abc/de///'))
 
-		self.assertEqual(u'abc_de', sanitize_filename(u'abc\\de'))
-		self.assertEqual(u'abc_de', sanitize_filename(u'abc\\de'))
-		self.assertTrue(u'de' in  sanitize_filename(u'abc\\de'))
+		self.assertEqual(u'abc-de', sanitize_filename(u'abc/<>\\*|de'))
+		self.assertEqual(u'xxx', sanitize_filename(u'xxx/<>\\*|'))
+		self.assertEqual(u'yes no', sanitize_filename(u'yes? no'))
+		self.assertEqual(u'this - that', sanitize_filename(u'this: that'))
 
 		self.assertEqual(sanitize_filename(u'ä'), u'ä')
 		self.assertEqual(sanitize_filename(u'кириллица'), u'кириллица')

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -194,10 +194,20 @@ def timeconvert(timestr):
 def sanitize_filename(s):
 	"""Sanitizes a string so it could be used as part of a filename."""
 	def replace_insane(char):
-		if char in u' .\\/|?*<>:"' or ord(char) < 32:
-			return '_'
+		if char == '?' or ord(char) < 32 or ord(char) == 127:
+			return ''
+		elif char == '"':
+			return '\''
+		elif char == ':':
+			return ' -'
+		elif char in '\\/|*<>':
+			return '-'
 		return char
-	return u''.join(map(replace_insane, s)).strip('_')
+
+	result = u''.join(map(replace_insane, s))
+	while '--' in result:
+		result = result.replace('--', '-')
+	return result.strip('-')
 
 def orderedSet(iterable):
 	""" Remove all duplicates from the input iterable """


### PR DESCRIPTION
Ok, the old one was a dumb one. The new:
- leave space and `.`
- kill `?` and control characters (ASCII < 32 and == 127)
- replace `"` with `'`
- replace `:` with space + `-`
- replace `\/|*<>` with `-` (this is the one I am most uncertain on, but it seemed a good replacement for these characters)

Finally, kills any double or trailing `-`
