### PR TITLE
temporary fix for the time jumps

### DIFF
--- a/youtube_dl/downloader/hls.py
+++ b/youtube_dl/downloader/hls.py
@@ -13,7 +13,7 @@ class HlsFD(FileDownloader):
         self.report_destination(filename)
         tmpfilename = self.temp_name(filename)
 
-        args = ['-y', '-i', url, '-f', 'mp4', '-c', 'copy',
+        args = ['-y', '-i', url, '-t', '72000', '-f', 'mp4', '-c', 'copy',
             '-bsf:a', 'aac_adtstoasc', tmpfilename]
 
         for program in ['avconv', 'ffmpeg']:


### PR DESCRIPTION
I have added -t 72000 (20 hours) to force ffmpeg to mux the file when a "time jump" happens.

For some reason every jump I've seen so far (at least 6 in total) was to 20 hours or more.

I think It's a safe value, which won't cause any troubles. There is no chance recording a live stream for 20 hours without interruptions anyway (my personal record is 3 hours).

https://github.com/rg3/youtube-dl/issues/2213