### PR TITLE
change error into warning for blank title #1391

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1335,7 +1335,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
 
         # title
         if 'title' not in video_info:
-            raise ExtractorError(u'Unable to extract video title')
+            video_info['title'] = " "
+            print "Warning: Title was not found"
+            # raise ExtractorError(u'Unable to extract video title')
         video_title = compat_urllib_parse.unquote_plus(video_info['title'][0])
 
         # thumbnail image


### PR DESCRIPTION
In issue #1391 youtube-dl breaks when the video does not have a title, this changes that error into a warning and leaves the title blank
