### PR TITLE
Copy the mtime from the oldest source file to the file created by ffmpeg

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -79,6 +79,7 @@ class FFmpegPostProcessor(PostProcessor):
         files_cmd = []
         for path in input_paths:
             files_cmd.extend(['-i', encodeFilename(path, True)])
+        oldest_mtime = min(os.stat(path).st_mtime for path in input_paths)
         cmd = ([self._executable, '-y'] + files_cmd
                + [encodeArgument(o) for o in opts] +
                [encodeFilename(self._ffmpeg_filename_argument(out_path), True)])
@@ -91,6 +92,7 @@ class FFmpegPostProcessor(PostProcessor):
             stderr = stderr.decode('utf-8', 'replace')
             msg = stderr.strip().split('\n')[-1]
             raise FFmpegPostProcessorError(msg)
+        os.utime(out_path, (oldest_mtime, oldest_mtime))
         if self._deletetempfiles:
             for ipath in input_paths:
                 os.remove(ipath)


### PR DESCRIPTION
This fixes #4245.

I tested this with Python 2.7.8 and Python 3.4.1 on Windows 7.  The mtime is now correctly set when using `-f bestvideo+bestaudio`.

`--no-mtime` still works as expected.