### PR TITLE
Added title with default value None to url_result

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -492,11 +492,12 @@ class InfoExtractor(object):
 
     # Methods for following #608
     @staticmethod
-    def url_result(url, ie=None, video_id=None):
+    def url_result(url, ie=None, video_id=None, title=None):
         """Returns a url that points to a page that should be processed"""
         # TODO: ie should be the class used for getting the info
         video_info = {'_type': 'url',
                       'url': url,
+                      'title': title,
                       'ie_key': ie}
         if video_id is not None:
             video_info['id'] = video_id


### PR DESCRIPTION
Fixes jwplayer playlists with unknown video titles
I used this to make discogs.com embeds work. I hope it makes sense like
this...
This works now:
  youtube-dl --verbose --user-agent "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:35.0) Gecko/20100101 Firefox/35.0" http://www.discogs.com/master/15295

This closes #4790.