### PR TITLE
Add option to only display suitable detectors when passing a URL.

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -249,6 +249,9 @@ def parseOpts(overrideArguments=None):
     general.add_option('--list-extractors',
             action='store_true', dest='list_extractors',
             help='List all supported extractors and the URLs they would handle', default=False)
+    general.add_option('--only-suitable',
+            action='store_true', dest='only_suitable',
+            help='Only list suitable extractors', default=False)
     general.add_option('--extractor-descriptions',
             action='store_true', dest='list_extractor_descriptions',
             help='Output descriptions of all supported extractors', default=False)
@@ -620,10 +623,13 @@ def _real_main(argv=None):
 
     if opts.list_extractors:
         for ie in sorted(extractors, key=lambda ie: ie.IE_NAME.lower()):
-            compat_print(ie.IE_NAME + (' (CURRENTLY BROKEN)' if not ie._WORKING else ''))
             matchedUrls = [url for url in all_urls if ie.suitable(url)]
-            for mu in matchedUrls:
-                compat_print(u'  ' + mu)
+            if opts.only_suitable and not matchedUrls:
+                continue
+            compat_print(ie.IE_NAME + (' (CURRENTLY BROKEN)' if not ie._WORKING else ''))
+            if not opts.only_suitable:
+                for mu in matchedUrls:
+                    compat_print(u'  ' + mu)
         sys.exit(0)
     if opts.list_extractor_descriptions:
         for ie in sorted(extractors, key=lambda ie: ie.IE_NAME.lower()):


### PR DESCRIPTION
Hi,

It would be nice to be able to only display suitable extractors when calling `--list-extractors` as that helps determining whether `youtube-dl` should be used to download a given `URL` or not..

This PR adds an options for that.
