### PR TITLE
download raw videos from LiveLeak (without branding)

### DIFF
--- a/youtube_dl/extractor/liveleak.py
+++ b/youtube_dl/extractor/liveleak.py
@@ -11,10 +11,10 @@ class LiveLeakIE(InfoExtractor):
     _VALID_URL = r'^(?:http://)?(?:\w+\.)?liveleak\.com/view\?(?:.*?)i=(?P<video_id>[\w_]+)(?:.*)'
     _TESTS = [{
         'url': 'http://www.liveleak.com/view?i=757_1364311680',
-        'md5': '0813c2430bea7a46bf13acf3406992f4',
+        'md5': '50f79e05ba149149c1b4ea961223d5b3',
         'info_dict': {
             'id': '757_1364311680',
-            'ext': 'mp4',
+            'ext': 'flv',
             'description': 'extremely bad day for this guy..!',
             'uploader': 'ljfriel2',
             'title': 'Most unlucky car accident'

--- a/youtube_dl/extractor/liveleak.py
+++ b/youtube_dl/extractor/liveleak.py
@@ -82,7 +82,8 @@ class LiveLeakIE(InfoExtractor):
 
         formats = [{
             'format_note': s.get('label'),
-            'url': s['file'],
+            # removing this from the URL gives us the raw video without LiveLeak branding
+            'url': s['file'].replace('.h264_base.mp4', ''),
         } for s in sources]
         self._sort_formats(formats)
 


### PR DESCRIPTION
Removing `.h264_base.mp4` from the URL gives us the raw video, which is essentially the same video without the LiveLeak logo at the top:

![before-after image](https://i.imgur.com/r8bkRlm.png)
Actually the video quality seems to be slightly better now as well.

Some of the raw videos are `flv` instead of `mp4`, so they won't always be `mp4` (as it was before). I hope that is okay.

All tests are passing after I changed the expected result to flv for one of the videos.

I have never worked with youtube-dl before, please forgive me if this is the wrong place for this kind of modification.