### PR TITLE
UnicodeEncodeError on WinXP

### DIFF
--- a/youtube_dl/FileDownloader.py
+++ b/youtube_dl/FileDownloader.py
@@ -351,6 +351,7 @@ class FileDownloader(object):
 		"""Process a single dictionary returned by an InfoExtractor."""
 
 		info_dict['stitle'] = sanitize_filename(info_dict['title'], self.params.get('restrictfilenames'))
+		info_dict['atitle'] = info_dict['stitle'].encode('ascii', 'ignore')
 
 		reason = self._match_entry(info_dict)
 		if reason is not None:


### PR DESCRIPTION
Youtube-dl will generate UnicodeErrors on WinXP when a video title contains weird unicode characters and an external process is invoked (ffmpeg, rtmpdump). For an example see bug #436.

I don’t think that’s easily fixable – the Subprocess module does not work properly with exotic unicode filenames, and I actually think none of the python2 process creation functions do (on win32). This is solvable by using an external module like Qt, but I think that is a little bit much.

As an easy solution is not available, I created a workaround, so youtube-dl is at least useable for videos with weird titles: I added a title format option "atitle", that contains the video title in ascii.
