### PR TITLE
Try to use sogou proxy if youku videos are blocked

### DIFF
--- a/youtube_dl/extractor/youku.py
+++ b/youtube_dl/extractor/youku.py
@@ -86,8 +86,6 @@ class YoukuIE(InfoExtractor):
                 error_code = config['data'][0].get('error_code')
                 # XXX: needs a way to restore the original proxy settings
                 compat_urllib_request.install_opener(compat_urllib_request.build_opener(compat_urllib_request.ProxyHandler({})))
-            else:
-                print 'hahaha'
 
             if error_code:
                 error = config['data'][0].get('error')  # Chinese and English, separated by newline.


### PR DESCRIPTION
The core algorithm is from xiaoxia@xiaoxia.org. Use with the permission from XiaoXia. See the comments at 2013/08/18 in http://xiaoxia.org/2011/11/14/update-sogou-proxy-program-with-https-support/
