### PR TITLE
Fix #2310. Play by the 8tracks rules

### DIFF
--- a/youtube_dl/extractor/eighttracks.py
+++ b/youtube_dl/extractor/eighttracks.py
@@ -135,7 +135,7 @@ class EightTracksIE(InfoExtractor):
                     if download_tries > 3:
                         raise
                     else:
-                        ++download_tries
+                        download_tries += 1
                         time.sleep(avg_song_duration)
 
             api_data = json.loads(api_json)

--- a/youtube_dl/extractor/eighttracks.py
+++ b/youtube_dl/extractor/eighttracks.py
@@ -4,10 +4,12 @@ from __future__ import unicode_literals
 import json
 import random
 import re
+import time
 
 from .common import InfoExtractor
 from ..utils import (
     compat_str,
+    ExtractorError,
 )
 
 
@@ -112,14 +114,30 @@ class EightTracksIE(InfoExtractor):
         session = str(random.randint(0, 1000000000))
         mix_id = data['id']
         track_count = data['tracks_count']
+        duration = data['duration']
+        avg_song_duration = duration / track_count
         first_url = 'http://8tracks.com/sets/%s/play?player=sm&mix_id=%s&format=jsonh' % (session, mix_id)
         next_url = first_url
         entries = []
+
         for i in range(track_count):
-            api_json = self._download_webpage(
-                next_url, playlist_id,
-                note='Downloading song information %d/%d' % (i + 1, track_count),
-                errnote='Failed to download song information')
+            
+            api_json = None
+            download_tries = 0
+
+            while api_json is None:
+                try:
+                    api_json = self._download_webpage(
+                        next_url, playlist_id,
+                        note='Downloading song information %d/%d' % (i + 1, track_count),
+                        errnote='Failed to download song information')
+                except ExtractorError:
+                    if download_tries > 3:
+                        raise
+                    else:
+                        ++download_tries
+                        time.sleep(avg_song_duration)
+
             api_data = json.loads(api_json)
             track_data = api_data['set']['track']
             info = {
@@ -131,6 +149,7 @@ class EightTracksIE(InfoExtractor):
                 'ext': 'm4a',
             }
             entries.append(info)
+
             next_url = 'http://8tracks.com/sets/%s/next?player=sm&mix_id=%s&format=jsonh&track_id=%s' % (
                 session, mix_id, track_data['id'])
         return {


### PR DESCRIPTION
because we cant to predict the real download links without the server, we must play by the 8tracks rules:
* max 3 skip in hour. but playlist contains min 8 tracks, so 3 isn't enough
* continue to the next song after the current track done. but we don't know the exact length of track

so, some is better than nothing, and currently the exiting plugin is useless.
I calculate the average track length from playlist length and track count, then sleep after download failed until that new request be considered as legitimate.

ugly, takes a long time, but works! 