### PR TITLE
title extraction condition less restrictive

### DIFF
--- a/youtube_dl/extractor/extremetube.py
+++ b/youtube_dl/extractor/extremetube.py
@@ -37,7 +37,7 @@ class ExtremeTubeIE(InfoExtractor):
         webpage = self._download_webpage(req, video_id)
 
         video_title = self._html_search_regex(
-            r'<h1 [^>]*?title="([^"]+)"[^>]*>\1<', webpage, 'title')
+            r'<h1 [^>]*?title="([^"]+)"[^>]*>', webpage, 'title')
         uploader = self._html_search_regex(
             r'>Posted by:(?=<)(?:\s|<[^>]*>)*(.+?)\|', webpage, 'uploader',
             fatal=False)


### PR DESCRIPTION
The title of the clip is currently found in the first h1 tag with an title attribute. The attribute contains the title of the clip, and usualy this title repeated verbatim after the h1 tag.

This works most of the times, but not always.

If the "clear text" title contains trailing dots, the text within the title attribute does not, and the regex fails.

This patch removes the condition that the text has to be repeated after the h1 tag.

The h1 tag, which contains the title information is still the only one with a title parameter.

[Example](http://www.extremetube.com/gay/video/thug-getting-his-massive-dick-sucked-long-and-hard-gaypridevault-40025)
