### PR TITLE
Add: -d shortcut for --write-description, implements #3166

### DIFF
--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -537,7 +537,7 @@ def parseOpts(overrideArguments=None):
         action='store_false', dest='updatetime', default=True,
         help='do not use the Last-modified header to set the file modification time')
     filesystem.add_option(
-        '--write-description',
+        '-d','--write-description',
         action='store_true', dest='writedescription', default=False,
         help='write video description to a .description file')
     filesystem.add_option(


### PR DESCRIPTION
Simple change to shortcut the --write-description flag to -d
