### PR TITLE
Update rtlnl.py

### DIFF
--- a/youtube_dl/extractor/rtlnl.py
+++ b/youtube_dl/extractor/rtlnl.py
@@ -8,7 +8,7 @@ from ..utils import parse_duration
 
 class RtlXlIE(InfoExtractor):
     IE_NAME = 'rtlxl.nl'
-    _VALID_URL = r'https?://www\.rtlxl\.nl/#!/[^/]+/(?P<uuid>[^/?]+)'
+    _VALID_URL = r'https?://(www\.)?rtlxl\.nl/#!/[^/]+/(?P<uuid>[^/?]+)'
 
     _TEST = {
         'url': 'http://www.rtlxl.nl/#!/rtl-nieuws-132237/6e4203a6-0a5e-3596-8424-c599a59e0677',


### PR DESCRIPTION
Added support for the non-www version of rtlxl.nl by making "www." optional.
E.g.:
http://www.rtlxl.nl/#!/divorce-277291/291d70e8-8bd2-39ef-b849-c4ec94fc46c2
and
http://rtlxl.nl/#!/divorce-277291/291d70e8-8bd2-39ef-b849-c4ec94fc46c2
are two urls for the same content.
