### PR TITLE
describe permitted .conf file content

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -125,7 +125,7 @@ For a complete list, execute <code>youtube-dl --list-extractors</code>.
 <h1 id="d8">Configuration</h1>
 
 <p>
-You can configure youtube-dl by placing default arguments (such as <code>--extract-audio --no-mtime</code> to always extract the audio and not copy the mtime) into <code>/etc/youtube-dl.conf</code> and/or <code>~/.config/youtube-dl.conf</code>.
+You can configure youtube-dl by placing default arguments (such as <code>--extract-audio --no-mtime</code> to always extract the audio and not copy the mtime) into <code>/etc/youtube-dl.conf</code> and/or <code>~/.config/youtube-dl.conf</code>. Arguments in these files may be written across multiple lines, and any line beginning with the <code>#</code> character will be treated as a comment.
 </p>
 
 <div class="note">


### PR DESCRIPTION
Determined by inspecting the documentation for the Python `shlex` module:

http://docs.python.org/2/library/shlex.html
