### PR TITLE
Fix 2 bugs in youtube_dl/extractor/sohu.py

### DIFF
--- a/youtube_dl/extractor/sohu.py
+++ b/youtube_dl/extractor/sohu.py
@@ -13,7 +13,7 @@ class SohuIE(InfoExtractor):
     _TEST = {
         u'url': u'http://tv.sohu.com/20130724/n382479172.shtml#super',
         u'file': u'382479172.mp4',
-        u'md5': u'cc84eed6b6fbf0f2f9a8d3cb9da1939b', 
+        u'md5': u'29175c8cadd8b5cc4055001e85d6b372', 
         u'info_dict': {
             u'title': u'MV：Far East Movement《The Illest》',
         },


### PR DESCRIPTION
1. Highest quality is the first one in ('ori', 'super', 'high', 'nor')
   Their chinese names are 原画, 超清, 高清, 标清, respectively
2. Sohu's server can't identify duplicate slashes in the url.

An example that the old extractor does not work properly: 
    http://tv.sohu.com/20130710/n381244182.shtml
