### PR TITLE
Add antigen compatible plugin description

### DIFF
--- a/youtube-dl.plugin.zsh
+++ b/youtube-dl.plugin.zsh
@@ -1,1 +1,23 @@
+# This allows the youtube-dl command to be installed in ZSH using antigen.
+# Antigen is a bundle manager. It allows you to enhance the functionality of
+# your zsh session by installing bundles and themes easily.
+
+# Antigen documentation:
+# http://antigen.sharats.me/
+# https://github.com/zsh-users/antigen
+
+# Install youtube-dl:
+# antigen bundle rg3/youtube-dl
+# Bundles installed by antigen are available for use immediately.
+
+# Update youtube-dl (and all other antigen bundles):
+# antigen update
+
+# The antigen command will download the git repository to a folder and then
+# execute an enabling script (this file). The complete process for loading the
+# code is documented here:
+# https://github.com/zsh-users/antigen#notes-on-writing-plugins
+
+# This specific script just adds the downloaded folder to the end of the $PATH,
+# which allows the contained youtube-dl executable to be found.
 export PATH=${PATH}:$(dirname $0)


### PR DESCRIPTION
This adds antigen support for ZSH. See https://github.com/zsh-users/antigen for more details.

This allows a user to start using this library using the command:

antigen bundle matthewfranglen/youtube-dl

Which handles downloading the repository and adding the command to your path. This is compatible with the automatic update that is triggered on the first request.
