### PR TITLE
Add ability to explicitly set Referer header for downloading final video url

### DIFF
--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -23,8 +23,8 @@ class HttpFD(FileDownloader):
         headers = {'Youtubedl-no-compression': 'True'}
         if 'user_agent' in info_dict:
             headers['Youtubedl-user-agent'] = info_dict['user_agent']
-        if 'referer' in info_dict:
-            headers['Referer'] = info_dict['referer']
+        if 'http_referer' in info_dict:
+            headers['Referer'] = info_dict['http_referer']
         basic_request = compat_urllib_request.Request(url, None, headers)
         request = compat_urllib_request.Request(url, None, headers)
 

--- a/youtube_dl/extractor/auengine.py
+++ b/youtube_dl/extractor/auengine.py
@@ -51,5 +51,5 @@ class AUEngineIE(InfoExtractor):
             'url': video_url,
             'title': title,
             'thumbnail': thumbnail,
-            'referer': 'http://www.auengine.com/flowplayer/flowplayer.commercial-3.2.14.swf',
+            'http_referer': 'http://www.auengine.com/flowplayer/flowplayer.commercial-3.2.14.swf',
         }


### PR DESCRIPTION
AUEngine requires Referer header to be set for final download link, it fails otherwise with 403.
