### PR TITLE
Dirty fix for doubling rate-limit to fix #595

### DIFF
--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -146,7 +146,7 @@ class FileDownloader(object):
 
     def slow_down(self, start_time, byte_counter):
         """Sleep if the download speed is over the rate limit."""
-        rate_limit = self.params.get('ratelimit', None)
+        rate_limit = self.params.get('ratelimit', None)/2
         if rate_limit is None or byte_counter == 0:
             return
         now = time.time()


### PR DESCRIPTION
Fix #595 (not sure whether that goes in description or here so I picked both).

Youtube-dl somewhere doubles the rate limit, I can verify this.  If we half it as it is coming in, it is then doubled and goes to the normal rate limit.  Yes, it's a dirty fix, but it should work until we can figure out why the rate-limit is doubling.

My only concern is backwards compatibility for people who knew that the rate limit was doubled and set up their scripts to be half the rate limit they wanted.
