### PR TITLE
Correctly write and restore the console title on the stack (fixes #1782)

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -217,13 +217,15 @@ class YoutubeDL(object):
         if not self.params.get('consoletitle', False):
             return
         if 'TERM' in os.environ:
-            write_string(u'\033[22t', self._screen_file)
+            # Save the title on stack
+            write_string(u'\033[22;0t', self._screen_file)
 
     def restore_console_title(self):
         if not self.params.get('consoletitle', False):
             return
         if 'TERM' in os.environ:
-            write_string(u'\033[23t', self._screen_file)
+            # Restore the title from stack
+            write_string(u'\033[23;0t', self._screen_file)
 
     def __enter__(self):
         self.save_console_title()


### PR DESCRIPTION
According to http://invisible-island.net/xterm/ctlseqs/ctlseqs.html (search for `Save xterm icon and window title on stack.`) for writing the title to the stack `22;0t` is used instead of `22t`, the same for restoring the title.

I have tested it in OSX, it works in `xterm` and `iTerm`, but not with `Terminal.app` (included with the system).
