### PR TITLE
extractor: youtube: Set extension of AAC audio formats to m4a.

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -236,10 +236,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
         '136': 'mp4',
         '137': 'mp4',
         '138': 'mp4',
-        '139': 'mp4',
+        '160': 'mp4',
+
+        # Dash mp4 audio
+        '139': 'm4a',
         '140': 'm4a',
         '141': 'm4a',
-        '160': 'm4a',
 
         # Dash webm
         '171': 'webm',


### PR DESCRIPTION
This, in particular, eases downloading both audio and videos in DASH formats
before muxing them, which alleviates the problem that I exposed on issue

Furthermore, one may argue that this is, indeed, the case for correctness's
sake.

Signed-off-by: Rogério Brito rbrito@ime.usp.br
