### PR TITLE
Playlists (I give up, implemented on the API)

### DIFF
--- a/test/test_all_urls.py
+++ b/test/test_all_urls.py
@@ -11,12 +11,18 @@ from youtube_dl.InfoExtractors import YoutubeIE, YoutubePlaylistIE
 
 class TestAllURLsMatching(unittest.TestCase):
     def test_youtube_playlist_matching(self):
-        self.assertTrue(YoutubePlaylistIE().suitable(u'ECUl4u3cNGP61MdtwGTqZA0MreSaDybji8'))
-        self.assertTrue(YoutubePlaylistIE().suitable(u'PL63F0C78739B09958'))
-        self.assertFalse(YoutubePlaylistIE().suitable(u'PLtS2H6bU1M'))
+        self.assertTrue(YoutubePlaylistIE.suitable(u'ECUl4u3cNGP61MdtwGTqZA0MreSaDybji8'))
+        self.assertTrue(YoutubePlaylistIE.suitable(u'UUBABnxM4Ar9ten8Mdjj1j0Q')) #585
+        self.assertTrue(YoutubePlaylistIE.suitable(u'PL63F0C78739B09958'))
+        self.assertTrue(YoutubePlaylistIE.suitable(u'https://www.youtube.com/playlist?list=UUBABnxM4Ar9ten8Mdjj1j0Q'))
+        self.assertTrue(YoutubePlaylistIE.suitable(u'https://www.youtube.com/course?list=ECUl4u3cNGP61MdtwGTqZA0MreSaDybji8'))
+        self.assertTrue(YoutubePlaylistIE.suitable(u'https://www.youtube.com/playlist?list=PLwP_SiAcdui0KVebT0mU9Apz359a4ubsC'))
+        self.assertTrue(YoutubePlaylistIE.suitable(u'https://www.youtube.com/watch?v=AV6J6_AeFEQ&playnext=1&list=PL4023E734DA416012')) #668
+        self.assertFalse(YoutubePlaylistIE.suitable(u'PLtS2H6bU1M'))
 
     def test_youtube_matching(self):
-        self.assertTrue(YoutubeIE().suitable(u'PLtS2H6bU1M'))
+        self.assertTrue(YoutubeIE.suitable(u'PLtS2H6bU1M'))
+        self.assertFalse(YoutubeIE.suitable(u'https://www.youtube.com/watch?v=AV6J6_AeFEQ&playnext=1&list=PL4023E734DA416012')) #668
 
     def test_youtube_extract(self):
         self.assertEqual(YoutubeIE()._extract_id('http://www.youtube.com/watch?&v=BaW_jenozKc'), 'BaW_jenozKc')

--- a/test/test_youtube_lists.py
+++ b/test/test_youtube_lists.py
@@ -41,6 +41,18 @@ class TestYoutubeLists(unittest.TestCase):
         self.assertEqual(map(lambda x: YoutubeIE()._extract_id(x[0]), DL.result),
             [ 'bV9L5Ht9LgY', 'FXxLjLQi3Fg', 'tU3Bgo5qJZE' ])
 
+        #661
+        DL = FakeDownloader()
+        IE = YoutubePlaylistIE(DL)
+        IE.extract('PLMCmkNmxw6Z9eduM7BZjSEh7HiU543Ig0')
+        self.assertTrue(len(DL.result) > 20)
+
+        #673
+        DL = FakeDownloader()
+        IE = YoutubePlaylistIE(DL)
+        IE.extract('PLBB231211A4F62143')
+        self.assertTrue(len(DL.result) > 40)
+
     def test_youtube_playlist_long(self):
         DL = FakeDownloader()
         IE = YoutubePlaylistIE(DL)
@@ -48,6 +60,7 @@ class TestYoutubeLists(unittest.TestCase):
         self.assertTrue(len(DL.result) >= 799)
 
     def test_youtube_playlist_with_deleted(self):
+        #651
         DL = FakeDownloader()
         IE = YoutubePlaylistIE(DL)
         IE.extract('https://www.youtube.com/playlist?list=PLwP_SiAcdui0KVebT0mU9Apz359a4ubsC')


### PR DESCRIPTION
Simply switching to the public API killed three nasty bugs.

Then I corrected the "is it a video or a playlist" mismatch by making `YoutubeIE.suitable` first run `YoutubePlaylistIE.suitable` and return `False` on positive. Trust me, current behavior can't be reproduced with sane regexes.

(Plus some other PL-related changes and the definition as `@classmethod`s of `IE.working` and `IE.suitable`)
