### PR TITLE
only add video-id to archive, when successful

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1145,11 +1145,11 @@ class YoutubeDL(object):
 
             if success:
                 try:
-                    self.record_download_archive(info_dict)
                     self.post_process(filename, info_dict)
                 except (PostProcessingError) as err:
                     self.report_error('postprocessing: %s' % str(err))
                     return
+                self.record_download_archive(info_dict)
 
 
     def download(self, url_list):


### PR DESCRIPTION
Example:
no space left--> youtube-dl adds the id to archive, but the video isn't fully downloaded
