### PR TITLE
Merge output format

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -912,7 +912,7 @@ class YoutubeDL(object):
                             selected_format = {
                                 'requested_formats': formats_info,
                                 'format': rf,
-                                'ext': formats_info[0]['ext'],
+                                'ext': self.params['merge_output_format'] if self.params['merge_output_format'] is not None else formats_info[0]['ext'],
                             }
                         else:
                             selected_format = None

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -166,6 +166,9 @@ def _real_main(argv=None):
     if opts.recodevideo is not None:
         if opts.recodevideo not in ['mp4', 'flv', 'webm', 'ogg', 'mkv']:
             parser.error('invalid video recode format specified')
+    if opts.merge_output_format is not None and not '+' in opts.format: #if merge format output is used on videos that don't require merging, ignore
+        opts.merge_output_format = None
+        
     if opts.date is not None:
         date = DateRange.day(opts.date)
     else:
@@ -323,6 +326,7 @@ def _real_main(argv=None):
         'encoding': opts.encoding,
         'exec_cmd': opts.exec_cmd,
         'extract_flat': opts.extract_flat,
+        'merge_output_format': opts.merge_output_format,
         'postprocessors': postprocessors,
     }
 

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -302,6 +302,12 @@ def parseOpts(overrideArguments=None):
         '--youtube-skip-dash-manifest',
         action='store_false', dest='youtube_include_dash_manifest',
         help='Do not download the DASH manifest on YouTube videos')
+    video_format.add_option(
+    	'--merge-output-format',
+        action='store', dest='merge_output_format', metavar='FORMAT' ,default=None,
+        help=(
+            'If a merge is required (e.g. bestvideo+bestaudio), output to given container format (e.g. mkv, mp4, ogg, webm, flv) '
+            'Ignored if no merge is required'))
 
     subtitles = optparse.OptionGroup(parser, 'Subtitle Options')
     subtitles.add_option(


### PR DESCRIPTION
As explained in https://github.com/rg3/youtube-dl/issues/3610, https://github.com/rg3/youtube-dl/issues/2765 there are cases when downloading separate video and audio and then merging when the video container (usually webm containing VP8/VP9) is incompatible with the audio codec (aac/mp3). By default, youtube-dl attempts to create a merge in the container format of the video file.

This is a redo of pull request https://github.com/rg3/youtube-dl/pull/4577. This time around I've added a video option called "merge-ouput-format" that specifies what container format the merge output should be put into. It is only used if merging is required (something like "-f best" will not use it for instance). If you provide nothing for it, the video part's container format will be used, just like before.