### PR TITLE
Update readme.md configuration paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,16 @@ which means you can modify it, redistribute it or use it however you like.
 
 # CONFIGURATION
 
-You can configure youtube-dl by placing default arguments (such as `--extract-audio --no-mtime` to always extract the audio and not copy the mtime) into `/etc/youtube-dl.conf` and/or `~/.config/youtube-dl/config`. On Windows, the configuration file locations are `%APPDATA%\youtube-dl\config.txt` and `C:\Users\<user name>\youtube-dl.conf`.
+**On Mac:** You can configure youtube-dl by placing default arguments into `/etc/youtube-dl.conf` and/or `~/.config/youtube-dl.conf`.
+
+**On Windows:** The configuration file locations are `%APPDATA%\youtube-dl\config.txt` and `C:\Users\<user name>\youtube-dl.conf`.
+
+**Example youtube-dl.conf:**
+To always extract the audio and not copy the mtime:
+```
+--extract-audio
+--no-mtime
+```
 
 # OUTPUT TEMPLATE
 


### PR DESCRIPTION
- for me the file path is `~/.config/youtube-dl.conf` which is more consistent with the second URL so I thing this is a good update
- also updated the paragraph for readabilty by separating win and mac
- also extracted the example line to show implicitly that multiple lines in the .conf file are ok.