### PR TITLE
[ard] Add rss support

### DIFF
--- a/youtube_dl/extractor/ard.py
+++ b/youtube_dl/extractor/ard.py
@@ -56,7 +56,7 @@ class ARDMediathekIE(InfoExtractor):
         if '>Der gewünschte Beitrag ist nicht mehr verfügbar.<' in webpage:
             raise ExtractorError('Video %s is no longer available' % video_id, expected=True)
 
-        if re.search(r'rss=true', url):
+        if re.search(r'[\?&]rss($|[=&])', url):
             doc = parse_xml(webpage)
             if doc.tag == 'rss':
                 return GenericIE()._extract_rss(url, video_id, doc)


### PR DESCRIPTION
Basically the problem is _VALID_URL of ARDMediathekIE also matches on rss feeds such as `http://mediathek.daserste.de/extra-3/Sendung?documentId=23817212&rss=true`, but the extractor can't handle it. It'd be much better to let GenericIE do the rss handling and use ARDMediathekIE for the actual video download. But due to my limited python regexp knowledge I couldn't come up with a solution, that doesn't match on rss=true.
So this is kind of a hackish workaround. Maybe you can come up with a better solution.

Cheers,
olebowle
