### PR TITLE
Check load_more_widget_html for feed paging

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1325,6 +1325,7 @@ class YoutubeFeedsInfoExtractor(YoutubeBaseInfoExtractor):
                                           u'%s feed' % self._FEED_NAME,
                                           u'Downloading page %s' % i)
             feed_html = info.get('feed_html') or info.get('content_html')
+            load_more_widget_html = info.get('load_more_widget_html') or feed_html
             m_ids = re.finditer(r'"/watch\?v=(.*?)["&]', feed_html)
             ids = orderedSet(m.group(1) for m in m_ids)
             feed_entries.extend(
@@ -1332,7 +1333,7 @@ class YoutubeFeedsInfoExtractor(YoutubeBaseInfoExtractor):
                 for video_id in ids)
             mobj = re.search(
                 r'data-uix-load-more-href="/?[^"]+paging=(?P<paging>\d+)',
-                feed_html)
+                load_more_widget_html)
             if mobj is None:
                 break
             paging = mobj.group('paging')


### PR DESCRIPTION
I believe the fix for Youtube feeds introduced in f6177462dbba73f80df52a72c666ca769bea173f (closing: #2671) caused an issue with pagination for some(all new-style?) feeds.

Bug found while trying to download my watch later playlist, the playlist has ~150 entries, but only the first page of 100 videos was being downloaded.

The new feeds appear to have the old feed_html split into 2 parts, 'content_html' and 'load_more_widget_html'. 'content_html' was fixed in f6177462dbba73f80df52a72c666ca769bea173f, but the 'load_more_widget_html' is not being used for finding the pagination data.
