### PR TITLE
Allow falling back to mkv container when merging incompatible video & audio (fixes #3610)

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -324,6 +324,7 @@ def _real_main(argv=None):
         'encoding': opts.encoding,
         'exec_cmd': opts.exec_cmd,
         'extract_flat': opts.extract_flat,
+        'fallback_mkv': opts.fallback_mkv,
         'postprocessors': postprocessors,
     }
 

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -385,6 +385,11 @@ def parseOpts(overrideArguments=None):
         '--bidi-workaround',
         dest='bidi_workaround', action='store_true',
         help='Work around terminals that lack bidirectional text support. Requires bidiv or fribidi executable in PATH')
+    workarounds.add_option(
+    	'--fallback-mkv',
+    	dest='fallback_mkv', action='store_true',
+    	help='If downloading separate vieo and audio (e.g. -f bestvideo+bestaudio) and merging fails, try to use an mkv container'
+    )
 
     verbosity = optparse.OptionGroup(parser, 'Verbosity / Simulation Options')
     verbosity.add_option(

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -516,13 +516,30 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))
         return True, info
 
-
 class FFmpegMergerPP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']
         args = ['-c', 'copy', '-map', '0:v:0', '-map', '1:a:0', '-shortest']
         self._downloader.to_screen('[ffmpeg] Merging formats into "%s"' % filename)
-        self.run_ffmpeg_multiple_files(info['__files_to_merge'], filename, args)
+        #first attempt to merge them as normal but if a merge error happens attempt to eat it and try again with mkv output
+        #attempt to merge the files into the filename that the upstream methods have determined
+	#there's little point to try to guess from the start which video format will be compatible with which audio
+	#if the standard merge fails, fallback to mkv instead
+        try:
+        	self.run_ffmpeg_multiple_files(info['__files_to_merge'], filename, args)
+        except FFmpegPostProcessorError as fpe:
+        	if self._downloader.params.get('fallback_mkv', False) and "incorrect codec parameters" in fpe.msg.lower():
+        		warning = "Could not merge to %s format, ffmpeg said: '%s'\nAttempting to merge to mkv instead" % (info['ext'], fpe.msg)
+        		self._downloader.report_warning(warning)
+        		fname, ext = os.path.splitext(filename)
+        		mkv_filename = fname + ".mkv"
+        		self._downloader.to_screen('[ffmpeg] Merging formats into "%s"' % mkv_filename)
+        		self.run_ffmpeg_multiple_files(info['__files_to_merge'], mkv_filename, args)
+        		os.remove(encodeFilename(filename))
+        		info['filepath'] = mkv_filename
+        		info['ext'] = 'mkv'
+        	else:
+        		raise fpe	
         return True, info
 
 

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -521,10 +521,9 @@ class FFmpegMergerPP(FFmpegPostProcessor):
         filename = info['filepath']
         args = ['-c', 'copy', '-map', '0:v:0', '-map', '1:a:0', '-shortest']
         self._downloader.to_screen('[ffmpeg] Merging formats into "%s"' % filename)
-        #first attempt to merge them as normal but if a merge error happens attempt to eat it and try again with mkv output
         #attempt to merge the files into the filename that the upstream methods have determined
 	#there's little point to try to guess from the start which video format will be compatible with which audio
-	#if the standard merge fails, fallback to mkv instead
+	#so instead just try merging with what we have and see what happens
         try:
         	self.run_ffmpeg_multiple_files(info['__files_to_merge'], filename, args)
         except FFmpegPostProcessorError as fpe:


### PR DESCRIPTION
As explained in https://github.com/rg3/youtube-dl/issues/3610, there are cases when downloading separate video and audio and then merging when the video container (usually webm containing VP8/VP9) is incompatible with the audio codec (aac/mp3). By default, youtube-dl attempts to create a merge in the container format of the video file. 

In this pull request I've attempted to add a workaround option "--fallback-mkv" that, when merging the two files, attempts to merge in the normal way first, and if that fails due to codec incompatibilities, attempts to merge to mkv container output instead.

My code doesn't attempt to determine upfront whether the merge will fail or not (there are probably more formats out there then I am aware of) but instead attempts to fall back to mkv if the normal merge doesn't work