### PR TITLE
Handling Connection Reset by Peer Error

### DIFF
--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -3,6 +3,9 @@ from __future__ import unicode_literals
 import os
 import time
 
+from socket import error as SocketError
+import errno
+
 from .common import FileDownloader
 from ..compat import (
     compat_urllib_request,
@@ -99,6 +102,11 @@ class HttpFD(FileDownloader):
                             resume_len = 0
                             open_mode = 'wb'
                             break
+
+            except SocketError as e:
+                if e.errno != errno.ECONNRESET:
+                    raise # Not error we are looking for
+                pass
             # Retry
             count += 1
             if count <= retries:


### PR DESCRIPTION
"Connection Reset By Peer" error is frequent in when connecting through a firewall and retrying download often is a workaround for this.