### PR TITLE
VimeoIE: allow to download password protected videos

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -423,7 +423,7 @@ def _real_main(argv=None):
     if opts.usenetrc and (opts.username is not None or opts.password is not None):
         parser.error(u'using .netrc conflicts with giving username/password')
     if opts.password is not None and opts.username is None:
-        parser.error(u'account username missing')
+        print(u'WARNING: account username missing')
     if opts.outtmpl is not None and (opts.usetitle or opts.autonumber or opts.useid):
         parser.error(u'using output template conflicts with using title, video ID or auto number')
     if opts.usetitle and opts.useid:


### PR DESCRIPTION
Tested with https://vimeo.com/68375962 (password: `youtube-dl`)
I'm not sure if not giving a username should raise just a warning or an error, it may be better to add a `--video-password` option for videos protected with a password, what's your opinion?

Closes #769 and #328.
