### PR TITLE
Fix spiegel.de video

### DIFF
--- a/youtube_dl/extractor/spiegel.py
+++ b/youtube_dl/extractor/spiegel.py
@@ -47,7 +47,7 @@ class SpiegelIE(InfoExtractor):
         formats = [
             {
                 'format_id': n.tag.rpartition('type')[2],
-                'url': 'http://video2.spiegel.de/flash/' + n.find('./filename').text,
+                'url': base_url + n.find('./filename').text,
                 'width': int(n.find('./width').text),
                 'height': int(n.find('./height').text),
                 'abr': int(n.find('./audiobitrate').text),


### PR DESCRIPTION
spiegel.de/video didn't work anymore:

```
elias@moria ~ % youtube-dl -g http://www.spiegel.de/video/johann-westhauser-videobotschaft-des-hoehlenforschers-video-1502367.html
ERROR: Failed to download XML: HTTP Error 404: Not Found; please report this issue on https://yt-dl.org/bug . Be sure to call youtube-dl with the --verbose flag and include its complete output. Make sure you are using the latest version; type  youtube-dl -U  to update.
```

This PR fixes it:

```
elias@moria ~ % youtube-dl -g http://www.spiegel.de/video/johann-westhauser-videobotschaft-des-hoehlenforschers-video-1502367.html
http://video2.spiegel.de/flash/1502367_1024x576_H264_HQ.mp4
```

Not sure about the test cases, as/if they might need to be adapted as well.
