### PR TITLE
Use sys.stdout.buffer when writing to standard out

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -329,7 +329,7 @@ def sanitize_open(filename, open_mode):
             if sys.platform == 'win32':
                 import msvcrt
                 msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-            return (sys.stdout, filename)
+            return (sys.stdout.buffer, filename)
         stream = open(encodeFilename(filename), open_mode)
         return (stream, filename)
     except (IOError, OSError) as err:


### PR DESCRIPTION
Downloading a file to - gives the following error:

```
youtube-dl -o - http://www.youtube.com/watch?v=QlWZluzBNxM
[youtube] Setting language
[youtube] QlWZluzBNxM: Downloading video webpage
[youtube] QlWZluzBNxM: Downloading video info webpage
[youtube] QlWZluzBNxM: Extracting video information
[download] Destination: -
Traceback (most recent call last):
  File "/usr/bin/youtube-dl", line 6, in <module>
    youtube_dl.main()
  File "/usr/lib/python3.3/site-packages/youtube_dl/__init__.py", line 516, in main
    _real_main()
  File "/usr/lib/python3.3/site-packages/youtube_dl/__init__.py", line 500, in _real_main
    retcode = fd.download(all_urls)
  File "/usr/lib/python3.3/site-packages/youtube_dl/FileDownloader.py", line 525, in download
    self.process_info(video)
  File "/usr/lib/python3.3/site-packages/youtube_dl/FileDownloader.py", line 468, in process_info
    success = self._do_download(filename, info_dict)
  File "/usr/lib/python3.3/site-packages/youtube_dl/FileDownloader.py", line 752, in _do_download
    stream.write(data_block)
TypeError: must be str, not bytes
```

From the python documentation for sys.stdout:

> By default, these streams are regular text streams as returned by the open() function.  To write or read binary data from/to the standard streams, use the underlying binary buffer.

Replacing sys.stdout with sys.stdout.buffer solved the problem for me.
