### PR TITLE
Fix issue #2932: Photobucket download url is incorrect

### DIFF
--- a/youtube_dl/extractor/photobucket.py
+++ b/youtube_dl/extractor/photobucket.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
 
-import datetime
 import json
 import re
 
 from .common import InfoExtractor
+from utils import compat_urllib_parse
 
 
 class PhotobucketIE(InfoExtractor):
@@ -14,6 +14,7 @@ class PhotobucketIE(InfoExtractor):
         'file': 'zpsc0c3b9fa.mp4',
         'md5': '7dabfb92b0a31f6c16cebc0f8e60ff99',
         'info_dict': {
+            'timestamp': 1367669341,
             'upload_date': '20130504',
             'uploader': 'rachaneronas',
             'title': 'Tired of Link Building? Try BacklinkMyDomain.com!',
@@ -32,11 +33,12 @@ class PhotobucketIE(InfoExtractor):
         info_json = self._search_regex(r'Pb\.Data\.Shared\.put\(Pb\.Data\.Shared\.MEDIA, (.*?)\);',
             webpage, 'info json')
         info = json.loads(info_json)
+        url = compat_urllib_parse.unquote(self._html_search_regex('file=(.+\.mp4)', info['linkcodes']['html'], 'url'))
         return {
             'id': video_id,
-            'url': info['downloadUrl'],
+            'url': url,
             'uploader': info['username'],
-            'upload_date': datetime.date.fromtimestamp(info['creationDate']).strftime('%Y%m%d'),
+            'timestamp': info['creationDate'],
             'title': info['title'],
             'ext': video_extension,
             'thumbnail': info['thumbUrl'],


### PR DESCRIPTION
Now, the correct URL is extracted from the page, resulting in a passing test and a working download.
