### PR TITLE
[bliptv] Fix some videos not downloading

### DIFF
--- a/youtube_dl/extractor/bliptv.py
+++ b/youtube_dl/extractor/bliptv.py
@@ -130,7 +130,7 @@ class BlipTVIE(SubtitlesInfoExtractor):
             msg = self._download_webpage(
                 url + '?showplayer=20140425131715&referrer=http://blip.tv&mask=7&skin=flashvars&view=url',
                 video_id, 'Resolving URL for %s' % role)
-            real_url = compat_urlparse.parse_qs(msg)['message'][0]
+            real_url = compat_urlparse.parse_qs(msg.strip())['message'][0]
 
             media_type = media_content.get('type')
             if media_type == 'text/srt' or url.endswith('.srt'):


### PR DESCRIPTION
Download of some videos on blip.tv failed with this error:

```
$ youtube-dl --verbose http://blip.tv/play/gbk766dkj4Yn
[debug] System config: []
[debug] User config: []
[debug] Command-line args: ['--verbose', 'http://blip.tv/play/gbk766dkj4Yn']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2014.11.24
[debug] Python version 3.4.2 - Linux-3.14.25-1-lts-x86_64-with-arch
[debug] exe versions: ffmpeg 2.4.3, ffprobe 2.4.3, rtmpdump 2.4
[debug] Proxy map: {}
[BlipTV] gbk766dkj4Yn: Resolving lookup id
ERROR: Unable to extract video_id; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/youtube_dl/YoutubeDL.py", line 553, in extract_info
    ie_result = ie.extract(url)
  File "/usr/lib/python3.4/site-packages/youtube_dl/extractor/common.py", line 240, in extract
    return self._real_extract(url)
  File "/usr/lib/python3.4/site-packages/youtube_dl/extractor/bliptv.py", line 79, in _real_extract
    video_id = self._search_regex(r'config\.id\s*=\s*"([0-9]+)', info_page, 'video_id')
  File "/usr/lib/python3.4/site-packages/youtube_dl/extractor/common.py", line 478, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
youtube_dl.utils.RegexNotFoundError: Unable to extract video_id; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

```

This was caused by "http://blip.tv/play/%s.x?p=1" page returning "No such post" for these videos. Fixed this by requesting "http://blip.tv/play/%s" instead and examining the redirect location (which contained video id).

Also fixed extractor returning URLs which end with \n\n as described by @tycode [here](https://github.com/rg3/youtube-dl/issues/3544#issuecomment-53166516).
