### PR TITLE
Support download of multipart videos

### DIFF
--- a/test/test_download.py
+++ b/test/test_download.py
@@ -151,8 +151,9 @@ def generator(test_case):
                     sys.stderr.write(u'\n"info_dict": ' + json.dumps(test_info_dict, ensure_ascii=False, indent=2) + u'\n')
 
                 # Check for the presence of mandatory fields
-                for key in ('id', 'url', 'title', 'ext'):
+                for key in ('id', 'title', 'ext'):
                     self.assertTrue(key in info_dict.keys() and info_dict[key])
+                self.assertTrue(any(key in info_dict.keys() and info_dict[key] for key in ('url', 'parts')))
                 # Check for mandatory fields that are automatically set by YoutubeDL
                 for key in ['webpage_url', 'extractor', 'extractor_key']:
                     self.assertTrue(info_dict.get(key), u'Missing field: %s' % key)

--- a/youtube_dl/PostProcessor.py
+++ b/youtube_dl/PostProcessor.py
@@ -11,6 +11,7 @@ from .utils import (
     PostProcessingError,
     shell_quote,
     subtitles_filename,
+    build_part_filename,
 )
 
 
@@ -518,7 +519,7 @@ class FFmpegJoinVideosPP(FFmpegPostProcessor):
         parts = information.get('parts')
         if parts is None or len(parts) == 1:
             return (True, information)
-        parts_files = [u'%s.%s' % (filename, i) for (i, _) in enumerate(parts)]
+        parts_files = [build_part_filename(filename, i) for (i, _) in enumerate(parts)]
         files_file = u'%s.videos' % filename
         with io.open(encodeFilename(files_file), 'w', encoding='utf-8') as f:
                     for video in parts_files:
@@ -527,7 +528,7 @@ class FFmpegJoinVideosPP(FFmpegPostProcessor):
         try:
             self.run_ffmpeg(files_file, filename, ['-c', 'copy'], ['-f', 'concat'])
         except FFmpegPostProcessorError:
-            return False
+            return False, information
         os.remove(encodeFilename(files_file))
         # We have to manually remove the parts if requested
         if not self._downloader.params.get('keepvideo', False):

--- a/youtube_dl/PostProcessor.py
+++ b/youtube_dl/PostProcessor.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 import time
+import io
 
 
 from .utils import (
@@ -78,15 +79,15 @@ class FFmpegPostProcessor(PostProcessor):
         programs = ['avprobe', 'avconv', 'ffmpeg', 'ffprobe']
         return dict((program, executable(program)) for program in programs)
 
-    def run_ffmpeg_multiple_files(self, input_paths, out_path, opts):
+    def run_ffmpeg_multiple_files(self, input_paths, out_path, opts, input_opts=[]):
         if not self._exes['ffmpeg'] and not self._exes['avconv']:
             raise FFmpegPostProcessorError(u'ffmpeg or avconv not found. Please install one.')
 
         files_cmd = []
         for path in input_paths:
             files_cmd.extend(['-i', encodeFilename(path)])
-        cmd = ([self._exes['avconv'] or self._exes['ffmpeg'], '-y'] + files_cmd
-               + opts +
+        cmd = ([self._exes['avconv'] or self._exes['ffmpeg'], '-y'] +
+               input_opts + files_cmd + opts +
                [encodeFilename(self._ffmpeg_filename_argument(out_path))])
 
         if self._downloader.params.get('verbose', False):
@@ -98,8 +99,8 @@ class FFmpegPostProcessor(PostProcessor):
             msg = stderr.strip().split('\n')[-1]
             raise FFmpegPostProcessorError(msg)
 
-    def run_ffmpeg(self, path, out_path, opts):
-        self.run_ffmpeg_multiple_files([path], out_path, opts)
+    def run_ffmpeg(self, path, out_path, opts, input_opts=[]):
+        self.run_ffmpeg_multiple_files([path], out_path, opts, input_opts)
 
     def _ffmpeg_filename_argument(self, fn):
         # ffmpeg broke --, see https://ffmpeg.org/trac/ffmpeg/ticket/2127 for details
@@ -509,3 +510,18 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         os.remove(encodeFilename(filename))
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))
         return True, info
+
+
+class FFmpegJoinVideos(FFmpegPostProcessor):
+    def join(self, final_video, videos):
+        files_file = u'%s.videos' % final_video
+        with io.open(encodeFilename(files_file), 'w', encoding='utf-8') as f:
+                    for video in videos:
+                        f.write(u'file \'%s\'\n' % video)
+        self._downloader.to_screen(u'[ffmpeg] Joining video parts, destination: %s' % final_video)
+        try:
+            self.run_ffmpeg(files_file, final_video, ['-c', 'copy'], ['-f', 'concat'])
+        except FFmpegPostProcessorError:
+            return False
+        os.remove(encodeFilename(files_file))
+        return True

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -43,6 +43,7 @@ from .utils import (
     SameFileError,
     sanitize_filename,
     subtitles_filename,
+    build_part_filename,
     takewhile_inclusive,
     UnavailableVideoError,
     write_json_file,
@@ -790,7 +791,7 @@ class YoutubeDL(object):
                             for (i, part) in enumerate(parts):
                                 part_info = dict(info_dict)
                                 part_info.update(part)
-                                part_filename = u'%s.%s' % (filename, i)
+                                part_filename = build_part_filename(filename, i)
                                 parts_success.append(self.fd._do_download(part_filename, part_info))
                             success = all(parts_success)
                 except (compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -778,7 +778,7 @@ class YoutubeDL(object):
                     if not parts:
                         success = self.fd._do_download(filename, info_dict)
                     elif len(parts) == 1:
-                        info_dict['url'] = parts[0]
+                        info_dict.update(parts[0])
                         success = self.fd._do_download(filename, info_dict)
                     else:
                         # We check if the final video has already been downloaded
@@ -789,9 +789,9 @@ class YoutubeDL(object):
                             parts_success = []
                             parts_files = []
                             self.to_screen(u'[info] Downloading %s parts' % len(parts))
-                            for (i, part_url) in enumerate(parts):
+                            for (i, part) in enumerate(parts):
                                 part_info = dict(info_dict)
-                                part_info['url'] = part_url
+                                part_info.update(part)
                                 part_filename = u'%s.%s' % (filename, i)
                                 parts_files.append(part_filename)
                                 parts_success.append(self.fd._do_download(part_filename, part_info))

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -52,7 +52,6 @@ from .utils import (
 from .extractor import get_info_extractor, gen_extractors
 from .FileDownloader import FileDownloader
 from .version import __version__
-from .PostProcessor import FFmpegJoinVideos
 
 
 class YoutubeDL(object):
@@ -787,25 +786,13 @@ class YoutubeDL(object):
                             success = True
                         else:
                             parts_success = []
-                            parts_files = []
                             self.to_screen(u'[info] Downloading %s parts' % len(parts))
                             for (i, part) in enumerate(parts):
                                 part_info = dict(info_dict)
                                 part_info.update(part)
                                 part_filename = u'%s.%s' % (filename, i)
-                                parts_files.append(part_filename)
                                 parts_success.append(self.fd._do_download(part_filename, part_info))
                             success = all(parts_success)
-                            if success:
-                                video_joiner = FFmpegJoinVideos(self)
-                                join_success = video_joiner.join(filename, parts_files)
-                                if not join_success:
-                                    self.report_error(u'Could not join the video parts')
-                                else:
-                                    self.to_screen(u'[info] Removing video parts')
-                                    for part_file in parts_files:
-                                        os.remove(encodeFilename(part_file))
-                                success = join_success
                 except (compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:
                     self.report_error(u'unable to download video data: %s' % str(err))
                     return

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -781,26 +781,31 @@ class YoutubeDL(object):
                         info_dict['url'] = parts[0]
                         success = self.fd._do_download(filename, info_dict)
                     else:
-                        parts_success = []
-                        parts_files = []
-                        self.to_screen(u'[info] Downloading %s parts' % len(parts))
-                        for (i, part_url) in enumerate(parts):
-                            part_info = dict(info_dict)
-                            part_info['url'] = part_url
-                            part_filename = u'%s.%s' % (filename, i)
-                            parts_files.append(part_filename)
-                            parts_success.append(self.fd._do_download(part_filename, part_info))
-                        success = all(parts_success)
-                        if success:
-                            video_joiner = FFmpegJoinVideos(self)
-                            join_success = video_joiner.join(filename, parts_files)
-                            if not join_success:
-                                self.report_error(u'Could not join the video parts')
-                            else:
-                                self.to_screen(u'[info] Removing video parts')
-                                for part_file in parts_files:
-                                    os.remove(encodeFilename(part_file))
-                            success = join_success
+                        # We check if the final video has already been downloaded
+                        if self.params.get('continuedl', False) and os.path.isfile(encodeFilename(filename)):
+                            self.fd.report_file_already_downloaded(filename)
+                            success = True
+                        else:
+                            parts_success = []
+                            parts_files = []
+                            self.to_screen(u'[info] Downloading %s parts' % len(parts))
+                            for (i, part_url) in enumerate(parts):
+                                part_info = dict(info_dict)
+                                part_info['url'] = part_url
+                                part_filename = u'%s.%s' % (filename, i)
+                                parts_files.append(part_filename)
+                                parts_success.append(self.fd._do_download(part_filename, part_info))
+                            success = all(parts_success)
+                            if success:
+                                video_joiner = FFmpegJoinVideos(self)
+                                join_success = video_joiner.join(filename, parts_files)
+                                if not join_success:
+                                    self.report_error(u'Could not join the video parts')
+                                else:
+                                    self.to_screen(u'[info] Removing video parts')
+                                    for part_file in parts_files:
+                                        os.remove(encodeFilename(part_file))
+                                success = join_success
                 except (compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:
                     self.report_error(u'unable to download video data: %s' % str(err))
                     return

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -76,6 +76,7 @@ from .PostProcessor import (
     FFmpegVideoConvertor,
     FFmpegExtractAudioPP,
     FFmpegEmbedSubtitlePP,
+    FFmpegJoinVideosPP,
 )
 
 
@@ -390,6 +391,8 @@ def parseOpts(overrideArguments=None):
             help='ffmpeg/avconv audio quality specification, insert a value between 0 (better) and 9 (worse) for VBR or a specific bitrate like 128K (default 5)')
     postproc.add_option('--recode-video', metavar='FORMAT', dest='recodevideo', default=None,
             help='Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm)')
+    postproc.add_option('--join-parts', action='store_true', dest='joinparts', default=False,
+            help='Join the video parts if the video is splitted in different parts.')
     postproc.add_option('-k', '--keep-video', action='store_true', dest='keepvideo', default=False,
             help='keeps the video file on disk after the post-processing; the video is erased by default')
     postproc.add_option('--no-post-overwrites', action='store_true', dest='nopostoverwrites', default=False,
@@ -658,6 +661,8 @@ def _real_main(argv=None):
         ydl.add_default_info_extractors()
 
         # PostProcessors
+        if opts.joinparts:
+            ydl.add_post_processor(FFmpegJoinVideosPP())
         # Add the metadata pp first, the other pps will copy it
         if opts.addmetadata:
             ydl.add_post_processor(FFmpegMetadataPP())

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -55,6 +55,7 @@ class InfoExtractor(object):
     subtitles:      The subtitle file contents as a dictionary in the format
                     {language: subtitles}.
     view_count:     How many users have watched the video on the platform.
+    parts:          A list of urls for each of the parts of the video.
     urlhandle:      [internal] The urlHandle to be used to download the file,
                     like returned by urllib.request.urlopen
     age_limit:      Age restriction for the video, as an integer (years)

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -55,7 +55,9 @@ class InfoExtractor(object):
     subtitles:      The subtitle file contents as a dictionary in the format
                     {language: subtitles}.
     view_count:     How many users have watched the video on the platform.
-    parts:          A list of urls for each of the parts of the video.
+    parts:          A list of info_dicts for each of the parts of the video,
+                    it must include the url field, if it's a rtmp download it
+                    can contain additional fields for rtmpdump.
     urlhandle:      [internal] The urlHandle to be used to download the file,
                     like returned by urllib.request.urlopen
     age_limit:      Age restriction for the video, as an integer (years)

--- a/youtube_dl/extractor/tudou.py
+++ b/youtube_dl/extractor/tudou.py
@@ -67,15 +67,11 @@ class TudouIE(InfoExtractor):
             part_id = part['k']
             final_url = self._url_for_id(part_id, quality)
             ext = (final_url.split('?')[0]).split('.')[-1]
-            parts.append(final_url)
+            parts.append({'url': final_url})
 
-        info_dict = {'id': video_id,
-                     'ext': ext,
-                     'title': title,
-                     'thumbnail': thumbnail_url,
-                     }
-        if len_segs == 1:
-            info_dict['url'] = parts[0]
-        else:
-            info_dict['parts'] = parts
-        return info_dict
+        return {'id': video_id,
+                'ext': ext,
+                'title': title,
+                'thumbnail': thumbnail_url,
+                'parts': parts,
+                }

--- a/youtube_dl/extractor/tudou.py
+++ b/youtube_dl/extractor/tudou.py
@@ -10,7 +10,7 @@ class TudouIE(InfoExtractor):
     _VALID_URL = r'(?:http://)?(?:www\.)?tudou\.com/(?:listplay|programs|albumplay)/(?:view|(.+?))/(?:([^/]+)|([^/]+))(?:\.html)?'
     _TESTS = [{
         u'url': u'http://www.tudou.com/listplay/zzdE77v6Mmo/2xN2duXMxmw.html',
-        u'file': u'159448201.f4v',
+        u'file': u'2xN2duXMxmw.f4v',
         u'md5': u'140a49ed444bd22f93330985d8475fcb',
         u'info_dict': {
             u"title": u"卡马乔国足开大脚长传冲吊集锦"
@@ -58,21 +58,24 @@ class TudouIE(InfoExtractor):
         # It looks like the keys are the arguments that have to be passed as
         # the hd field in the request url, we pick the higher
         quality = sorted(segments.keys())[-1]
-        parts = segments[quality]
-        result = []
-        len_parts = len(parts)
-        if len_parts > 1:
-            self.to_screen(u'%s: found %s parts' % (video_id, len_parts))
-        for part in parts:
+        segs = segments[quality]
+        parts = []
+        len_segs = len(segs)
+        if len_segs > 1:
+            self.to_screen(u'%s: found %s parts' % (video_id, len_segs))
+        for part in segs:
             part_id = part['k']
             final_url = self._url_for_id(part_id, quality)
             ext = (final_url.split('?')[0]).split('.')[-1]
-            part_info = {'id': part_id,
-                          'url': final_url,
-                          'ext': ext,
-                          'title': title,
-                          'thumbnail': thumbnail_url,
-                          }
-            result.append(part_info)
+            parts.append(final_url)
 
-        return result
+        info_dict = {'id': video_id,
+                     'ext': ext,
+                     'title': title,
+                     'thumbnail': thumbnail_url,
+                     }
+        if len_segs == 1:
+            info_dict['url'] = parts[0]
+        else:
+            info_dict['parts'] = parts
+        return info_dict

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -775,6 +775,10 @@ def determine_ext(url, default_ext=u'unknown_video'):
 def subtitles_filename(filename, sub_lang, sub_format):
     return filename.rsplit('.', 1)[0] + u'.' + sub_lang + u'.' + sub_format
 
+def build_part_filename(final_filename, part_index):
+    (name, ext) = os.path.splitext(final_filename)
+    return '%s.%d%s' % (name, part_index, ext)
+
 def date_from_str(date_str):
     """
     Return a datetime object from a string in the format YYYYMMDD or


### PR DESCRIPTION
This is my solution for the issue I posted in #991

A `parts` field can be set in the info_dict containing the urls of the different parts, when all the parts have been downloaded they are joined using the `FFmpegJoinVideos` postprocessor

I have tested it with a Tudou video: http://www.tudou.com/programs/view/J-P3o-chBp4/ (It's the only IE I  have found with multiple parts videos)