### PR TITLE
Extended regex match to include gay clips

### DIFF
--- a/youtube_dl/extractor/extremetube.py
+++ b/youtube_dl/extractor/extremetube.py
@@ -9,7 +9,7 @@ from ..utils import (
 )
 
 class ExtremeTubeIE(InfoExtractor):
-    _VALID_URL = r'^(?:https?://)?(?:www\.)?(?P<url>extremetube\.com/video/.+?(?P<videoid>[0-9]+))(?:[/?&]|$)'
+    _VALID_URL = r'^(?:https?://)?(?:www\.)?(?P<url>extremetube\.com/.*?video/.+?(?P<videoid>[0-9]+))(?:[/?&]|$)'
     _TEST = {
         u'url': u'http://www.extremetube.com/video/music-video-14-british-euro-brit-european-cumshots-swallow-652431',
         u'file': u'652431.mp4',


### PR DESCRIPTION
The "normal" url pattern at this site is:
http://www.extremetube.com/video/abcde-1234

For gay clips it is: 
http://www.extremetube.com/gay/video/abcde-1234

I've changed the _VALID_URL pattern to match both
