### PR TITLE
Write all thumbnails to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ which means you can modify it, redistribute it or use it however you like.
     --write-annotations              write video annotations to a .annotation
                                      file
     --write-thumbnail                write thumbnail image to disk
+    --write-all-thumbnails           write all thumbnail images to disk
 
 ## Verbosity / Simulation Options:
     -q, --quiet                      activates quiet mode

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -118,6 +118,7 @@ class YoutubeDL(object):
     writeinfojson:     Write the video description to a .info.json file
     writeannotations:  Write the video annotations to a .annotations.xml file
     writethumbnail:    Write the thumbnail image to a file
+    writeallthumbnails:Write all thumbnail images to disk
     writesubtitles:    Write the video subtitles to a file
     writeautomaticsub: Write the automatic subtitles to a file
     allsubtitles:      Downloads all the subtitles of the video
@@ -897,10 +898,31 @@ class YoutubeDL(object):
                     self.report_error('Cannot write metadata to JSON file ' + infofn)
                     return
 
-        if self.params.get('writethumbnail', False):
-            if info_dict.get('thumbnail') is not None:
-                thumb_format = determine_ext(info_dict['thumbnail'], 'jpg')
-                thumb_filename = os.path.splitext(filename)[0] + '.' + thumb_format
+        if self.params.get('writethumbnail', False) or self.params.get('writeallthumbnails', False):
+            # create a list of all thumbnails the user has requested (all or only one)
+            allthumbs = []
+            if self.params.get('writeallthumbnails', False) and info_dict.get('thumbnails') is not None:
+                for ele in info_dict.get('thumbnails'):
+                    try:
+                        if ele.get('url'):
+                            allthumbs.append(ele.get('url'))
+                    except AttributeError:
+                        # not all extractor return dicts
+                        allthumbs.append(ele)
+                if info_dict.get('thumbnail') and not info_dict.get('thumbnail') in allthumbs:
+                    allthumbs.insert(0,info_dict.get('thumbnail'))
+
+            allthumblen = len(allthumbs)
+            thumbcnt = 0
+            for thumburl in allthumbs:
+                thumbcnt += 1
+                thumb_format = determine_ext(thumburl, 'jpg')
+                if allthumblen == 1:
+                    thumb_filename = os.path.splitext(filename)[0] + '.' + thumb_format
+                else:
+                    # append '_1', '_2' etc. to filename, if necessary with leading zero(s)
+                    thumb_filename = os.path.splitext(filename)[0] + \
+                           ('_%%0%sd.%%s' % len(str(allthumblen)) % (thumbcnt, thumb_format))
                 if self.params.get('nooverwrites', False) and os.path.exists(encodeFilename(thumb_filename)):
                     self.to_screen('[%s] %s: Thumbnail is already present' %
                                    (info_dict['extractor'], info_dict['id']))
@@ -908,14 +930,14 @@ class YoutubeDL(object):
                     self.to_screen('[%s] %s: Downloading thumbnail ...' %
                                    (info_dict['extractor'], info_dict['id']))
                     try:
-                        uf = compat_urllib_request.urlopen(info_dict['thumbnail'])
+                        uf = compat_urllib_request.urlopen(thumburl)
                         with open(thumb_filename, 'wb') as thumbf:
                             shutil.copyfileobj(uf, thumbf)
                         self.to_screen('[%s] %s: Writing thumbnail to: %s' %
                             (info_dict['extractor'], info_dict['id'], thumb_filename))
                     except (compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:
                         self.report_warning('Unable to download thumbnail "%s": %s' %
-                            (info_dict['thumbnail'], compat_str(err)))
+                            (thumburl, compat_str(err)))
 
         if not self.params.get('skip_download', False):
             if self.params.get('nooverwrites', False) and os.path.exists(encodeFilename(filename)):

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -901,16 +901,13 @@ class YoutubeDL(object):
         if self.params.get('writethumbnail', False) or self.params.get('writeallthumbnails', False):
             # create a list of all thumbnails the user has requested (all or only one)
             allthumbs = []
-            if self.params.get('writeallthumbnails', False) and info_dict.get('thumbnails') is not None:
-                for ele in info_dict.get('thumbnails'):
-                    try:
-                        if ele.get('url'):
-                            allthumbs.append(ele.get('url'))
-                    except AttributeError:
-                        # not all extractor return dicts
-                        allthumbs.append(ele)
-                if info_dict.get('thumbnail') and not info_dict.get('thumbnail') in allthumbs:
+            if info_dict.get('thumbnails') is not None:
+                allthumbs = [ ele.get('url') for ele in info_dict.get('thumbnails')]
+            if info_dict.get('thumbnail') is not None:
+                if self.params.get('writethumbnail', False) or (not info_dict.get('thumbnail') in allthumbs):
                     allthumbs.insert(0,info_dict.get('thumbnail'))
+            if self.params.get('writethumbnail', False):
+                allthumbs = allthumbs[0:1]
 
             allthumblen = len(allthumbs)
             thumbcnt = 0

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -416,7 +416,9 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option('--write-thumbnail',
             action='store_true', dest='writethumbnail',
             help='write thumbnail image to disk', default=False)
-
+    filesystem.add_option('--write-all-thumbnails',
+            action='store_true', dest='writeallthumbnails',
+            help='write all thumbnail images to disk', default=False)
 
     postproc.add_option('-x', '--extract-audio', action='store_true', dest='extractaudio', default=False,
             help='convert video files to audio-only files (requires ffmpeg or avconv and ffprobe or avprobe)')
@@ -702,6 +704,7 @@ def _real_main(argv=None):
         'writeannotations': opts.writeannotations,
         'writeinfojson': opts.writeinfojson,
         'writethumbnail': opts.writethumbnail,
+        'writeallthumbnails': opts.writeallthumbnails,
         'writesubtitles': opts.writesubtitles,
         'writeautomaticsub': opts.writeautomaticsub,
         'allsubtitles': opts.allsubtitles,


### PR DESCRIPTION
Many extractors return a thumbnail in `thumbnail` or a list of them in `thumbnails` (in form of a list of dicts each with an `url` key).

The proposed change uses both sources to write one or all of them to disk, depending how many the user has asked for: one with `--write-thumbnail` or all with the new `--write-all-thumbnails`.

If the user only requests one, the content of `thumbnail` is returned, or if not present, the first entry from the list.

If the user requests all, the content of `thumbnail` (if present) is prepended to the list, if it is not already in there.

If only one file is to be written, the normal naming schema is used.
If more than one files are being wirtten, a counter is appended to the file name (e.g. _1, _2 or _01, _02, depending on the number of files in the list).

The download part is the same as before, it only now iterates over the array.

I hope I found all place in `youtube-dl` where additional command line parameters have to be documented.