### PR TITLE
Parameters as arguments to main

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -299,7 +299,7 @@ def parseOpts(arguments):
     systemConf = _readOptions('/etc/youtube-dl.conf')
     userConf = _readOptions(userConfFile)
     commandLineConf = sys.argv[1:] 
-    argv = systemConf + userConf + commandLineConf if not arguments else arguments
+    argv = (systemConf + userConf + commandLineConf) if not arguments else arguments
     opts, args = parser.parse_args(argv)
 
     if opts.verbose:


### PR DESCRIPTION
Hi.
It's only one commit which adds the ability to use youtube-dl programmatically from other python code by passing the commandline arguments to the main method and fetching any SystemExits.

Best regards,
Finn
