### PR TITLE
Points Comedy Central downloads to an alternative CDN which supports more versions of rtmpdump

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -2365,7 +2365,6 @@ class ComedyCentralIE(InfoExtractor):
                         # break on current RTMPDump builds
             
 
-			print "HELLO, WORLD!", video_url
 			broken_cdn = "rtmpe://viacomccstrmfs.fplive.net/viacomccstrm/gsp.comedystor/"
 			better_cdn = "rtmpe://cp10740.edgefcs.net/ondemand/mtvnorigin/gsp.comedystor/"
             


### PR DESCRIPTION
This patch updates the ComedyCentral info extractor to use an alternative CDN, which seems to support rtmpdump better than the default. This server does not use SWF verification, so this is disabled.
