### PR TITLE
Fix a quality bug on sohu.com

### DIFF
--- a/youtube_dl/extractor/sohu.py
+++ b/youtube_dl/extractor/sohu.py
@@ -54,7 +54,7 @@ class SohuIE(InfoExtractor):
             raise ExtractorError(u'No formats available for this video')
 
         # For now, we just pick the highest available quality
-        vid_id = vid_ids[-1]
+        vid_id = vid_ids[0]
 
         format_data = data if vid == vid_id else _fetch_data(vid_id, mytv)
         part_count = format_data['data']['totalBlocks']


### PR DESCRIPTION
By default it was intended to download the highest quality videos, but I guess someone had made a typo on `extractor/sohu.py` , and as a result the videos downloaded were actually the lowest quality.  
I've just fixed the typo, see the diff stats.

BTW, the travis test always fails.
