### PR TITLE
XHamsterIE: fix video extension and add video description

### DIFF
--- a/youtube_dl/extractor/xhamster.py
+++ b/youtube_dl/extractor/xhamster.py
@@ -36,7 +36,7 @@ class XHamsterIE(InfoExtractor):
             video_url = compat_urllib_parse.unquote(mobj.group('file'))
         else:
             video_url = mobj.group('server')+'/key='+mobj.group('file')
-        video_extension = video_url.split('.')[-1]
+        video_extension = video_url.split('.')[-1].split('?')[0]
 
         video_title = self._html_search_regex(r'<title>(?P<title>.+?) - xHamster\.com</title>',
             webpage, u'title')


### PR DESCRIPTION
1. Some videos have a wrong video extension e.g.:
   $ youtube-dl -o "%(ext)s" --get-filename "http://xhamster.com/movies/1722902/.html"
   flvcdn_hash=e5678088dd31481c86f76d70391520ef&cdn_creation_time=1376033082&cdn_ttl=14400
2. Some vieos have an description e.g.:
   http://xhamster.com/movies/1503398/.html
