### PR TITLE
[fm4] Add new extractor

### DIFF
--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -96,6 +96,7 @@ from .fktv import (
     FKTVPosteckeIE,
 )
 from .flickr import FlickrIE
+from .fm4 import FM4IE
 from .fourtube import FourTubeIE
 from .franceculture import FranceCultureIE
 from .franceinter import FranceInterIE

--- a/youtube_dl/extractor/fm4.py
+++ b/youtube_dl/extractor/fm4.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import calendar
+import datetime
+import re
+
+from .common import InfoExtractor
+
+# audios on fm4.orf.at are only available for 7 days, so we can't
+# add tests.
+
+
+class FM4IE(InfoExtractor):
+    IE_DESC = 'fm4.orf.at'
+    _VALID_URL = r'http://fm4\.orf\.at/7tage#(?P<date>[0-9]+)/(?P<show>[\w]+)'
+
+    def _extract_entry_dict(self, info, title, subtitle):
+        result = {
+            'id': info['loopStreamId'].replace('.mp3', ''),
+            'url': 'http://loopstream01.apa.at/?channel=fm4&id=%s' % info['loopStreamId'],
+            'title': title,
+            'description': subtitle,
+            'duration': (info['end'] - info['start']) / 1000,
+            'timestamp': info['start'] / 1000,
+            'ext': 'mp3'
+        }
+
+        return result
+
+    def _real_extract(self, url):
+        mobj = re.match(self._VALID_URL, url)
+        show_date = mobj.group('date')
+        show_id = mobj.group('show')
+
+        data = self._download_json(
+            'http://audioapi.orf.at/fm4/json/2.0/broadcasts/%s/4%s' % (show_date, show_id),
+            show_id
+        )
+
+        entries = [ self._extract_entry_dict(t, data['title'], data['subtitle']) for t in data['streams']]
+
+        return {
+            '_type': 'playlist',
+            'id': show_id,
+            'title': data['title'],
+            'description': data['subtitle'],
+            'entries': entries
+        }


### PR DESCRIPTION
Add extractor for http://fm4.orf.at/7tage 
There are no test because the audio files are only available for 7 days.

Example links:
http://fm4.orf.at/7tage#20140730/HOP
http://fm4.orf.at/7tage#20140802/CH

Based on the oe1 extractor form phaer@f0da3f1
