### PR TITLE
if there is more than one subtitle for the language, use the first one

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -493,6 +493,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
         sub_lang_list = {}
         for l in lang_list:
             lang = l[1]
+            if lang in sub_lang_list:
+                continue
             params = compat_urllib_parse.urlencode({
                 'lang': lang,
                 'v': video_id,


### PR DESCRIPTION
When there is more than one subtitle for the language, use the first one.

Currently, when I'm watching the google io, i found that the subtitle is not right, but it's ok in the youtube. After some debug, I found that some language has more than one subtitle, youtube use the first one, but the `youtube-dl` use the last one.

This patch use the first subtitle for the language. However, it may be a better idea to add the `name` to the subtitle.

For Google IO 2014's Keynote, https://www.youtube.com/watch?v=wtLJPvx7-ys, there are two subtitles for english, `<no name>` and `cc1`. As the youtube use the first subtitle for english, so it's ok, but the `youtube-dl` use the second one, so it's wrong.
