### PR TITLE
[ffmpeg] fix encoding mismatch in commandline arguments (fixes #4337)

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -80,8 +80,8 @@ class FFmpegPostProcessor(PostProcessor):
 
         files_cmd = []
         for path in input_paths:
-            files_cmd.extend(['-i', encodeFilename(path, True)])
-        cmd = ([self._executable, '-y'] + files_cmd
+            files_cmd.extend([encodeArgument('-i'), encodeFilename(path, True)])
+        cmd = ([encodeArgument(self._executable), encodeArgument('-y')] + files_cmd
                + [encodeArgument(o) for o in opts] +
                [encodeFilename(self._ffmpeg_filename_argument(out_path), True)])
 


### PR DESCRIPTION
As reported in #4337, when file name has some Korean or Japanese (or maybe other language) characters, mux by ffmpeg raises UnicodeDecodeError.
I think it is because of encoding mismatch in commandline arguments. This pull request fixes it.
