### PR TITLE
Support TeamCoco URLs with video_id in the title

### DIFF
--- a/youtube_dl/extractor/teamcoco.py
+++ b/youtube_dl/extractor/teamcoco.py
@@ -9,7 +9,7 @@ from ..utils import (
 
 
 class TeamcocoIE(InfoExtractor):
-    _VALID_URL = r'http://teamcoco\.com/video/([^/]*)?/?(.*)'
+    _VALID_URL = r'http://teamcoco\.com/video/(?P<video_id>\d*)?/?(?P<url_title>.*)'
     _TESTS = [
     {
         'url': 'http://teamcoco.com/video/80187/conan-becomes-a-mary-kay-beauty-consultant',
@@ -35,13 +35,11 @@ class TeamcocoIE(InfoExtractor):
         mobj = re.match(self._VALID_URL, url)
         if mobj is None:
             raise ExtractorError('Invalid URL: %s' % url)
-        url_title = mobj.group(2)
-        if url_title == '':
-            url_title = mobj.group(1)
+        url_title = mobj.group('url_title')
         webpage = self._download_webpage(url, url_title)
         
-        video_id = mobj.group(1)
-        if mobj.group(2) == '':
+        video_id = mobj.group("video_id")
+        if video_id == '':
             video_id = self._html_search_regex(
                 r'<article class="video" data-id="(\d+?)"',
                 webpage, 'video id')


### PR DESCRIPTION
If the URL has the video_id in it, use that since the current method of
finding the id breaks on those pages.

Fixes #2698.
