### PR TITLE
Properly handle missing video_id (round 2)

### DIFF
--- a/youtube_dl/extractor/teamcoco.py
+++ b/youtube_dl/extractor/teamcoco.py
@@ -39,7 +39,7 @@ class TeamcocoIE(InfoExtractor):
         webpage = self._download_webpage(url, url_title)
         
         video_id = mobj.group("video_id")
-        if video_id == '':
+        if video_id == '' or video_id == None:
             video_id = self._html_search_regex(
                 r'<article class="video" data-id="(\d+?)"',
                 webpage, 'video id')


### PR DESCRIPTION
This is what happens when you don't read the docs, kids.

Fixes #2715 (I think).
