### PR TITLE
[lynda] Fixed subtitles broken file

### DIFF
--- a/youtube_dl/extractor/lynda.py
+++ b/youtube_dl/extractor/lynda.py
@@ -152,7 +152,7 @@ class LyndaIE(InfoExtractor):
                 continue
             appear_time = m_current.group('timecode')
             disappear_time = m_next.group('timecode')
-            text = seq_current['Caption']
+            text = seq_current['Caption'].strip()
             srt += '%s\r\n%s --> %s\r\n%s' % (str(pos), appear_time, disappear_time, text)
         if srt:
             return srt


### PR DESCRIPTION
Ajax subtitle request returns text captions with new line characters in the beginning and the end.

    '\nIn the next several chapters of this\ncourse, we're going to be going over the \n'

Result .srt file has bad format and ignored by VLC and some other players.
Example:

    1
    00:00:00.025 --> 00:00:04.939
    
    In the next several chapters of this 
    course, we're going to be going over the 

To fix this bug, we need to remove empty line after timecode

    1
    00:00:00.025 --> 00:00:04.939    
    In the next several chapters of this 
    course, we're going to be going over the 

This is done with **strip** function
