### PR TITLE
fix UnboundLocalError: local variable 'video_id' referenced before assignment for Soundcloud Extractor

### DIFF
--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -184,7 +184,6 @@ class SoundcloudSetIE(SoundcloudIE):
         resolv_url = self._resolv_url(url)
         info_json = self._download_webpage(resolv_url, full_title)
 
-        videos = []
         info = json.loads(info_json)
         if 'errors' in info:
             for err in info['errors']:


### PR DESCRIPTION
Fix UnboundLocalError: local variable 'video_id' referenced before assignment
Also removed unnecessary variable videos in _real_extract (pylint hint)
