### PR TITLE
extractor: youtube: Allow format number as output template.

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1485,7 +1485,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
             # Extension
             video_extension = self._video_extensions.get(format_param, 'flv')
 
-            video_format = '{0} - {1}{2}'.format(format_param if format_param else video_extension,
+            numeric_video_format = '{0}'.format(format_param if format_param else video_extension)
+
+            video_format = '{0} - {1}{2}'.format(numeric_video_format,
                                               self._video_dimensions.get(format_param, '???'),
                                               ' ('+self._special_itags[format_param]+')' if format_param in self._special_itags else '')
 
@@ -1498,6 +1500,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
                 'title':    video_title,
                 'ext':      video_extension,
                 'format':   video_format,
+                'format_num':   numeric_video_format,
                 'thumbnail':    video_thumbnail,
                 'description':  video_description,
                 'player_url':   player_url,


### PR DESCRIPTION
Since many video formats map to the same extension, we get problems when
trying to download more than one format of the same audio/video with the
same ID.

This commit introduces a numeric version of the template of the video
format, which can help users who start downloading with a format (say, 720p
mp4), stop and then resume with another format (say, 360p mp4). See:
- http://bugs.debian.org/689294
- http://bugs.debian.org/643831

An output template like '%(title)s-%(id)s.%(format_num)s.%(ext)s' would,
unmistakenly, solve such problems.

This is also helpful to know what format was effectively downloaded when a
user expected something else (like, for instance, in issue #1578 or many of
its duplicates).

Another application of this is in separate downloads of audio video (as in
issue #1612).

Signed-off-by: Rogério Brito rbrito@ime.usp.br
