### PR TITLE
Fix _remove_comments regex because of function that has “/*” in it:

### DIFF
--- a/youtube_dl/jsinterp.py
+++ b/youtube_dl/jsinterp.py
@@ -35,7 +35,7 @@ class JSInterpreter(object):
         self._objects = objects
 
     def _remove_comments(self, code):
-        return re.sub(r'(?s)/\*.*?\*/', '', code)
+        return re.sub(r'(?s)/\*[^\[].*?\*/', '', code)
 
     def interpret_statement(self, stmt, local_vars, allow_recursion=100):
         if allow_recursion < 0:


### PR DESCRIPTION
This function has a couple of "/*" in it that is throwing off the regex to remove comments. This only happens occasionally - one video threw an exception but that same video worked fine on a different IP address. So I don't think this should be a permanent fix, but until we narrow down the issue this can be a workaround.

This fixes #4976 

```javascript
function LB(a) {
        if ("undefined" != typeof a.selectNodes) {
            var b = Ad(a);
            "undefined" != typeof b.setProperty && b.setProperty("SelectionLanguage", "XPath");
            return a.selectNodes('vmap:Extensions/vmap:Extension[@type = "YTBreakTime"]/*[name() = "yt:BreakTime"]')
        }
        if (document.implementation.hasFeature("XPath", "3.0")) {
            var b = Ad(a),
                c = b.createNSResolver(b.documentElement);
            a = b.evaluate('vmap:Extensions/vmap:Extension[@type = "YTBreakTime"]/*[name() = "yt:BreakTime"]', a, c, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
            for (var b = [], c = a.snapshotLength, d = 0; d < c; d++) b.push(a.snapshotItem(d));
            return b
        }
        return []
    }
```