### PR TITLE
Workaround to deal with Phython bug in 2.6.0 - 2.6.4, fixes #3813

### DIFF
--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -106,10 +106,12 @@ def parseOpts(overrideArguments=None):
     fmt.format_option_strings = _format_option_string
 
     kw = {
-        'version': __version__,
-        'formatter': fmt,
-        'usage': '%prog [options] url [url...]',
-        'conflict_handler': 'resolve',
+        # The b prefix is for Python 2.6.0 - 2.6.4:
+        # http://bugs.python.org/issue2646
+        b'version': __version__,
+        b'formatter': fmt,
+        b'usage': '%prog [options] url [url...]',
+        b'conflict_handler': 'resolve',
     }
 
     parser = optparse.OptionParser(**kw)


### PR DESCRIPTION
youtube-dl imports unicode_literals from **future**, which makes
the string literals used as keys for dictionaries to be
unicode strings, but that's not supported until Python 2.6.5.
This workaround labels them as binary strings using the "b" prefix,
which keeps them as old-style strings.
