### PR TITLE
Add seq_index field for playlists (Issue #570)

### DIFF
--- a/youtube_dl/FileDownloader.py
+++ b/youtube_dl/FileDownloader.py
@@ -390,7 +390,7 @@ class FileDownloader(object):
                 return u'"' + title + '" title matched reject pattern "' + rejecttitle + '"'
         return None
 
-    def process_info(self, info_dict):
+    def process_info(self, info_dict, seq_index=0):
         """Process a single dictionary returned by an InfoExtractor."""
 
         # Keep for backwards compatibility
@@ -398,6 +398,8 @@ class FileDownloader(object):
 
         if not 'format' in info_dict:
             info_dict['format'] = info_dict['ext']
+
+        info_dict['seq_index'] = compat_str(seq_index)
 
         reason = self._match_entry(info_dict)
         if reason is not None:
@@ -494,7 +496,7 @@ class FileDownloader(object):
                     self.trouble(u'ERROR: postprocessing: %s' % str(err))
                     return
 
-    def download(self, url_list):
+    def download(self, url_list, seq_index=0):
         """Download a given list of URLs."""
         if len(url_list) > 1 and self.fixed_template():
             raise SameFileError(self.params['outtmpl'])
@@ -534,7 +536,7 @@ class FileDownloader(object):
                     video['extractor'] = ie.IE_NAME
                     try:
                         self.increment_downloads()
-                        self.process_info(video)
+                        self.process_info(video, seq_index=seq_index)
                     except UnavailableVideoError:
                         self.trouble(u'\nERROR: unable to download video')
 

--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -1756,8 +1756,10 @@ class YoutubePlaylistIE(InfoExtractor):
         else:
             self._downloader.to_screen(u'[youtube] PL %s: Found %i videos, downloading %i' % (playlist_id, total, len(videos)))
 
+        seq_index = playliststart + 1
         for video in videos:
-            self._downloader.download([video])
+            self._downloader.download([video], seq_index=seq_index)
+            seq_index += 1
         return
 
 

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -222,7 +222,7 @@ def parseOpts():
             action='store_true', dest='autonumber',
             help='number downloaded files starting from 00000', default=False)
     filesystem.add_option('-o', '--output',
-            dest='outtmpl', metavar='TEMPLATE', help='output filename template. Use %(title)s to get the title, %(uploader)s for the uploader name, %(uploader_id)s for the uploader nickname if different, %(autonumber)s to get an automatically incremented number, %(ext)s for the filename extension, %(upload_date)s for the upload date (YYYYMMDD), %(extractor)s for the provider (youtube, metacafe, etc), %(id)s for the video id and %% for a literal percent. Use - to output to stdout. Can also be used to download to a different directory, for example with -o \'/my/downloads/%(uploader)s/%(title)s-%(id)s.%(ext)s\' .')
+            dest='outtmpl', metavar='TEMPLATE', help='output filename template. Use %(title)s to get the title, %(uploader)s for the uploader name, %(uploader_id)s for the uploader nickname if different, %(autonumber)s to get an automatically incremented number, %(ext)s for the filename extension, %(upload_date)s for the upload date (YYYYMMDD), %(extractor)s for the provider (youtube, metacafe, etc), %(id)s for the video id, %(seq_index)s for the playlist sequence number (0 if not a playlist), and %% for a literal percent. Use - to output to stdout. Can also be used to download to a different directory, for example with -o \'/my/downloads/%(uploader)s/%(title)s-%(id)s.%(ext)s\' .')
     filesystem.add_option('--restrict-filenames',
             action='store_true', dest='restrictfilenames',
             help='Restrict filenames to only ASCII characters, and avoid "&" and spaces in filenames', default=False)


### PR DESCRIPTION
This commit adds the info_dict['seq_index'] field.  It is the sequence number in a video play list.  The same field can be used in a -o output format specification as %(seq_index)s.  Handles --playlist-start.  Tested against YouTube playlist.  
