### PR TITLE
[f4m] call progress hook

### DIFF
--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -335,8 +335,10 @@ class F4mFD(FileDownloader):
             # report totals to actual hooks
             toplevel_status = {'status': 'downloading', 'filename': filename, 'tmpfilename': tmpfilename}
             toplevel_status['downloaded_bytes'] = state['downloaded_bytes']
-            if (state['downloaded_bytes'] > 0) and (progress > 0):
-                toplevel_status['total_bytes'] = int(100.0 * state['downloaded_bytes'] / progress)
+            total_bytes = 0
+            if progress > 0:
+                total_bytes = int((100.0 * state['downloaded_bytes']) / progress)
+            toplevel_status['total_bytes'] = total_bytes
             if 'speed' in status:
                 toplevel_status['speed'] = status['speed']
             if 'eta' in status:

--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -333,11 +333,12 @@ class F4mFD(FileDownloader):
                                  status.get('speed'), eta)
 
             # report totals to actual hooks
-            status['status'] = 'downloading'
-            #status['downloaded_bytes'] = state['downloaded_bytes'] ?
-            #status['total_bytes'] = ?
+            toplevel_status = {'status': 'downloading', 'filename': filename, 'tmpfilename': tmpfilename}
+            toplevel_status['downloaded_bytes'] = state['downloaded_bytes']
+            if (state['downloaded_bytes'] > 0) and (progress > 0):
+                toplevel_status['total_bytes'] = int(100.0 * state['downloaded_bytes'] / progress)
             for hook in self._progress_hooks:
-                hook(status)
+                hook(toplevel_status)
 
         http_dl.add_progress_hook(frag_progress_hook)
 

--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -337,6 +337,10 @@ class F4mFD(FileDownloader):
             toplevel_status['downloaded_bytes'] = state['downloaded_bytes']
             if (state['downloaded_bytes'] > 0) and (progress > 0):
                 toplevel_status['total_bytes'] = int(100.0 * state['downloaded_bytes'] / progress)
+            if 'speed' in status:
+                toplevel_status['speed'] = status['speed']
+            if 'eta' in status:
+                toplevel_status['eta'] = status['eta']
             for hook in self._progress_hooks:
                 hook(toplevel_status)
 

--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -333,15 +333,16 @@ class F4mFD(FileDownloader):
                                  status.get('speed'), eta)
 
             # report totals to actual hooks
-            toplevel_status = {'status': 'downloading', 'filename': filename, 'tmpfilename': tmpfilename}
+            toplevel_status = {'status': 'downloading', 'filename': filename,
+                               'tmpfilename': tmpfilename, 'eta': eta}
             toplevel_status['downloaded_bytes'] = state['downloaded_bytes']
             total_bytes = 0
             if progress > 0:
+                # subject to rounding error
                 total_bytes = int((100.0 * state['downloaded_bytes']) / progress)
             toplevel_status['total_bytes'] = total_bytes
             if 'speed' in status:
                 toplevel_status['speed'] = status['speed']
-            toplevel_status['eta'] = eta
             self._hook_progress(toplevel_status)
 
         http_dl.add_progress_hook(frag_progress_hook)

--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -343,8 +343,7 @@ class F4mFD(FileDownloader):
                 toplevel_status['speed'] = status['speed']
             if 'eta' in status:
                 toplevel_status['eta'] = eta
-            for hook in self._progress_hooks:
-                hook(toplevel_status)
+            self._hook_progress(toplevel_status)
 
         http_dl.add_progress_hook(frag_progress_hook)
 

--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -342,7 +342,7 @@ class F4mFD(FileDownloader):
             if 'speed' in status:
                 toplevel_status['speed'] = status['speed']
             if 'eta' in status:
-                toplevel_status['eta'] = status['eta']
+                toplevel_status['eta'] = eta
             for hook in self._progress_hooks:
                 hook(toplevel_status)
 

--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -341,8 +341,7 @@ class F4mFD(FileDownloader):
             toplevel_status['total_bytes'] = total_bytes
             if 'speed' in status:
                 toplevel_status['speed'] = status['speed']
-            if 'eta' in status:
-                toplevel_status['eta'] = eta
+            toplevel_status['eta'] = eta
             self._hook_progress(toplevel_status)
 
         http_dl.add_progress_hook(frag_progress_hook)

--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -331,6 +331,14 @@ class F4mFD(FileDownloader):
             eta = self.calc_eta(start, time.time(), estimated_size, byte_counter)
             self.report_progress(progress, format_bytes(estimated_size),
                                  status.get('speed'), eta)
+
+            # report totals to actual hooks
+            status['status'] = 'downloading'
+            #status['downloaded_bytes'] = state['downloaded_bytes'] ?
+            #status['total_bytes'] = ?
+            for hook in self._progress_hooks:
+                hook(status)
+
         http_dl.add_progress_hook(frag_progress_hook)
 
         frags_filenames = []


### PR DESCRIPTION
the actual progress hooks were not called (#4860)
however, I'd like the fields downloaded_bytes and total_bytes be computed correctly from the progress of each frag.
the sum ot total bytes downloaded seems recorded in state['downloaded_bytes'],
but how would you account for total_bytes ? it seems fragments don't have the same size, do we know it in advance ?
otherwise we could add a 'progress' field in the status with the ratio downloaded_bytes/total_bytes when total_bytes is known or else the estimate of f4m.
should I add a get_progress_hooks() to return _progress_hooks ?