### PR TITLE
[YT Search] No results if items is not in response

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -1478,6 +1478,10 @@ class YoutubeSearchIE(InfoExtractor):
                 return
             api_response = json.loads(data)['data']
 
+            if not 'items' in api_response:
+                self._downloader.trouble(u'[youtube] No video results')
+                return
+
             new_ids = list(video['id'] for video in api_response['items'])
             video_ids += new_ids
 


### PR DESCRIPTION
When a query results of 0 items, the key items is not present in the api_response dictionary, raising a KeyError:

``` bash
$  youtube-dl -v "ytsearch:Carajo Apiere´mapare piarolo´"
[debug] youtube-dl version 2013.02.02
[debug] Python version 3.3.0 - Linux-3.7.7-1-ARCH-x86_64-with-arch
[debug] Proxy map: {}
[youtube] query "Carajo Apiere´mapare piarolo´": Downloading page 1
Traceback (most recent call last):
  File "/usr/bin/youtube-dl", line 6, in <module>
    youtube_dl.main()
  File "/usr/lib/python3.3/site-packages/youtube_dl/__init__.py", line 512, in main
    _real_main()
  File "/usr/lib/python3.3/site-packages/youtube_dl/__init__.py", line 496, in _real_main
    retcode = fd.download(all_urls)
  File "/usr/lib/python3.3/site-packages/youtube_dl/FileDownloader.py", line 505, in download
    videos = ie.extract(url)
  File "/usr/lib/python3.3/site-packages/youtube_dl/InfoExtractors.py", line 93, in extract
    return self._real_extract(url)
  File "/usr/lib/python3.3/site-packages/youtube_dl/InfoExtractors.py", line 1395, in _real_extract
    self._download_n_results(query, 1)
  File "/usr/lib/python3.3/site-packages/youtube_dl/InfoExtractors.py", line 1433, in _download_n_results
    new_ids = list(video['id'] for video in api_response['items'])
KeyError: 'items'
```

Intead, look for the key and call trouble if it's not present:

``` bash
$ python -m youtube_dl "ytsearch:Carajo Apiere´mapare piarolo´" 
[youtube] query "Carajo Apiere´mapare piarolo´": Downloading page 1
[youtube] No video results
```

Maybe this should be a `to_stderr` instead of `trouble`. The verbose log throws the exception:

``` bash
$ python -m youtube_dl -v "ytsearch:Carajo Apiere´mapare piarolo´"
[debug] youtube-dl version 2013.02.25
[debug] Git HEAD: 9e07cf2
[debug] Python version 3.3.0 - Linux-3.7.7-1-ARCH-x86_64-with-arch
[debug] Proxy map: {}
[youtube] query "Carajo Apiere´mapare piarolo´": Downloading page 1
[youtube] No video results
  File "/usr/lib/python3.3/runpy.py", line 160, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python3.3/runpy.py", line 73, in _run_code
    exec(code, run_globals)
  File "./youtube_dl/__main__.py", line 17, in <module>
    youtube_dl.main()
  File "./youtube_dl/__init__.py", line 516, in main
    _real_main()
  File "./youtube_dl/__init__.py", line 500, in _real_main
    retcode = fd.download(all_urls)
  File "./youtube_dl/FileDownloader.py", line 507, in download
    videos = ie.extract(url)
  File "./youtube_dl/InfoExtractors.py", line 93, in extract
    return self._real_extract(url)
  File "./youtube_dl/InfoExtractors.py", line 1443, in _real_extract
    self._download_n_results(query, 1)
  File "./youtube_dl/InfoExtractors.py", line 1482, in _download_n_results
    self._downloader.trouble(u'[youtube] No video results')
  File "./youtube_dl/FileDownloader.py", line 230, in trouble
    tb_data = traceback.format_list(traceback.extract_stack())
```

Feel free to change it accordingly.
