### PR TITLE
add tox configuration file for easy testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ updates_key.pem
 *.mp4
 *.part
 test/testdata
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py26,py27,py33
+[testenv]
+deps = nose
+commands = nosetests --with-coverage --cover-package=youtube_dl --cover-html --verbose test


### PR DESCRIPTION
_[tox](http://tox.readthedocs.org/en/latest/)_ is a useful tool that will create virtualenvs for each Python version and then run the tests in each one by simply running `tox`. I've added the configuration file to run it.

I find it useful, I leave it to you to decide wether to merge it.
