### PR TITLE
UX: Add a note about the help if no parameters are passed

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -361,7 +361,8 @@ def _real_main(argv=None):
                 sys.exit()
 
             ydl.warn_if_short_id(sys.argv[1:] if argv is None else argv)
-            parser.error('you must provide at least one URL')
+            parser.error('You must provide at least one URL.\n'
+                         'For more details on how to use the program type "youtube-dl -h"')
 
         try:
             if opts.load_info_filename is not None:


### PR DESCRIPTION
When I tried to display the help, the necessary command wasn't intuitively clear to me.
I would suggest to add a small note how one can display the help if no parameters are passed.