### PR TITLE
[dailymotion] Add support for URLs starting with //

### DIFF
--- a/youtube_dl/extractor/dailymotion.py
+++ b/youtube_dl/extractor/dailymotion.py
@@ -27,7 +27,7 @@ class DailymotionBaseInfoExtractor(InfoExtractor):
 class DailymotionIE(DailymotionBaseInfoExtractor, SubtitlesInfoExtractor):
     """Information Extractor for Dailymotion"""
 
-    _VALID_URL = r'(?i)(?:https?://)?(?:(www|touch)\.)?dailymotion\.[a-z]{2,3}/(?:(embed|#)/)?video/(?P<id>[^/?_]+)'
+    _VALID_URL = r'(?i)(?:(?:https?:)?//)?(?:(www|touch)\.)?dailymotion\.[a-z]{2,3}/(?:(embed|#)/)?video/(?P<id>[^/?_]+)'
     IE_NAME = u'dailymotion'
 
     _FORMATS = [


### PR DESCRIPTION
This will happen if a site embeds dailymotion like this:
    <iframe src="//www.dailymotion.com/embed/ [...]
in order to be compatible with both http and https and prevent mixed
content blocking.

It will be detected by the generic extractor, but then fail to be
accepted by the information extractor.

This protocol matching should probably be extended to other extractors
(although vimeo and youtube extractors already do this)
