### PR TITLE
Try setuptools first, then fallback to distutils.core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,13 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
-from distutils.core import setup
 import pkg_resources
 import sys
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 try:
     import py2exe


### PR DESCRIPTION
Hi,

This is a request related to the OpenBSD port for youtube-dl.

I'd like this diff to be applied because our ports framework uses 'install --single-version-externally-managed' when dealing with setuptools-based python packages.

Currently, packaging of youtube-dl fails with the error:

===>  Faking installation for youtube-dl-2013.01.28
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: option --single-version-externally-managed not recognized

**\* Error 1 in . (/usr/ports/lang/python/python.port.mk:181 'do-install': @cd /usr/ports/pobj/youtube-dl-2013.01.28/youtube-dl && /usr/bin/e...)
**\* Error 1 in . (/usr/ports/infrastructure/mk/bsd.port.mk:2678 '/usr/ports/pobj/youtube-dl-2013.01.28/fake-amd64/.fake_done')
**\* Error 1 in /usr/ports/mystuff/www/youtube-dl (/usr/ports/infrastructure/mk/bsd.port.mk:2323 'fake')

Please consider merging my almost unobtrusive change.
