### PR TITLE
added --no-generic option to skip the generic information extractor.

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -198,6 +198,7 @@ def parseOpts(overrideArguments=None):
             help='Output descriptions of all supported extractors', default=False)
     general.add_option('--proxy', dest='proxy', default=None, help='Use the specified HTTP/HTTPS proxy', metavar='URL')
     general.add_option('--no-check-certificate', action='store_true', dest='no_check_certificate', default=False, help='Suppress HTTPS certificate validation.')
+    general.add_option('--no-generic', action='store_true', dest='no_generic', default=False, help='Do not attempt to fall back on the generic information extractor.')
     general.add_option(
         '--cache-dir', dest='cachedir', default=get_cachedir(), metavar='DIR',
         help='Location in the filesystem where youtube-dl can store downloaded information permanently. By default $XDG_CACHE_HOME/youtube-dl or ~/.cache/youtube-dl .')

--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from .appletrailers import AppleTrailersIE
 from .addanime import AddAnimeIE
 from .archiveorg import ArchiveOrgIE
@@ -170,7 +171,9 @@ _ALL_CLASSES = [
     for name, klass in globals().items()
     if name.endswith('IE') and name != 'GenericIE'
 ]
-_ALL_CLASSES.append(GenericIE)
+
+if '--no-generic' not in sys.argv:
+    _ALL_CLASSES.append(GenericIE)
 
 
 def gen_extractors():


### PR DESCRIPTION
Added --no-generic option to prevent youtube-dl from attempting to download a url that matched no other extractor.

Since extractor/__init__.py is imported before the OptionParser object is available, I checked sys.argv directly. If there is a better way to do this I would be happy to fix it. Thanks!
