### PR TITLE
Comedy Central extractor supports format selection and available format listing

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -2390,7 +2390,7 @@ class ComedyCentralIE(InfoExtractor):
 		            return
 
 			# For now, just pick the highest bitrate
- 			format,video_url = turls[-1]
+			format,video_url = turls[-1]
 
 			# Get the format arg from the arg stream
 			req_format = self._downloader.params.get('format', None)


### PR DESCRIPTION
Comedy Central extractor now supports selection of format, as well as listing of available formats. Code currently supports the list of formats on the current Daly Show episode. I presume this doesn't change much.
