### PR TITLE
Floor instead of round in format_percent

### DIFF
--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -70,7 +70,7 @@ class FileDownloader(object):
     def format_percent(percent):
         if percent is None:
             return '---.-%'
-        return '%6s' % ('%3.1f%%' % percent)
+        return '%3s.%.1s%%' % tuple(str(float(percent)).split('.'))
 
     @staticmethod
     def calc_eta(start, now, total, current):


### PR DESCRIPTION
Only return '100.0%' if the download is really complete.
