### PR TITLE
Report correct percentage when download is finished

### DIFF
--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -244,14 +244,18 @@ class FileDownloader(object):
         msg = u'%s at %s (%s)' % (downloaded_str, speed_str, elapsed_str)
         self._report_progress_status(msg)
 
-    def report_finish(self, data_len_str, tot_time):
+    def report_finish(self, percent, data_len_str, tot_time):
         """Report download finished."""
         if self.params.get('noprogress', False):
             self.to_screen(u'[download] Download completed')
         else:
+            if percent is not None:
+                percent_str = self.format_percent(percent)
+            else:
+                percent_str = 'Unknown %'
             self._report_progress_status(
-                (u'100%% of %s in %s' %
-                 (data_len_str, self.format_seconds(tot_time))),
+                (u'%s of %s in %s' %
+                 (percent_str, data_len_str, self.format_seconds(tot_time))),
                 is_last_line=True)
 
     def report_resuming_byte(self, resume_len):

--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -298,7 +298,7 @@ class F4mFD(FileDownloader):
                         break
             frags_filenames.append(frag_filename)
 
-        self.report_finish(format_bytes(state['downloaded_bytes']), time.time() - start)
+        self.report_finish(100, format_bytes(state['downloaded_bytes']), time.time() - start)
 
         self.try_rename(tmpfilename, filename)
         for frag_file in frags_filenames:

--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -167,7 +167,11 @@ class HttpFD(FileDownloader):
             self.report_error(u'Did not get any data blocks')
             return False
         stream.close()
-        self.report_finish(data_len_str, (time.time() - start))
+        if data_len is None:
+            percent = None
+        else:
+            percent = self.calc_percent(byte_counter, data_len)
+        self.report_finish(percent, data_len_str, (time.time() - start))
         if data_len is not None and byte_counter != data_len:
             raise ContentTooShortError(byte_counter, int(data_len))
         self.try_rename(tmpfilename, filename)


### PR DESCRIPTION
Currently youtube-dl is always printing "[download] 100% of ... in ..." when a download is finished, even if the file is downloaded only partially. (ContentTooShortError)
