### PR TITLE
[wistia] Use API and make more generic

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -382,6 +382,19 @@ class GenericIE(InfoExtractor):
                 'thumbnail': 're:^https?://.*\.jpg$',
             },
         },
+        # Wistia embed
+        {
+            'url': 'http://education-portal.com/academy/lesson/north-american-exploration-failed-colonies-of-spain-france-england.html#lesson',
+            'md5': '8788b683c777a5cf25621eaf286d0c23',
+            'info_dict': {
+                'id': '1cfaf6b7ea',
+                'ext': 'mov',
+                'title': 'md5:51364a8d3d009997ba99656004b5e20d',
+                'duration': 643.0,
+                'filesize': 182808282,
+                'uploader': 'education-portal.com',
+            },
+        },
     ]
 
     def report_download_webpage(self, video_id):
@@ -653,6 +666,16 @@ class GenericIE(InfoExtractor):
                 'uploader': video_uploader,
                 'title': video_title,
                 'id': video_id,
+            }
+        match = re.search(r'(?:id=["\']wistia_|data-wistiaid=["\']|Wistia\.embed\(["\'])(?P<id>[^"\']+)', webpage)
+        if match:
+            return {
+                '_type': 'url_transparent',
+                'url': 'http://fast.wistia.net/embed/iframe/{0:}'.format(match.group('id')),
+                'ie_key': 'Wistia',
+                'uploader': video_uploader,
+                'title': video_title,
+                'id': match.group('id')
             }
 
         # Look for embedded blip.tv player


### PR DESCRIPTION
Hi,
this changes the wistia extractor to use wistia JSON API instead of searching for metadata in the embedded javascript. Doing that allows us to make it more generic, as only the video ID is required. Also touches issues: #3314, #1765 and #3791.

Improvements and suggestions are very welcome.
