### PR TITLE
[GenericIE] Also detect youtube if src url of iframe is embedded in ' instead of "

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -160,9 +160,9 @@ class GenericIE(InfoExtractor):
 
         # Look for embedded YouTube player
         mobj = re.search(
-            r'<iframe[^>]+?src="(https?://(?:www\.)?youtube.com/embed/.+?)"', webpage)
+            r'<iframe[^>]+?src=(["\'])(?P<url>https?://(?:www\.)?youtube.com/embed/.+?)\1', webpage)
         if mobj:
-            surl = unescapeHTML(mobj.group(1))
+            surl = unescapeHTML(mobj.group(u'url'))
             return self.url_result(surl, 'Youtube')
 
         # Look for Bandcamp pages with custom domain


### PR DESCRIPTION
E.g. http://www.tested.com/tech/48700-jamie-hynemans-electric-outboard-boat-motor/ doesn't work
