### PR TITLE
[generic] indicate when a direct video has been extracted

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -559,6 +559,7 @@ class GenericIE(InfoExtractor):
             return {
                 'id': video_id,
                 'title': os.path.splitext(url_basename(url))[0],
+                'direct': True,
                 'formats': [{
                     'format_id': m.group('format_id'),
                     'url': url,


### PR DESCRIPTION
Fixes #4052.

I'm not quite sure if I'm supposed to change the tests or something, but I've been getting a whole bunch (~700) of test failures so it's hard for me to check if anything broke (since the travis-ci builds have been failing because of the same problems for a while I'm guessing those test failures are not my fault).
