### PR TITLE
Escapist videos are acutally .mp4, not .flv

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -2557,7 +2557,7 @@ class EscapistIE(InfoExtractor):
             'uploader': showName,
             'upload_date': None,
             'title': showName,
-            'ext': 'flv',
+            'ext': 'mp4',
             'thumbnail': imgUrl,
             'description': description,
             'player_url': playerUrl,


### PR DESCRIPTION
Files downloaded with the Escapist info extractor are actually MPEGv4 files, not Flash video:

$ youtube-dl "http://www.escapistmagazine.com/videos/view/zero-punctuation/6964-Crysis-3"
[escapist] zero-punctuation: Extracting information
[escapist] zero-punctuation: Downloading configuration
[download] Destination: 6964-Crysis-3.flv
[download] 100.0% of 7.06M at    4.35M/s ETA 00:00
$ file 6964-Crysis-3.flv 
6964-Crysis-3.flv: ISO Media, MPEG v4 system, version 1
$ ffmpeg -i 6964-Crysis-3.flv 
...
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '6964-Crysis-3.flv':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    title           : New Video (zp_crysis-3_030612.mp4)[Pending Review]
    album           : Zero Punctuation
    encoder         : Lavf54.29.104
    comment         : New Video
  Duration: 00:05:42.45, start: 0.000000, bitrate: 172 kb/s
    Stream #0:0(eng): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 512x288 [SAR 1:1 DAR 16:9], 70 kb/s, 20 fps, 20 tbr, 20 tbn, 40 tbc
    Metadata:
      handler_name    : VideoHandler
    Stream #0:1(eng): Audio: aac (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 96 kb/s
    Metadata:
      handler_name    : SoundHandler
At least one output file must be specified

I've tested this on a handful of videos from different features and over a wide range of release dates, from today to 2007, and they're all in this format.

Cheers!
