### PR TITLE
fixed viddler support; also added a viddler generic extractor 

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -498,6 +498,19 @@ class GenericIE(InfoExtractor):
                 'uploader': 'www.abc.net.au',
                 'title': 'Game of Thrones with dice - Dungeons and Dragons fantasy role-playing game gets new life - 19/01/2015',
             }
+        },
+        # embedded viddler video
+        {
+            'url': 'http://deadspin.com/i-cant-stop-watching-john-wall-chop-the-nuggets-with-th-1681801597',
+            'info_dict': {
+                'id': '4d03aad9',
+                'ext': 'mp4',
+                'uploader': 'deadspin',
+                'title': 'WALL-TO-GORTAT',
+                'timestamp': 1422285291,
+                'upload_date': '20150126',
+            },
+            'add_ie': ['Viddler'],
         }
     ]
 
@@ -857,6 +870,13 @@ class GenericIE(InfoExtractor):
         # Look for embedded Vevo player
         mobj = re.search(
             r'<iframe[^>]+?src=(["\'])(?P<url>(?:https?:)?//(?:cache\.)?vevo\.com/.+?)\1', webpage)
+        if mobj is not None:
+            return self.url_result(mobj.group('url'))
+
+        # Look for embedded Viddler player
+        mobj = (re.search(r'<iframe[^>]+?src=(["\'])(?P<url>(?:https?:)?//(?:www\.)?viddler\.com/embed/.+?)\1', webpage) or
+                re.search(r'<param[^>]+?value=(["\'])(?P<url>(?:https?:)?//(?:www\.)?viddler\.com/player/.+?)\1', webpage))
+
         if mobj is not None:
             return self.url_result(mobj.group('url'))
 

--- a/youtube_dl/extractor/viddler.py
+++ b/youtube_dl/extractor/viddler.py
@@ -5,11 +5,14 @@ from ..utils import (
     float_or_none,
     int_or_none,
 )
+from ..compat import (
+   compat_urllib_request
+)
 
 
 class ViddlerIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?viddler\.com/(?:v|embed|player)/(?P<id>[a-z0-9]+)'
-    _TEST = {
+    _TESTS = [{
         "url": "http://www.viddler.com/v/43903784",
         'md5': 'ae43ad7cb59431ce043f0ff7fa13cbf4',
         'info_dict': {
@@ -25,7 +28,30 @@ class ViddlerIE(InfoExtractor):
             'view_count': int,
             'categories': ['video content', 'high quality video', 'video made easy', 'how to produce video with limited resources', 'viddler'],
         }
-    }
+    }, {
+        "url": "http://www.viddler.com/v/4d03aad9/",
+        "file": "4d03aad9.mp4",
+        "md5": "faa71fbf70c0bee7ab93076fd007f4b0",
+        "info_dict": {
+            'upload_date': '20150126',
+            'uploader': 'deadspin',
+            'id': '4d03aad9',
+            'timestamp': 1422285291,
+            'title': 'WALL-TO-GORTAT',
+        }
+    }, {
+        "url": "http://www.viddler.com/player/221ebbbd/0/",
+        "file": "221ebbbd.mp4",
+        "md5": "0defa2bd0ea613d14a6e9bd1db6be326",
+        "info_dict": {
+            'upload_date': '20140929',
+            'uploader': 'BCLETeens',
+            'id': '221ebbbd',
+            'timestamp': 1411997190,
+            'title': 'LETeens-Grammar-snack-third-conditional',
+            'description': ' '
+        }
+    }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
@@ -33,7 +59,9 @@ class ViddlerIE(InfoExtractor):
         json_url = (
             'http://api.viddler.com/api/v2/viddler.videos.getPlaybackDetails.json?video_id=%s&key=v0vhrt7bg2xq1vyxhkct' %
             video_id)
-        data = self._download_json(json_url, video_id)['video']
+        headers = {'Referer': 'http://static.cdn-ec.viddler.com/js/arpeggio/v2/embed.html'}
+        request = compat_urllib_request.Request(json_url, None, headers)
+        data = self._download_json(request, video_id)['video']
 
         formats = []
         for filed in data['files']:
@@ -53,7 +81,7 @@ class ViddlerIE(InfoExtractor):
 
             if filed.get('cdn_url'):
                 f = f.copy()
-                f['url'] = self._proto_relative_url(filed['cdn_url'])
+                f['url'] = self._proto_relative_url(filed['cdn_url'], 'http:')
                 f['format_id'] = filed['profile_id'] + '-cdn'
                 f['source_preference'] = 1
                 formats.append(f)


### PR DESCRIPTION
This fixes the Viddler extractor. There  were a couple of issues: 

1. The API call needed a Referer header or else would get a 403 response code
2. The cdn url does not work over https (SSL) - would result in a 404, so have to specify the scheme to be http.

This resolves #2466 and #3897