### PR TITLE
Add option to ignore config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ which means you can modify it, redistribute it or use it however you like.
     --user-agent UA          specify a custom user agent
     --list-extractors        List all supported extractors and the URLs they
                              would handle
+    --ignore-config          Ignore the configuration files                           
 
 ## Video Selection:
     --playlist-start NUMBER  playlist video to start at (default is 1)

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -141,6 +141,8 @@ def parseOpts():
             action='store_true', dest='list_extractors',
             help='List all supported extractors and the URLs they would handle', default=False)
     general.add_option('--test', action='store_true', dest='test', default=False, help=optparse.SUPPRESS_HELP)
+    general.add_option('--ignore-config', action='store_true',
+            help="Ignore the configuration files", default=False)
 
     selection.add_option('--playlist-start',
             dest='playliststart', metavar='NUMBER', help='playlist video to start at (default is %default)', default=1)
@@ -265,12 +267,18 @@ def parseOpts():
     parser.add_option_group(authentication)
     parser.add_option_group(postproc)
 
-    xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
-    if xdg_config_home:
-        userConf = os.path.join(xdg_config_home, 'youtube-dl.conf')
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    if not opts.ignore_config:
+        xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
+        if xdg_config_home:
+            userConf = os.path.join(xdg_config_home, 'youtube-dl.conf')
+        else:
+            userConf = os.path.join(os.path.expanduser('~'), '.config', 'youtube-dl.conf')
+        argv = _readOptions('/etc/youtube-dl.conf') + _readOptions(userConf) + sys.argv[1:]
     else:
-        userConf = os.path.join(os.path.expanduser('~'), '.config', 'youtube-dl.conf')
-    argv = _readOptions('/etc/youtube-dl.conf') + _readOptions(userConf) + sys.argv[1:]
+        argv = sys.argv[1:]
+
     opts, args = parser.parse_args(argv)
 
     return parser, opts, args


### PR DESCRIPTION
That way if you have set in your config files to use title or other option in the output files, and you specify an output template on the command line, the template is used and you don't get the error: `using output template conflicts with using title, video ID or auto number`.
