### PR TITLE
Ignore non-ascii characters in py3k filename and stdout/stderr output

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -147,6 +147,8 @@ class YoutubeDL(object):
             output = message + terminator
             if 'b' in getattr(self._screen_file, 'mode', '') or sys.version_info[0] < 3: # Python 2 lies about the mode of sys.stdout/sys.stderr
                 output = output.encode(preferredencoding(), 'ignore')
+            if sys.version_info >= (3, 0):
+                output = output.encode('ascii','ignore').decode()
             self._screen_file.write(output)
             self._screen_file.flush()
 
@@ -156,6 +158,8 @@ class YoutubeDL(object):
         output = message + u'\n'
         if 'b' in getattr(self._screen_file, 'mode', '') or sys.version_info[0] < 3: # Python 2 lies about the mode of sys.stdout/sys.stderr
             output = output.encode(preferredencoding())
+        if sys.version_info >= (3, 0):
+            output = output.encode('ascii','ignore').decode()
         sys.stderr.write(output)
 
     def fixed_template(self):

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -449,6 +449,7 @@ def encodeFilename(s):
 
     # Python 3 has a Unicode API
     if sys.version_info >= (3, 0):
+        s = s.encode('ascii','ignore').decode()
         return s
 
     if sys.platform == 'win32' and sys.getwindowsversion()[0] >= 5:


### PR DESCRIPTION
Hi,

I tried to retrieve this video using youtube-dl-2013.09.07 with python 3.3:
https://www.youtube.com/watch?v=v9cJWCYdvUk

Here is the traceback:
$ youtube-dl https://www.youtube.com/watch?v=v9cJWCYdvUk
[youtube] Setting language
[youtube] v9cJWCYdvUk: Downloading video webpage
[youtube] v9cJWCYdvUk: Downloading video info webpage
[youtube] v9cJWCYdvUk: Extracting video information
Traceback (most recent call last):
  File "/usr/bin/youtube-dl", line 6, in <module>
    youtube_dl.main()
  File "/usr/lib/python3.3/site-packages/youtube_dl/**init**.py", line 667, in main
    _real_main(argv)
  File "/usr/lib/python3.3/site-packages/youtube_dl/__init__.py", line 651, in _real_main
    retcode = ydl.download(all_urls)
  File "/usr/lib/python3.3/site-packages/youtube_dl/YoutubeDL.py", line 573, in download
    videos = self.extract_info(url)
  File "/usr/lib/python3.3/site-packages/youtube_dl/YoutubeDL.py", line 339, in extract_info
    return self.process_ie_result(ie_result, download=download)
  File "/usr/lib/python3.3/site-packages/youtube_dl/YoutubeDL.py", line 422, in process_ie_result
    for r in ie_result['entries']
  File "/usr/lib/python3.3/site-packages/youtube_dl/YoutubeDL.py", line 422, in <listcomp>
    for r in ie_result['entries']
  File "/usr/lib/python3.3/site-packages/youtube_dl/YoutubeDL.py", line 369, in process_ie_result
    self.process_info(ie_result)
  File "/usr/lib/python3.3/site-packages/youtube_dl/YoutubeDL.py", line 548, in process_info
    success = self.fd._do_download(filename, info_dict)
  File "/usr/lib/python3.3/site-packages/youtube_dl/FileDownloader.py", line 376, in _do_download
    if self.params.get('continuedl', False) and os.path.isfile(encodeFilename(filename)) and not self.params.get('nopart', False):
  File "/usr/lib/python3.3/genericpath.py", line 29, in isfile
    st = os.stat(path)
UnicodeEncodeError: 'ascii' codec can't encode character '\xe3' in position 24: ordinal not in range(128)

The attached patch ignores some utf-8 but non ascii caracters originating from the title parsed html, because python3 wants ascii filenames by default. The stderr/stdout default encoding seems also to be ascii, at least for python3.

Regards,

x.
