### PR TITLE
[youtube] Use a static algorithm for the age gate videos' signatures (fixes #3270)

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -865,6 +865,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
     def _decrypt_signature(self, s, video_id, player_url, age_gate=False):
         """Turn the encrypted s field into a working signature"""
 
+        if age_gate:
+            return self._static_decrypt_age_gate_signature(s)
+
         if player_url is None:
             raise ExtractorError(u'Cannot decrypt signature without player_url')
 
@@ -885,6 +888,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
             tb = traceback.format_exc()
             raise ExtractorError(
                 u'Automatic signature extraction failed: ' + tb, cause=e)
+
+    def _static_decrypt_age_gate_signature(self, s):
+        if len(s) == 86:
+            return s[2:63] + s[82] + s[64:82] + s[63]
+        else:
+            raise ExtractorError(u'Unable to decrypt signature, key length %d not supported; retrying might work' % (len(s)))
 
     def _get_available_subtitles(self, video_id, webpage):
         try:


### PR DESCRIPTION
I haven't managed to get the swf parser to work with the current swf player: http://s.ytimg.com/yts/swfbin/player-vflq0-BLs/watch_as3.swf (from http://www.youtube.com/watch?v=BaW_jenozKc), I always get an `unsupported opcode` message. Since the algorithm hasn't changed in a long time, I think it is reasonable to continue using it.

Pinging @phihag.
