### PR TITLE
Embed description and URL as MP4 tags

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -509,6 +509,10 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
             metadata['artist'] = info['uploader']
         elif info.get('uploader_id') is not None:
             metadata['artist'] = info['uploader_id']
+        if info.get('description') is not None:
+            metadata['description'] = info['description']
+        if info.get('webpage_url') is not None:
+            metadata['comment'] = info['webpage_url']
 
         if not metadata:
             self._downloader.to_screen('[ffmpeg] There isn\'t any metadata to add')


### PR DESCRIPTION
Description is one of the MP4 tags honored by ffmpeg, looks like a good place to store the video description when embedding metadata. I believe the source URL is useful information to keep as well, the comment tag seems like a good place to record it.

While I don't see the description becoming long enough to significantly affect the size of the output video, it can be long and unwieldy, for example while reading mediainfo dumps. Should including it be dependant on another option in addition to --add-metadata, perhaps --add-description?