### PR TITLE
Retrieve the URLs of all availale thumbnails

### DIFF
--- a/youtube_dl/extractor/tumblr.py
+++ b/youtube_dl/extractor/tumblr.py
@@ -38,8 +38,7 @@ class TumblrIE(InfoExtractor):
         thumb_list = []
         ma = re.search(r'posters.*?\[(?P<thumb>\\x22.*?\\x22)]', webpage)
         if not ma is None:
-            for t in ma.group('thumb').replace(r'\\/', '/').split(','):
-                t = t.replace(r'\x22','"')
+            for t in ma.group('thumb').decode('string-escape').replace(r'\/',r'/').split(','):
                 if (t[0] == '"') and (t[-1] == '"'):
                     thumb_list.append( {"url": t[1:-1]} )
 

--- a/youtube_dl/extractor/tumblr.py
+++ b/youtube_dl/extractor/tumblr.py
@@ -38,15 +38,10 @@ class TumblrIE(InfoExtractor):
         thumb_list = []
         ma = re.search(r'posters.*?\[(?P<thumb>\\x22.*?\\x22)]', webpage)
         if not ma is None:
-            for t in ma.group('thumb').replace('\\\\/', '/').split(','):
-                t = t.replace('\\x22','"')
-                if (t[0]=='"') and (t[-1]=='"'):
+            for t in ma.group('thumb').replace(r'\\/', '/').split(','):
+                t = t.replace(r'\x22','"')
+                if (t[0] == '"') and (t[-1] == '"'):
                     thumb_list.append(t[1:-1])
-
-        # take the first, if user only wants one
-        single_thumb = None
-        if len(thumb_list)>0:
-            single_thumb = thumb_list[0]
 
         # The only place where you can get a title, it's not complete,
         # but searching in other places doesn't work for all videos
@@ -57,6 +52,5 @@ class TumblrIE(InfoExtractor):
                  'url': video_url,
                  'title': video_title,
                  'thumbnails': thumb_list,
-                 'thumbnail': single_thumb,
                  'ext': ext
                  }]

--- a/youtube_dl/extractor/tumblr.py
+++ b/youtube_dl/extractor/tumblr.py
@@ -34,11 +34,19 @@ class TumblrIE(InfoExtractor):
         video_url = video.group('video_url')
         ext = video.group('ext')
 
-        video_thumbnail = self._search_regex(
-            r'posters.*?\[\\x22(.*?)\\x22',
-            webpage, 'thumbnail', fatal=False)  # We pick the first poster
-        if video_thumbnail:
-            video_thumbnail = video_thumbnail.replace('\\\\/', '/')
+        # retrieve all available thumbnails
+        thumb_list = []
+        ma = re.search(r'posters.*?\[(?P<thumb>\\x22.*?\\x22)]', webpage)
+        if not ma is None:
+            for t in ma.group('thumb').replace('\\\\/', '/').split(','):
+                t = t.replace('\\x22','"')
+                if (t[0]=='"') and (t[-1]=='"'):
+                    thumb_list.append(t[1:-1])
+
+        # take the first, if user only wants one
+        single_thumb = None
+        if len(thumb_list)>0:
+            single_thumb = thumb_list[0]
 
         # The only place where you can get a title, it's not complete,
         # but searching in other places doesn't work for all videos
@@ -48,6 +56,7 @@ class TumblrIE(InfoExtractor):
         return [{'id': video_id,
                  'url': video_url,
                  'title': video_title,
-                 'thumbnail': video_thumbnail,
+                 'thumbnails': thumb_list,
+                 'thumbnail': single_thumb,
                  'ext': ext
                  }]

--- a/youtube_dl/extractor/tumblr.py
+++ b/youtube_dl/extractor/tumblr.py
@@ -41,7 +41,7 @@ class TumblrIE(InfoExtractor):
             for t in ma.group('thumb').replace(r'\\/', '/').split(','):
                 t = t.replace(r'\x22','"')
                 if (t[0] == '"') and (t[-1] == '"'):
-                    thumb_list.append(t[1:-1])
+                    thumb_list.append( {"url": t[1:-1]} )
 
         # The only place where you can get a title, it's not complete,
         # but searching in other places doesn't work for all videos


### PR DESCRIPTION
The clips on Tumblr pages are usually accompanied by more than one thumbnail. Their URL is stored in an array in  the source code of the page.

This patch decodes this array in its entirety and returns their URL under the *thumbnails* key.
It also returns the first URL under the *thumbnail* key.