### PR TITLE
[XHamsterIE] Make hd video search more robust

### DIFF
--- a/youtube_dl/extractor/xhamster.py
+++ b/youtube_dl/extractor/xhamster.py
@@ -103,6 +103,7 @@ class XHamsterIE(InfoExtractor):
         }]
 
         if not hd:
+            mrss_url = self._search_regex(r'<link rel="canonical" href="([^"]+)', webpage, 'mrss_url')
             webpage = self._download_webpage(mrss_url + '?hd', video_id, note='Downloading HD webpage')
             if is_hd(webpage):
                 video_url = extract_video_url(webpage)


### PR DESCRIPTION
Currently HD video extraction fails for URLs with altered SEO part.
E.g.: http://xhamster.com/movies/2221348/seo.html
