### PR TITLE
fix audio conversion not working with newer versions of ffmpeg

### DIFF
--- a/youtube_dl/PostProcessor.py
+++ b/youtube_dl/PostProcessor.py
@@ -110,7 +110,7 @@ class FFmpegExtractAudioPP(PostProcessor):
             acodec_opts = ['-acodec', codec]
         cmd = ([self._exes['avconv'] or self._exes['ffmpeg'], '-y', '-i', encodeFilename(path), '-vn']
                + acodec_opts + more_opts +
-               ['--', encodeFilename(out_path)])
+               [encodeFilename(out_path)])
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout,stderr = p.communicate()
         if p.returncode != 0:


### PR DESCRIPTION
I tried to run the following command with the newest youtube-dl version and ffmpeg 1.1 installed and got an error:

$ youtube-dl -x -k "https://www.youtube.com/playlist?list=PLr9rc7slvdRXfdRUITmYArOtB-99mr5h5"
[youtube] PL r9rc7slvdRXfdRUITmYArOtB-99mr5h5: Downloading page #1
[youtube] PL r9rc7slvdRXfdRUITmYArOtB-99mr5h5: Found 25 videos
[youtube] Setting language
[youtube] ytKvgLuy7ng: Downloading video webpage
[youtube] ytKvgLuy7ng: Downloading video info webpage
[youtube] ytKvgLuy7ng: Extracting video information
[download] Destination: ytKvgLuy7ng.mp4
[download] 100.0% of 82.40M at    1.33M/s ETA 00:00
[ffmpeg] Destination: ytKvgLuy7ng.aac
ERROR: audio conversion failed: Error splitting the argument list: Option not found

The error occurs because in newer versions, ffmpeg doesn't accept the -- option any more:
$ ffmpeg -y -i ytKvgLuy7ng.mp4 -vn -acodec copy -f adts -- ytKvgLuy7ng.aac 
Unrecognized option '-'.
Error splitting the argument list: Option not found

So I did some poking around in the code and found a solution which on my system works with at least versions 0.11.1 and 1.1 of ffmpeg.
