### PR TITLE
Fix regex error when only subtitled video is available on arte.

### DIFF
--- a/youtube_dl/extractor/arte.py
+++ b/youtube_dl/extractor/arte.py
@@ -98,7 +98,7 @@ class ArteTvIE(InfoExtractor):
                 l = 'F'
             elif lang == 'de':
                 l = 'A'
-            regexes = [r'VO?%s' % l, r'V%s-ST.' % l]
+            regexes = [r'VO?%s' % l, r'VO?.-ST%s' % l]
             return any(re.match(r, f['versionCode']) for r in regexes)
         # Some formats may not be in the same language as the url
         formats = filter(_match_lang, formats)


### PR DESCRIPTION
Fixes filter error on subtitled only arte videos. Example below.

```
$ youtube-dl -t -c "http://www.arte.tv/guide/de/049474-000/soul-night?autoplay=1"
[arte.tv] 049474-000: Downloading webpage
[arte.tv] 049474-000: Downloading info json
[arte.tv] 049474-000: Extracting information
Traceback (most recent call last):
  File "/home/domi/bin/youtube-dl", line 10, in <module>
    youtube_dl.main()
  File "/home/domi/projects/youtube-dl/youtube_dl/__init__.py", line 639, in main
    _real_main(argv)
  File "/home/domi/projects/youtube-dl/youtube_dl/__init__.py", line 623, in _real_main
    retcode = ydl.download(all_urls)
  File "/home/domi/projects/youtube-dl/youtube_dl/YoutubeDL.py", line 573, in download
    videos = self.extract_info(url)
  File "/home/domi/projects/youtube-dl/youtube_dl/YoutubeDL.py", line 312, in extract_info
    ie_result = ie.extract(url)
  File "/home/domi/projects/youtube-dl/youtube_dl/extractor/common.py", line 96, in extract
    return self._real_extract(url)
  File "/home/domi/projects/youtube-dl/youtube_dl/extractor/arte.py", line 63, in _real_extract
    return self._extract_emission(url, video_id, lang)
  File "/home/domi/projects/youtube-dl/youtube_dl/extractor/arte.py", line 109, in _extract_emission
    format_info = formats[-1]
IndexError: list index out of range
```
