### PR TITLE
KeyError on initialising YoutubeDL in python3 #3910

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -228,7 +228,7 @@ class YoutubeDL(object):
 
         if (sys.version_info >= (3,) and sys.platform != 'win32' and
                 sys.getfilesystemencoding() in ['ascii', 'ANSI_X3.4-1968']
-                and not params['restrictfilenames']):
+                and not params.get('restrictfilenames', False)):
             # On Python 3, the Unicode filesystem API will throw errors (#1474)
             self.report_warning(
                 'Assuming --restrict-filenames since file system encoding '


### PR DESCRIPTION
Proposed fix to Issue #3910. Also fixed a small typo in the warning message.

Here is the output when the patch is applied:

``` bash
ubuntu@localhost:~$ LC_ALL=ascii python3
Python 3.4.0 (default, Apr 11 2014, 13:05:11) 
[GCC 4.8.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from youtube_dl import YoutubeDL
>>> import sys
>>> sys.getfilesystemencoding()
'ascii'
>>> yt = YoutubeDL()
WARNING: Assuming --restrict-filenames since file system encoding cannot encode all charactes. Set the LC_ALL environment variable to fix this.
>>> 
```
