### PR TITLE
Add an Atom feed generator in devscripts

### DIFF
--- a/devscripts/release.sh
+++ b/devscripts/release.sh
@@ -69,7 +69,7 @@ ROOT=$(pwd)
     ORIGIN_URL=$(git config --get remote.origin.url)
     cd build/gh-pages
     "$ROOT/devscripts/gh-pages/add-version.py" $version
-    "$ROOT/devscripts/gh-pages/update-feed.py" $version
+    "$ROOT/devscripts/gh-pages/update-feed.py"
     "$ROOT/devscripts/gh-pages/sign-versions.py" < "$ROOT/updates_key.pem"
     "$ROOT/devscripts/gh-pages/generate-download.py"
     "$ROOT/devscripts/gh-pages/update-copyright.py"


### PR DESCRIPTION
Generate an atom feed when a new version is released. The first time it will need an "atom.atom" in the gh-pages branch, like:

```
<?xml version='1.0' encoding='utf-8'?>
<atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
        <atom:title>youtube-dl</atom:title>
        <atom:subtitle>Updates feed.</atom:subtitle>
        <atom:id>youtube-dl-updates-feed</atom:id>
        <atom:updated></atom:updated>
</atom:feed>
```

The final "atom.atom" is no pretty printed, I will try to solve it.
Of course, the feed should be added as a link or by adding `<link href="atom.atom" type="application/atom+xml" rel="alternate">` to the head of the page.
Suggested in #756
