### PR TITLE
VALID_URL changed to match different kinds of Tumblr-URLs

### DIFF
--- a/youtube_dl/extractor/tumblr.py
+++ b/youtube_dl/extractor/tumblr.py
@@ -9,7 +9,7 @@ from ..utils import (
 
 
 class TumblrIE(InfoExtractor):
-    _VALID_URL = r'http://(?P<blog_name>.*?)\.tumblr\.com/((post)|(video))/(?P<id>\d*)/(.*?)'
+    _VALID_URL = r'http://(?P<blog_name>.*?)\.tumblr\.com/((post)|(video))/(?P<id>\d*)($|/)'
     _TEST = {
         'url': 'http://tatianamaslanydaily.tumblr.com/post/54196191430/orphan-black-dvd-extra-behind-the-scenes',
         'file': '54196191430.mp4',


### PR DESCRIPTION
Links to Tumblr post are usually given in one of the following formats:
- http://tatianamaslanydaily.tumblr.com/post/54196191430/orphan-black-dvd-extra-behind-the-scenes
- http://tatianamaslanydaily.tumblr.com/post/54196191430

Even though the first one is prevalent, some blogs use the second one.
The changed regex matches both formats while the old one only matched the first.
