### PR TITLE
Added --get-id option to print video IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ which means you can modify it, redistribute it or use it however you like.
     --skip-download            do not download the video
     -g, --get-url              simulate, quiet but print URL
     -e, --get-title            simulate, quiet but print title
+    --get-id                   simulate, quiet but print id
     --get-thumbnail            simulate, quiet but print thumbnail URL
     --get-description          simulate, quiet but print video description
     --get-filename             simulate, quiet but print output filename

--- a/youtube_dl/FileDownloader.py
+++ b/youtube_dl/FileDownloader.py
@@ -54,6 +54,7 @@ class FileDownloader(object):
     quiet:             Do not print messages to stdout.
     forceurl:          Force printing final URL.
     forcetitle:        Force printing title.
+    forceid:           Force printing ID.
     forcethumbnail:    Force printing thumbnail URL.
     forcedescription:  Force printing description.
     forcefilename:     Force printing final filename.
@@ -574,6 +575,8 @@ class FileDownloader(object):
         # Forced printings
         if self.params.get('forcetitle', False):
             compat_print(info_dict['title'])
+        if self.params.get('forceid', False):
+            compat_print(info_dict['id'])
         if self.params.get('forceurl', False):
             compat_print(info_dict['url'])
         if self.params.get('forcethumbnail', False) and 'thumbnail' in info_dict:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -216,6 +216,8 @@ def parseOpts(overrideArguments=None):
             action='store_true', dest='geturl', help='simulate, quiet but print URL', default=False)
     verbosity.add_option('-e', '--get-title',
             action='store_true', dest='gettitle', help='simulate, quiet but print title', default=False)
+    verbosity.add_option('--get-id',
+            action='store_true', dest='getid', help='simulate, quiet but print id', default=False)
     verbosity.add_option('--get-thumbnail',
             action='store_true', dest='getthumbnail',
             help='simulate, quiet but print thumbnail URL', default=False)
@@ -495,15 +497,16 @@ def _real_main(argv=None):
         'usenetrc': opts.usenetrc,
         'username': opts.username,
         'password': opts.password,
-        'quiet': (opts.quiet or opts.geturl or opts.gettitle or opts.getthumbnail or opts.getdescription or opts.getfilename or opts.getformat),
+        'quiet': (opts.quiet or opts.geturl or opts.gettitle or opts.getid or opts.getthumbnail or opts.getdescription or opts.getfilename or opts.getformat),
         'forceurl': opts.geturl,
         'forcetitle': opts.gettitle,
+        'forceid': opts.getid,
         'forcethumbnail': opts.getthumbnail,
         'forcedescription': opts.getdescription,
         'forcefilename': opts.getfilename,
         'forceformat': opts.getformat,
         'simulate': opts.simulate,
-        'skip_download': (opts.skip_download or opts.simulate or opts.geturl or opts.gettitle or opts.getthumbnail or opts.getdescription or opts.getfilename or opts.getformat),
+        'skip_download': (opts.skip_download or opts.simulate or opts.geturl or opts.gettitle or opts.getid or opts.getthumbnail or opts.getdescription or opts.getfilename or opts.getformat),
         'format': opts.format,
         'format_limit': opts.format_limit,
         'listformats': opts.listformats,


### PR DESCRIPTION
New option --get-id to print video ID(s) for single url or channel.
