### PR TITLE
[bliptv] Filter out SRT files

### DIFF
--- a/youtube_dl/extractor/bliptv.py
+++ b/youtube_dl/extractor/bliptv.py
@@ -78,8 +78,8 @@ class BlipTVIE(InfoExtractor):
             upload_date = datetime.datetime.strptime(data['datestamp'], '%m-%d-%y %H:%M%p').strftime('%Y%m%d')
             formats = []
             if 'additionalMedia' in data:
-                for f in sorted(data['additionalMedia'], key=lambda f: int(f['media_height'])):
-                    if not int(f['media_width']): # filter m3u8
+                for f in sorted(data['additionalMedia'], key=lambda f: int(0 if f['media_height'] is None else f['media_height'])):
+                    if not int(0 if f['media_height'] is None else f['media_height']): # filter out m3u8 and srt files
                         continue
                     formats.append({
                         'url': f['url'],


### PR DESCRIPTION
The bliptv plugins currently fails for videos which have subtitles.
e.g. http://blip.tv/play/h6Uag5OEVgI.html fails with the following traceback:

```
Traceback (most recent call last):
  File "/usr/bin/youtube-dl", line 6, in <module>
    youtube_dl.main()
  File "/usr/lib64/python2.7/site-packages/youtube_dl/__init__.py", line 783, in main
    _real_main(argv)
  File "/usr/lib64/python2.7/site-packages/youtube_dl/__init__.py", line 773, in _real_main
    retcode = ydl.download(all_urls)
  File "/usr/lib64/python2.7/site-packages/youtube_dl/YoutubeDL.py", line 982, in download
    self.extract_info(url)
  File "/usr/lib64/python2.7/site-packages/youtube_dl/YoutubeDL.py", line 510, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/usr/lib64/python2.7/site-packages/youtube_dl/YoutubeDL.py", line 546, in process_ie_result
    extra_info=extra_info)
  File "/usr/lib64/python2.7/site-packages/youtube_dl/YoutubeDL.py", line 493, in extract_info
    ie_result = ie.extract(url)
  File "/usr/lib64/python2.7/site-packages/youtube_dl/extractor/common.py", line 158, in extract
    return self._real_extract(url)
  File "/usr/lib64/python2.7/site-packages/youtube_dl/extractor/bliptv.py", line 84, in _real_extract
    if not int(f['media_width']):  # filter m3u8
TypeError: int() argument must be a string or a number, not 'NoneType'
```
