### PR TITLE
New videos from gamekings.tv use video as video_url

### DIFF
--- a/youtube_dl/extractor/gamekings.py
+++ b/youtube_dl/extractor/gamekings.py
@@ -25,12 +25,16 @@ class GamekingsIE(InfoExtractor):
         name = mobj.group('name')
         webpage = self._download_webpage(url, name)
         video_url = self._og_search_video_url(webpage)
+        if 'vimeo' in video_url:
+            video = re.search(r'[0-9]+', video_url)
+            video_id = video.group(0)
+            video_url = video_url.replace('http://stream.gamekings.tv/','')
+        else:
+            video = re.search(r'[0-9]+', video_url)
+            video_id = video.group(0)
 
-        video = re.search(r'[0-9]+', video_url)
-        video_id = video.group(0)
-
-        # Todo: add medium format
-        video_url = video_url.replace(video_id, 'large/' + video_id)
+            # Todo: add medium format
+            video_url = video_url.replace(video_id, 'large/' + video_id)
 
         return {
             'id': video_id,


### PR DESCRIPTION
New videos for example http://www.gamekings.tv/videos/preview-e3-2014-assassins-creed-unity/ use vimeo as video source, as you can see in the url below. 
<meta property="og:video" content="http://stream.gamekings.tv/http://player.vimeo.com/external/96811741.hd.mp4?s=15873e94dec81a5d95e61607bb81db3e"/>
