### PR TITLE
[youtube] Add support for downloading top lists (fixes #1868)

### DIFF
--- a/test/test_youtube_lists.py
+++ b/test/test_youtube_lists.py
@@ -15,6 +15,7 @@ from youtube_dl.extractor import (
     YoutubeIE,
     YoutubeChannelIE,
     YoutubeShowIE,
+    YoutubeTopListIE,
 )
 
 
@@ -115,6 +116,13 @@ class TestYoutubeLists(unittest.TestCase):
         self.assertTrue(len(entries) >= 20)
         original_video = entries[0]
         self.assertEqual(original_video['id'], 'rjFaenf1T-Y')
+
+    def test_youtube_toplist(self):
+        dl = FakeYDL()
+        ie = YoutubeTopListIE(dl)
+        result = ie.extract('yttoplist:music:Top Tracks')
+        entries = result['entries']
+        self.assertTrue(len(entries) >= 9)
 
 if __name__ == '__main__':
     unittest.main()

--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -194,6 +194,7 @@ from .youtube import (
     YoutubeWatchLaterIE,
     YoutubeFavouritesIE,
     YoutubeHistoryIE,
+    YoutubeTopListIE,
 )
 from .zdf import ZDFIE
 


### PR DESCRIPTION
It needs to know the channel and the title of the list, because the ids change every time you browse the channels and are attached to a 'VISITOR_INFO1_LIVE' cookie.

It's not the ideal approach, but it's the only method I've found. If anyone has a better idea, please share it.
