### PR TITLE
* Change globo.py flash ver to 17.0.0.132 - Chrome 42.0.2311.22

### DIFF
--- a/youtube_dl/extractor/globo.py
+++ b/youtube_dl/extractor/globo.py
@@ -20,7 +20,7 @@ class GloboIE(InfoExtractor):
     _VALID_URL = 'https?://.+?\.globo\.com/(?P<id>.+)'
 
     _API_URL_TEMPLATE = 'http://api.globovideos.com/videos/%s/playlist'
-    _SECURITY_URL_TEMPLATE = 'http://security.video.globo.com/videos/%s/hash?player=flash&version=2.9.9.50&resource_id=%s'
+    _SECURITY_URL_TEMPLATE = 'http://security.video.globo.com/videos/%s/hash?player=flash&version=17.0.0.132&resource_id=%s'
 
     _VIDEOID_REGEXES = [
         r'\bdata-video-id="(\d+)"',


### PR DESCRIPTION
Globo.com download did not work with old flash version. Using Chrome-dev flash version.

Probe:  leonardo  dora  ~  $  youtube-dl "http://g1.globo.com/globo-reporter/noticia/2015/03/globo-reporter-mostra-pessoas-que-descobriram-como-viver-com-menos.html"
[Globo] globo-reporter/noticia/2015/03/globo-reporter-mostra-pessoas-que-descobriram-como-viver-com-menos.html: Downloading webpage
[Globo] 4028409: Downloading JSON metadata
[Globo] 4028409: Downloading security hash for 5500f59b9214470f1d0058e4
[Globo] 4028409: Downloading security hash for 5500f59b921447071c004ae0
[Globo] 4028409: Downloading security hash for 5500f59b92144739e3004c92
[Globo] 4028409: Downloading security hash for 5500f59b9214470f1d0058e2
[download] Destination: Globo Repórter mostra pessoas que descobriram como viver com menos-4028409.mp4
[download] 100% of 11.57MiB in 00:03
