### PR TITLE
Augmented Generic IE

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -135,7 +135,7 @@ class GenericIE(InfoExtractor):
         #   Video Title - Tagline | Site Name
         # and so on and so forth; it's just not practical
         video_title = self._html_search_regex(r'<title>(.*)</title>',
-            webpage, u'video title')
+            webpage, u'video title', default=u'video')
 
         # video uploader is domain name
         video_uploader = self._search_regex(r'(?:https?://)?([^/]*)/.*',


### PR DESCRIPTION
I changed one of regexes for the generic IE to handle the case in which file is a key inside a dictionary. This occurs sometimes and can be used to handle cases like:
http://www.mp4upload.com/embed-rt2yx5n01ydl-650x372.html
in which:

I also made 'video' the default title for the generic IE. I would argue that the generic IE needs to be a little more forgiving about not being able to find a correct title (the previous link is an example of youtube-dl not finding the correct title). Youtube-dl should not refuse to download a video because a title was not provided by the site.
