### PR TITLE
JustinTV: Work even if title is mysteriously missing

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -3544,7 +3544,7 @@ class JustinTVIE(InfoExtractor):
                 info.append({
                     'id': clip['id'],
                     'url': video_url,
-                    'title': clip['title'],
+                    'title': clip.get('title', ''),
                     'uploader': clip.get('channel_name', video_uploader_id),
                     'uploader_id': video_uploader_id,
                     'upload_date': video_date,


### PR DESCRIPTION
Apparently some JustinTV channels have videos with no title, like this channel: http://www.twitch.tv/esltv_studio2 . In this case, youtube-dl should just assume an empty-string title, instead of failing outright.

Thanks :)
