### PR TITLE
[Allocine] Support for more URLs

### DIFF
--- a/youtube_dl/extractor/allocine.py
+++ b/youtube_dl/extractor/allocine.py
@@ -12,7 +12,7 @@ from ..utils import (
 
 
 class AllocineIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?allocine\.fr/(?P<typ>article|video|film)/(fichearticle_gen_carticle=|player_gen_cmedia=|fichefilm_gen_cfilm=)(?P<id>[0-9]+)(?:\.html)?'
+    _VALID_URL = r'https?://(?:www\.)?allocine\.fr/(?P<typ>article|video|film)/(fichearticle_gen_carticle=|player_gen_cmedia=|fichefilm_gen_cfilm=|video-)(?P<id>[0-9]+)(?:\.html)?'
 
     _TESTS = [{
         'url': 'http://www.allocine.fr/article/fichearticle_gen_carticle=18635087.html',


### PR DESCRIPTION
I noticed Allocine was supported, yet some videos kept falling back to the generic extractor:

```
$ youtube-dl http://www.allocine.fr/video/video-19550147/                                                                                                                                                                                      
[generic] video-19550147: Requesting header
WARNING: Falling back on generic information extractor.
[generic] video-19550147: Downloading webpage
[generic] video-19550147: Extracting information
ERROR: Unsupported URL: http://www.allocine.fr/video/video-19550147/; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

This happens for all the videos [from the "Vidéos" section](http://www.allocine.fr/video/). The extractor itself works perfectly with them, it just needed the _VALID_URL regex to include them:

```
$ ./youtube_dl/__main__.py http://www.allocine.fr/video/video-19550147/                                                                                                                              [master] 
[Allocine] 19550147: Downloading webpage
[Allocine] 19550147: Downloading XML
[download] Destination: Faux Raccord N°123 - Les gaffes de Cliffhanger-19550147.mp4
[download] 100% of 88.85MiB in 00:56
```

The only downside I've noticed is that videos hosted elsewhere (YouTube or Dailymotion) aren't supported, but that's to be expected.
