### PR TITLE
Set resume_len to 0 if download is restarted

### DIFF
--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -85,6 +85,7 @@ class HttpFD(FileDownloader):
                         else:
                             # The length does not match, we start the download over
                             self.report_unable_to_resume()
+                            resume_len = 0
                             open_mode = 'wb'
                             break
             # Retry


### PR DESCRIPTION
If a download can't be resumed and is restarted, the download status messages are wrong because `resume_len` of the old overwritten file is added to `data_len` and `byte_counter`.

E.g.:

```
$ youtube-dl ...
[download]  10.1% of 54.55MiB at 99.34KiB/s ETA 08:25
ERROR: Interrupted by user

$ youtube-dl ...
[download] Unable to resume
[download]   8.7% of 58.98MiB at 60.64KiB/s ETA 15:09
```
