### PR TITLE
Update test_download.py

### DIFF
--- a/test/test_download.py
+++ b/test/test_download.py
@@ -196,7 +196,7 @@ def generator(test_case):
                                 format_bytes(got_fsize)))
                     if 'md5' in tc:
                         md5_for_file = _file_md5(tc_filename)
-                        self.assertEqual(md5_for_file, tc['md5'])
+                        self.assertEqual(tc['md5'], md5_for_file)
                 info_json_fn = os.path.splitext(tc_filename)[0] + '.info.json'
                 self.assertTrue(
                     os.path.exists(info_json_fn),


### PR DESCRIPTION
it's more intuitive to have the diff that follows the exception in this order:
-expected_md5
+current_md5
and it becomes consistent with the one that's given at test_download.py:207 "expect_info_dict(self, tc.get('info_dict', {}), info_dict)" for the description
