### PR TITLE
[lynda] Check for the empty subtitles

### DIFF
--- a/youtube_dl/extractor/lynda.py
+++ b/youtube_dl/extractor/lynda.py
@@ -144,6 +144,7 @@ class LyndaIE(InfoExtractor):
 
     def _fix_subtitles(self, subs):
         srt = ''
+        seq_counter = 0
         for pos in range(0, len(subs) - 1):
             seq_current = subs[pos]
             m_current = re.match(self._TIMECODE_REGEX, seq_current['Timecode'])
@@ -155,8 +156,10 @@ class LyndaIE(InfoExtractor):
                 continue
             appear_time = m_current.group('timecode')
             disappear_time = m_next.group('timecode')
-            text = seq_current['Caption'].lstrip()
-            srt += '%s\r\n%s --> %s\r\n%s' % (str(pos), appear_time, disappear_time, text)
+            text = seq_current['Caption'].strip()
+            if text:
+                seq_counter += 1
+                srt += '%s\r\n%s --> %s\r\n%s\r\n\r\n' % (seq_counter, appear_time, disappear_time, text)
         if srt:
             return srt
 


### PR DESCRIPTION
We can't use **lstrip** for subtitles. Not every subtitle line in the response contains two "new line" characters. And in some cases .srt files can be invalid.

Example: http://www.lynda.com/ajax/player?videoId=159736&courseId=123563&type=transcript
There are lines with only one "new line" and there are empty lines.
We should skip empty lines and add \r\n\r\n after each subtitle line.
Also sequence counter was updated.