### PR TITLE
Properly handle platform name containing UTF-8 characters

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -597,7 +597,7 @@ def _real_main(argv=None):
                 sys.exc_clear()
             except:
                 pass
-        sys.stderr.write(u'[debug] Python version %s - %s' %(platform.python_version(), platform.platform()) + u'\n')
+        sys.stderr.write(u'[debug] Python version %s - %s\n' %(platform.python_version(), decodeOption(platform.platform())))
         sys.stderr.write(u'[debug] Proxy map: ' + str(proxy_handler.proxies) + u'\n')
 
     ydl.add_default_info_extractors()


### PR DESCRIPTION
On Fedora 19, python's platform name is something like "Linux-3.10.4-300.fc19.x86_64-x86_64-with-fedora-19-Schrödinger’s_Cat"

This causes a UnicodeDecodeError when running youtube-dl in verbose mode.

This commit fixes it by decoding the platform name properly with the util function decodeOption()
