### PR TITLE
Resolve the symlink if __main__.py is invoke as a symlink.

### DIFF
--- a/youtube_dl/__main__.py
+++ b/youtube_dl/__main__.py
@@ -9,7 +9,8 @@ import sys
 if __package__ is None and not hasattr(sys, "frozen"):
     # direct call of __main__.py
     import os.path
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    path = os.path.realpath(os.path.abspath(__file__))
+    sys.path.append(os.path.dirname(os.path.dirname(path)))
 
 import youtube_dl
 


### PR DESCRIPTION
If you create a symlink to **main**.py and run that, sys.path does not get updated correctly so that it can find the youtube_dl module. Calling os.path.realpath fixes that.
