### PR TITLE
Use the 'extractor_key' field for the download archive file

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -837,7 +837,7 @@ class YoutubeDL(object):
     def _make_archive_id(self, info_dict):
         # Future-proof against any change in case
         # and backwards compatibility with prior versions
-        extractor = info_dict.get('extractor')
+        extractor = info_dict.get('extractor_key')
         if extractor is None:
             if 'id' in info_dict:
                 extractor = info_dict.get('ie_key')  # key in a playlist


### PR DESCRIPTION
It has the same value as the ie_key.

For most video only extractors the `extractor` and `extractor_key` have the same values, but it's not true for all, for example the extractor for 56.com. If a video from this site is included in a playlist, we would never skip it.
