### PR TITLE
Fix #595, ratelimit divide by 2

### DIFF
--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -146,9 +146,10 @@ class FileDownloader(object):
 
     def slow_down(self, start_time, byte_counter):
         """Sleep if the download speed is over the rate limit."""
-        rate_limit = self.params.get('ratelimit', None)/2
+        rate_limit = self.params.get('ratelimit', None)
         if rate_limit is None or byte_counter == 0:
             return
+        rate_limit=rate_limit/2
         now = time.time()
         elapsed = now - start_time
         if elapsed <= 0.0:


### PR DESCRIPTION
Fix #595 by dividing the incoming ratelimit by 2.  Similar to #3942 but works as normal if no ratelimit is specified.

Tested with --rate-limit, -r, and no ratelimit.
