### PR TITLE
Build and upload universal wheels to pypi

### DIFF
--- a/devscripts/release.sh
+++ b/devscripts/release.sh
@@ -97,7 +97,7 @@ rm -rf build
 
 make pypi-files
 echo "Uploading to PyPi ..."
-python setup.py sdist upload
+python setup.py sdist bdist_wheel upload
 make clean
 
 /bin/echo -e "\n### DONE!"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = True


### PR DESCRIPTION
@phihag  It requires the `wheel` and the `setuptools` packages.
