### PR TITLE
Also default to --title when --auto-number is used

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -696,10 +696,10 @@ def _real_main(argv=None):
     outtmpl =((opts.outtmpl is not None and opts.outtmpl)
             or (opts.format == '-1' and opts.usetitle and u'%(title)s-%(id)s-%(format)s.%(ext)s')
             or (opts.format == '-1' and u'%(id)s-%(format)s.%(ext)s')
-            or (opts.usetitle and opts.autonumber and u'%(autonumber)s-%(title)s-%(id)s.%(ext)s')
+            or (opts.autonumber and opts.useid and u'%(autonumber)s-%(id)s.%(ext)s')
+            or (opts.autonumber and u'%(autonumber)s-%(title)s-%(id)s.%(ext)s')
             or (opts.usetitle and u'%(title)s-%(id)s.%(ext)s')
             or (opts.useid and u'%(id)s.%(ext)s')
-            or (opts.autonumber and u'%(autonumber)s-%(id)s.%(ext)s')
             or u'%(title)s-%(id)s.%(ext)s')
     if not os.path.splitext(outtmpl)[1] and opts.extractaudio:
         parser.error(u'Cannot download a video and extract audio into the same'


### PR DESCRIPTION
--title has been the default option since 08b2ac74 (see #499), but when the
--auto-number option was specified the filename would by default still be based
on the ID, not the title. This commit changes it so that the title is always
used as default.

To emulate the old behaviour use the option --id together with --auto-number.
