### PR TITLE
Fix bug when the vimeo description is empty on Python 2.x.

### DIFF
--- a/youtube_dl/InfoExtractors.py
+++ b/youtube_dl/InfoExtractors.py
@@ -1130,7 +1130,7 @@ class VimeoIE(InfoExtractor):
         # Extract video description
         video_description = get_element_by_attribute("itemprop", "description", webpage)
         if video_description: video_description = clean_html(video_description)
-        else: video_description = ''
+        else: video_description = u''
 
         # Extract upload date
         video_upload_date = None


### PR DESCRIPTION
I ran into an error when downloading a video from video with no description. This fixes it.
