### PR TITLE
Fixed issue #1277 KeyError when no description.

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -492,6 +492,8 @@ class YoutubeDL(object):
                 self.report_writedescription(descfn)
                 with io.open(encodeFilename(descfn), 'w', encoding='utf-8') as descfile:
                     descfile.write(info_dict['description'])
+            except (KeyError, TypeError):
+                self.report_warning(u'Cannot extract description.')
             except (OSError, IOError):
                 self.report_error(u'Cannot write description file ' + descfn)
                 return


### PR DESCRIPTION
Allows a continue with a warning when an extractor cannot retrieve a description and either doesn't return a description or returns None as the description. #1277 
