### PR TITLE
Extended valid urls schema

### DIFF
--- a/youtube_dl/extractor/tube8.py
+++ b/youtube_dl/extractor/tube8.py
@@ -11,7 +11,7 @@ from ..aes import (
 )
 
 class Tube8IE(InfoExtractor):
-    _VALID_URL = r'^(?:https?://)?(?:www\.)?(?P<url>tube8\.com/[^/]+/[^/]+/(?P<videoid>[0-9]+)/?)'
+    _VALID_URL = r'^(?:https?://)?(?:www\.)?(?P<url>tube8\.com/.+?/(?P<videoid>\d+)/?)$'
     _TEST = {
         u'url': u'http://www.tube8.com/teen/kasia-music-video/229795/',
         u'file': u'229795.mp4',


### PR DESCRIPTION
The original regex matches against URLs like this: `http://www.tube8.com/aaa/bbb/#####/`and a few variations of this.

However. I also found URLs like this one `http://www.tube8.com/aaa/bbb/ccc/#####/`.

The updated regex matches both.
