### PR TITLE
Adding support to indentify multipl html5 elements in a webpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ updates_key.pem
 *.part
 test/testdata
 .tox
-/.idea

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -316,7 +316,6 @@ class InfoExtractor(object):
     @staticmethod
     def video_result(video_url=None, video_id=None, uploader=None, video_title=None):
         """Returns a url that points to a page that should be processed"""
-        #TODO: ie should be the class used for getting the info
         video_info = {'_type': 'video',
                       'url': video_url,
                       'id': video_id,


### PR DESCRIPTION
Example
--verbose -g http://flowplayer.org/

results in only the first asset being shown.

which these changes it show all nine.
