### PR TITLE
Message for delete video it's not an error

### DIFF
--- a/youtube_dl/FileDownloader.py
+++ b/youtube_dl/FileDownloader.py
@@ -552,7 +552,7 @@ class FileDownloader(object):
                 self.to_stderr(u'ERROR: ' + e.msg)
         if keep_video is False and not self.params.get('keepvideo', False):
             try:
-                self.to_stderr(u'Deleting original file %s (pass -k to keep)' % filename)
+                self.to_screen(u'Deleting original file %s (pass -k to keep)' % filename)
                 os.remove(encodeFilename(filename))
             except (IOError, OSError):
                 self.to_stderr(u'WARNING: Unable to remove downloaded video file')


### PR DESCRIPTION
When using youtube-dl from another python script with the quiet option on, and a post procesor for extract the audio. The message of deleting video shows in the first script logs (as it goes to stderr).

There is no way to keep this quiet as it's treated as an error, even if, for me, it's not.
