### PR TITLE
[generic] Unescape webpage contents

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -145,6 +145,17 @@ class GenericIE(InfoExtractor):
                 'description': 'Episode 18: President Barack Obama sits down with Zach Galifianakis for his most memorable interview yet.',
             }
         },
+        # nowvideo embed hidden behind percent encoding
+        {
+            'url': 'http://www.waoanime.tv/the-super-dimension-fortress-macross-episode-1/',
+            'md5': '2baf4ddd70f697d94b1c18cf796d5107',
+            'info_dict': {
+                'id': '06e53103ca9aa',
+                'ext': 'flv',
+                'title': 'Macross Episode 001  Watch Macross Episode 001 onl',
+                'description': 'No description',
+            },
+        }
     ]
 
     def report_download_webpage(self, video_id):


### PR DESCRIPTION
This would allow handling generic webpages that hide embedded video iframe behind percent encoding (e.g. #2448).

```
document.write(unescape("%3c%69%66%72%61%6d%65%20%73%74%79%6c%65%3d%22%6f%76%65%72%66%6c%6f%77%3a%20%68%69%64%64%65%6e%3b%20%62%6f%72%64%65%72%3a%20%30%3b%20%77%69%64%74%68%3a%20%37%35%30%70%78%3b%20%68%65%69%67%68%74%3a%20%34%31%30%70%78%22%20%73%72%63%3d%22%68%74%74%70%3a%2f%2f%65%6d%62%65%64%2e%6e%6f%76%61%6d%6f%76%2e%63%6f%6d%2f%65%6d%62%65%64%2e%70%68%70%3f%77%69%64%74%68%3d%37%35%30%26%68%65%69%67%68%74%3d%34%31%30%26%76%3d%65%30%35%66%70%6c%70%63%74%7a%39%70%6b%26%70%78%3d%31%22%20%73%63%72%6f%6c%6c%69%6e%67%3d%22%6e%6f%22%3e%3c%2f%69%66%72%61%6d%65%3e"));
```

```
<iframe style="overflow: hidden; border: 0; width: 750px; height: 410px" src="http://embed.novamov.com/embed.php?width=750&height=410&v=e05fplpctz9pk&px=1" scrolling="no"></iframe>
```

Alternatively, we can do second pass using unescaped webpage after first (non-unescaped webpage) found nothing.
Not sure if this breaks something.
