### PR TITLE
Add format mixing info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,9 @@ which means you can modify it, redistribute it or use it however you like.
                                      mp4 , -f m4a and  -f flv  are also
                                      supported. You can also use the special
                                      names "best", "bestvideo", "bestaudio",
-                                     "worst", "worstvideo" and "worstaudio". By
-                                     default, youtube-dl will pick the best
+                                     "worst", "worstvideo" and "worstaudio".
+                                     Use a plus sign to mix formats: -f 22+140
+                                     By default, youtube-dl will pick the best
                                      quality. Use commas to download multiple
                                      audio formats, such as  -f
                                      136/137/mp4/bestvideo,140/m4a/bestaudio

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -125,7 +125,6 @@ from .postprocessor import (
     ExecAfterDownloadPP,
 )
 
-
 def _real_main(argv=None):
     # Compatibility fixes for Windows
     if sys.platform == 'win32':


### PR DESCRIPTION
The help was missing info on how to mix formats.

Before, I had to search around to find out how to do this, but it should be in the `--help`.
