### PR TITLE
Add moviestorm InfoExtractor

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -638,7 +638,7 @@ class YoutubeDL(object):
 
                 # ignore non-familiar links
                 if c != 'GenericIE' and c != 'MovieStormIE' and ie.suitable(farmed_url):
-                    familiar_farmed_urls.append( [ie, farmed_url] )
+                    familiar_farmed_urls.append([ie, farmed_url])
 
         for tuple in familiar_farmed_urls:
             ie = tuple[0]

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -677,7 +677,7 @@ class YoutubeDL(object):
 
                 # handle link farm extractors
                 if hasattr(ie, '_LINK_FARM') and ie._LINK_FARM:
-                	ie_result, ie = self.process_farmed_links(ie_result)
+                    ie_result, ie = self.process_farmed_links(ie_result)
 
                 if ie_result is None:  # Finished already (backwards compatibility; listformats and friends should be moved here)
                     break

--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -37,7 +37,6 @@ from .bandcamp import BandcampIE, BandcampAlbumIE
 from .bbccouk import BBCCoUkIE
 from .beeg import BeegIE
 from .behindkink import BehindKinkIE
-from .beatportpro import BeatportProIE
 from .bet import BetIE
 from .bild import BildIE
 from .bilibili import BiliBiliIE
@@ -232,7 +231,6 @@ from .jove import JoveIE
 from .jukebox import JukeboxIE
 from .jpopsukitv import JpopsukiIE
 from .kaltura import KalturaIE
-from .kanalplay import KanalPlayIE
 from .kankan import KankanIE
 from .karaoketv import KaraoketvIE
 from .keezmovies import KeezMoviesIE
@@ -281,6 +279,7 @@ from .moevideo import MoeVideoIE
 from .mofosex import MofosexIE
 from .mojvideo import MojvideoIE
 from .moniker import MonikerIE
+from .moviestorm import MovieStormIE
 from .mooshare import MooshareIE
 from .morningstar import MorningstarIE
 from .motherless import MotherlessIE
@@ -559,7 +558,6 @@ from .videoweed import VideoWeedIE
 from .vidme import VidmeIE
 from .vidzi import VidziIE
 from .vier import VierIE, VierVideosIE
-from .viewster import ViewsterIE
 from .vimeo import (
     VimeoIE,
     VimeoAlbumIE,

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -117,12 +117,12 @@ class MovieStormIE(InfoExtractor):
                 note=False,
                 errnote='Unable to download link farm watch page',
                 fatal=False
-        	)
+            )
 
-        	if watchpage is not None:
-        	    direct_url = MovieStormHTMLParser.extract_direct_url(watchpage)
-        	    if direct_url:
-        	        self.direct_urls.append(direct_url)
+            if watchpage is not None:
+                direct_url = MovieStormHTMLParser.extract_direct_url(watchpage)
+                if direct_url:
+                    self.direct_urls.append(direct_url)
 
         self.to_screen(': Passing off farmed links to InfoExtractors')
         return list(set(self.direct_urls))

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -47,28 +47,29 @@ class MovieStormHTMLParser(compat_html_parser.HTMLParser):
         return getattr(p, return_variable)
 
 class MovieStormIE(InfoExtractor):
-    # HANDLER INFO:
-    # There are no tests for this IE because the links on any given moviestorm
-    # page can dynamically change, and because the actual download/extraction
-    # is ultimately preformed by another IE. Example urls to
-    # feed to this IE are:
-    #
-    #   EPISODE: http://moviestorm.eu/view/5821-watch-portlandia/season-1/episode-1
-    #   MOVIE:   http://moviestorm.eu/view/5269-watch-taken-3-online.html
-    #
-    # If the user provides a series url, like the one below, this IE should detect
-    # and raise an error:
-    #
-    #   SERIES:  http://moviestorm.eu/view/5821-watch-portlandia.html
-    #
-    # In other news, moviestorm's drupal db config is unstable at times retry up to 5
-    # times before giving up, waiting 5 second delay between each retry.
-    #
-    # Also, this IE will catch all links with http://moviestorm.eu urls. If it's an
-    # un-handleable url, an error will be thrown informing the user of appropriate
-    # urls to provide. Not using a more complex regex is meant to prevent unacceptable
-    # moviestorm urls from falling back into the generic IE, as that will always fail on
-    # moviestorm links.
+    """EXTRACTOR INFO:
+    There are no tests for this IE because the links on any given moviestorm
+    page can dynamically change, and because the actual download/extraction
+    is ultimately preformed by another IE. Example urls to
+    feed to this IE are:
+
+        EPISODE: http://moviestorm.eu/view/5821-watch-portlandia/season-1/episode-1
+        MOVIE:   http://moviestorm.eu/view/5269-watch-taken-3-online.html
+
+    If the user provides a series url, like the one below, this IE should detect
+    and raise an error:
+
+        SERIES:  http://moviestorm.eu/view/5821-watch-portlandia.html
+
+    In other news, moviestorm's drupal db config is unstable at times retry up to 5
+    times before giving up, waiting 5 second delay between each retry.
+
+    Also, this IE will catch all links with http://moviestorm.eu urls. If it's an
+    un-handleable url, an error will be thrown informing the user of appropriate
+    urls to provide. Not using a more complex regex is meant to prevent unacceptable
+    moviestorm urls from falling back into the generic IE, as that will always fail on
+    moviestorm links.
+    """
 
     IE_DESC = 'Movie Storm (link farm)'
     IE_NAME = 'MovieStorm'

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -9,9 +9,7 @@ from .common import InfoExtractor
 from ..utils import ExtractorError
 from ..compat import (
     compat_html_parser,
-    compat_urllib_parse,
-    compat_urllib_request,
-    compat_urlparse,
+    compat_urlparse
 )
 
 class MovieStormHTMLParser(compat_html_parser.HTMLParser):

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -1,0 +1,128 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import os.path
+import re
+from time import sleep
+
+from .common import InfoExtractor
+from ..utils import ExtractorError
+from ..compat import (
+    compat_html_parser,
+    compat_urllib_parse,
+    compat_urllib_request,
+    compat_urlparse,
+)
+
+class MovieStormHTMLParser(compat_html_parser.HTMLParser):
+    def __init__(self):
+        self.found_button = False
+        self.watch_urls = []
+        self.direct_url = False
+        compat_html_parser.HTMLParser.__init__(self)
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict((k, v) for k, v in attrs)
+        if tag == 'td' and attrs['class'] == 'link_td':
+            self.found_button = True
+        elif tag == 'a' and self.found_button:
+            # suppress ishare and other direct links, can't handle now
+            if 'moviestorm' in attrs['href']:
+                self.watch_urls.append(attrs['href'].strip())
+        elif tag == 'a' and 'class' in attrs and attrs['class'] == 'real_link':
+        	self.direct_url = attrs['href'].strip()
+
+    def handle_endtag(self, tag):
+        if tag == 'td':
+            self.found_button = False
+
+    @classmethod
+    def extract_watch_urls(cls, html):
+        p = cls()
+        p.feed(html)
+        p.close()
+        return p.watch_urls
+
+    @classmethod
+    def extract_direct_url(cls, html):
+        p = cls()
+        p.feed(html)
+        p.close()
+        return p.direct_url
+
+class MovieStormIE(InfoExtractor):
+    IE_DESC = 'Movie Storm (link farm)'
+    IE_NAME = 'MovieStorm'
+    _VALID_URL = r'http://moviestorm\.eu/view/(\d+)-watch-(.*)/season-(\d+)/episode-(\d+)'
+    _LINK_FARM = True
+
+	# There are no tests for this IE because the links on any given moviestorm
+	# page can dynamically change, and because the actual download/extraction
+	# is ultimately preformed by another IE. An example of an acceptable url to
+	# feed to this IE is: http://moviestorm.eu/view/218-watch-the-simpsons/season-26/episode-1
+    _TEST = False
+
+	# moviestorm's drupal db config is unstable at times
+    # retry up to 5 times before giving up, 5 second delay
+    # between each retry
+    retry_count = 0
+    max_retries = 5
+    retry_wait = 5
+    direct_urls = []
+
+    def _parse_target(self, target):
+        uri = compat_urlparse.urlparse(target)
+        hash = uri.fragment[1:].split('?')[0]
+        token = os.path.basename(hash.rstrip('/'))
+        return (uri, hash, token)
+
+    def _real_extract(self, url):
+        # retry loop to capture moviestorm page
+        while True:
+        	if self.retry_count == 0:
+        	    note = 'Downloading link farm page'
+        	else:
+        		note = ('Unstable db connection, retying again in %s seconds '
+        			'[%s/%s]' % (self.retry_wait, self.retry_count,
+        			self.max_retries))
+
+        	(_, _, token) = self._parse_target(url)
+        	farmpage = self._download_webpage(
+            	url, token,
+            	note=note,
+            	errnote='Unable to download link farm page',
+            	fatal=False
+        	)
+
+        	if farmpage.strip() != 'MySQL server has gone away':
+        		break
+
+        	if self.retry_count < self.max_retries:
+        		self.retry_count += 1
+        		sleep(self.retry_wait)
+        	else:
+        		msg = 'The moviestorm database is currently unstable.  Please try again later.'
+        		raise ExtractorError(msg, expected=True)
+
+        # scrape WATCH button links from moviestorm page
+        self.to_screen(': Extracting watch page urls')
+        watch_urls = MovieStormHTMLParser.extract_watch_urls(farmpage)
+
+        # get direct urls from scraped watch pages
+        self.to_screen(': Extracting direct links from watch pages')
+        for watch_url in watch_urls:
+        	(_, _, token) = self._parse_target(watch_url)
+        	watchpage = self._download_webpage(
+        		watch_url, token,
+        		note=False,
+        		errnote='Unable to download link farm watch page',
+        		fatal=False
+        	)
+
+        	if watchpage is not None:
+        		direct_url = MovieStormHTMLParser.extract_direct_url(watchpage)
+        		if direct_url:
+        			self.direct_urls.append(direct_url)
+
+        self.to_screen(': Passing off farmed links to InfoExtractors')
+        return list(set(self.direct_urls))

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -86,23 +86,23 @@ class MovieStormIE(InfoExtractor):
                     '[%s/%s]' % (self.retry_wait, self.retry_count,
                     self.max_retries))
 
-        	(_, _, token) = self._parse_target(url)
-        	farmpage = self._download_webpage(
-            	url, token,
-            	note=note,
-            	errnote='Unable to download link farm page',
-            	fatal=False
-        	)
+            (_, _, token) = self._parse_target(url)
+            farmpage = self._download_webpage(
+                url, token,
+                note=note,
+                errnote='Unable to download link farm page',
+                fatal=False
+            )
 
-        	if farmpage.strip() != 'MySQL server has gone away':
-        	    break
+            if farmpage.strip() != 'MySQL server has gone away':
+                break
 
-        	if self.retry_count < self.max_retries:
-        	    self.retry_count += 1
-        	    sleep(self.retry_wait)
-        	else:
-        	    msg = 'The moviestorm database is currently unstable.  Please try again later.'
-        	    raise ExtractorError(msg, expected=True)
+            if self.retry_count < self.max_retries:
+                self.retry_count += 1
+                sleep(self.retry_wait)
+            else:
+                msg = 'The moviestorm database is currently unstable.  Please try again later.'
+                raise ExtractorError(msg, expected=True)
 
         # scrape WATCH button links from moviestorm page
         self.to_screen(': Extracting watch page urls')

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -56,13 +56,13 @@ class MovieStormIE(InfoExtractor):
     _VALID_URL = r'http://moviestorm\.eu/view/(\d+)-watch-(.*)/season-(\d+)/episode-(\d+)'
     _LINK_FARM = True
 
-	# There are no tests for this IE because the links on any given moviestorm
-	# page can dynamically change, and because the actual download/extraction
-	# is ultimately preformed by another IE. An example of an acceptable url to
-	# feed to this IE is: http://moviestorm.eu/view/218-watch-the-simpsons/season-26/episode-1
+    # There are no tests for this IE because the links on any given moviestorm
+    # page can dynamically change, and because the actual download/extraction
+    # is ultimately preformed by another IE. An example of an acceptable url to
+    # feed to this IE is: http://moviestorm.eu/view/218-watch-the-simpsons/season-26/episode-1
     _TEST = False
 
-	# moviestorm's drupal db config is unstable at times
+    # moviestorm's drupal db config is unstable at times
     # retry up to 5 times before giving up, 5 second delay
     # between each retry
     retry_count = 0
@@ -79,12 +79,12 @@ class MovieStormIE(InfoExtractor):
     def _real_extract(self, url):
         # retry loop to capture moviestorm page
         while True:
-        	if self.retry_count == 0:
+            if self.retry_count == 0:
         	    note = 'Downloading link farm page'
         	else:
-        		note = ('Unstable db connection, retying again in %s seconds '
-        			'[%s/%s]' % (self.retry_wait, self.retry_count,
-        			self.max_retries))
+        	    note = ('Unstable db connection, retying again in %s seconds '
+        	        '[%s/%s]' % (self.retry_wait, self.retry_count,
+        	        self.max_retries))
 
         	(_, _, token) = self._parse_target(url)
         	farmpage = self._download_webpage(
@@ -95,14 +95,14 @@ class MovieStormIE(InfoExtractor):
         	)
 
         	if farmpage.strip() != 'MySQL server has gone away':
-        		break
+        	    break
 
         	if self.retry_count < self.max_retries:
-        		self.retry_count += 1
-        		sleep(self.retry_wait)
+        	    self.retry_count += 1
+        	    sleep(self.retry_wait)
         	else:
-        		msg = 'The moviestorm database is currently unstable.  Please try again later.'
-        		raise ExtractorError(msg, expected=True)
+        	    msg = 'The moviestorm database is currently unstable.  Please try again later.'
+        	    raise ExtractorError(msg, expected=True)
 
         # scrape WATCH button links from moviestorm page
         self.to_screen(': Extracting watch page urls')
@@ -111,18 +111,18 @@ class MovieStormIE(InfoExtractor):
         # get direct urls from scraped watch pages
         self.to_screen(': Extracting direct links from watch pages')
         for watch_url in watch_urls:
-        	(_, _, token) = self._parse_target(watch_url)
-        	watchpage = self._download_webpage(
-        		watch_url, token,
-        		note=False,
-        		errnote='Unable to download link farm watch page',
-        		fatal=False
+            (_, _, token) = self._parse_target(watch_url)
+            watchpage = self._download_webpage(
+                watch_url, token,
+                note=False,
+                errnote='Unable to download link farm watch page',
+                fatal=False
         	)
 
         	if watchpage is not None:
-        		direct_url = MovieStormHTMLParser.extract_direct_url(watchpage)
-        		if direct_url:
-        			self.direct_urls.append(direct_url)
+        	    direct_url = MovieStormHTMLParser.extract_direct_url(watchpage)
+        	    if direct_url:
+        	        self.direct_urls.append(direct_url)
 
         self.to_screen(': Passing off farmed links to InfoExtractors')
         return list(set(self.direct_urls))

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -30,7 +30,7 @@ class MovieStormHTMLParser(compat_html_parser.HTMLParser):
             if 'moviestorm' in attrs['href']:
                 self.watch_urls.append(attrs['href'].strip())
         elif tag == 'a' and 'class' in attrs and attrs['class'] == 'real_link':
-        	self.direct_url = attrs['href'].strip()
+            self.direct_url = attrs['href'].strip()
 
     def handle_endtag(self, tag):
         if tag == 'td':
@@ -80,11 +80,11 @@ class MovieStormIE(InfoExtractor):
         # retry loop to capture moviestorm page
         while True:
             if self.retry_count == 0:
-        	    note = 'Downloading link farm page'
-        	else:
-        	    note = ('Unstable db connection, retying again in %s seconds '
-        	        '[%s/%s]' % (self.retry_wait, self.retry_count,
-        	        self.max_retries))
+                note = 'Downloading link farm page'
+            else:
+                note = ('Unstable db connection, retying again in %s seconds '
+                    '[%s/%s]' % (self.retry_wait, self.retry_count,
+                    self.max_retries))
 
         	(_, _, token) = self._parse_target(url)
         	farmpage = self._download_webpage(

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import os.path
-import re
 from time import sleep
 
 from .common import InfoExtractor
@@ -11,6 +10,7 @@ from ..compat import (
     compat_html_parser,
     compat_urlparse
 )
+
 
 class MovieStormHTMLParser(compat_html_parser.HTMLParser):
     def __init__(self):
@@ -45,6 +45,7 @@ class MovieStormHTMLParser(compat_html_parser.HTMLParser):
         p.feed(html)
         p.close()
         return getattr(p, return_variable)
+
 
 class MovieStormIE(InfoExtractor):
     """EXTRACTOR INFO:
@@ -92,7 +93,7 @@ class MovieStormIE(InfoExtractor):
         # Inform user to provide proper moviestorm link
         if 'watch' not in url:
             msg = ('The moviestorm handler requires either a movie page link or '
-                'a series episode page link.  Please try again with one of those.')
+                   'a series episode page link.  Please try again with one of those.')
             raise ExtractorError(msg, expected=True)
 
         while True:
@@ -100,8 +101,8 @@ class MovieStormIE(InfoExtractor):
                 note = 'Downloading link farm page'
             else:
                 note = ('Unstable db connection, retying again in %s seconds '
-                    '[%s/%s]' % (self.retry_wait, self.retry_count,
-                    self.max_retries))
+                        '[%s/%s]' % (self.retry_wait, self.retry_count,
+                                     self.max_retries))
 
             (_, _, token) = self._parse_target(url)
             farmpage = self._download_webpage(
@@ -120,7 +121,7 @@ class MovieStormIE(InfoExtractor):
                 # Fail if provided series home page
                 if series_home_page:
                     msg = ('It looks like you provided an show page url.  You must provide '
-                        'an episode page url or movie page url')
+                           'an episode page url or movie page url')
                     raise ExtractorError(msg, expected=True)
 
                 # Success

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -17,6 +17,7 @@ class MovieStormHTMLParser(compat_html_parser.HTMLParser):
         self.found_button = False
         self.watch_urls = []
         self.direct_url = False
+        self.series_home_page = False
         compat_html_parser.HTMLParser.__init__(self)
 
     def handle_starttag(self, tag, attrs):
@@ -24,7 +25,7 @@ class MovieStormHTMLParser(compat_html_parser.HTMLParser):
         if tag == 'td' and attrs['class'] == 'link_td':
             self.found_button = True
         elif tag == 'a' and self.found_button:
-            # suppress ishare and other direct links, can't handle now
+            # Suppress ishare and other direct links, can't handle now
             if 'moviestorm' in attrs['href']:
                 self.watch_urls.append(attrs['href'].strip())
         elif tag == 'a' and 'class' in attrs and attrs['class'] == 'real_link':
@@ -34,35 +35,47 @@ class MovieStormHTMLParser(compat_html_parser.HTMLParser):
         if tag == 'td':
             self.found_button = False
 
-    @classmethod
-    def extract_watch_urls(cls, html):
-        p = cls()
-        p.feed(html)
-        p.close()
-        return p.watch_urls
+    def handle_data(self, data):
+        if data.strip() == 'SHOW EPISODES':
+            self.series_home_page = True
 
     @classmethod
-    def extract_direct_url(cls, html):
+    def custom_parse(cls, html, return_variable):
         p = cls()
         p.feed(html)
         p.close()
-        return p.direct_url
+        return getattr(p, return_variable)
 
 class MovieStormIE(InfoExtractor):
-    IE_DESC = 'Movie Storm (link farm)'
-    IE_NAME = 'MovieStorm'
-    _VALID_URL = r'http://moviestorm\.eu/view/(\d+)-watch-(.*)/season-(\d+)/episode-(\d+)'
-    _LINK_FARM = True
-
+    # HANDLER INFO:
     # There are no tests for this IE because the links on any given moviestorm
     # page can dynamically change, and because the actual download/extraction
-    # is ultimately preformed by another IE. An example of an acceptable url to
-    # feed to this IE is: http://moviestorm.eu/view/218-watch-the-simpsons/season-26/episode-1
+    # is ultimately preformed by another IE. Example urls to
+    # feed to this IE are:
+    #
+    #   EPISODE: http://moviestorm.eu/view/5821-watch-portlandia/season-1/episode-1
+    #   MOVIE:   http://moviestorm.eu/view/5269-watch-taken-3-online.html
+    #
+    # If the user provides a series url, like the one below, this IE should detect
+    # and raise an error:
+    #
+    #   SERIES:  http://moviestorm.eu/view/5821-watch-portlandia.html
+    #
+    # In other news, moviestorm's drupal db config is unstable at times retry up to 5
+    # times before giving up, waiting 5 second delay between each retry.
+    #
+    # Also, this IE will catch all links with http://moviestorm.eu urls. If it's an
+    # un-handleable url, an error will be thrown informing the user of appropriate
+    # urls to provide. Not using a more complex regex is meant to prevent unacceptable
+    # moviestorm urls from falling back into the generic IE, as that will always fail on
+    # moviestorm links.
+
+    IE_DESC = 'Movie Storm (link farm)'
+    IE_NAME = 'MovieStorm'
+    _VALID_URL = r'http://moviestorm\.eu'
+    _LINK_FARM = True
     _TEST = False
 
-    # moviestorm's drupal db config is unstable at times
-    # retry up to 5 times before giving up, 5 second delay
-    # between each retry
     retry_count = 0
     max_retries = 5
     retry_wait = 5
@@ -75,7 +88,12 @@ class MovieStormIE(InfoExtractor):
         return (uri, hash, token)
 
     def _real_extract(self, url):
-        # retry loop to capture moviestorm page
+        # Inform user to provide proper moviestorm link
+        if 'watch' not in url:
+            msg = ('The moviestorm handler requires either a movie page link or '
+                'a series episode page link.  Please try again with one of those.')
+            raise ExtractorError(msg, expected=True)
+
         while True:
             if self.retry_count == 0:
                 note = 'Downloading link farm page'
@@ -93,8 +111,21 @@ class MovieStormIE(InfoExtractor):
             )
 
             if farmpage.strip() != 'MySQL server has gone away':
+                series_home_page = MovieStormHTMLParser.custom_parse(
+                    farmpage,
+                    'series_home_page'
+                )
+
+                # Fail if provided series home page
+                if series_home_page:
+                    msg = ('It looks like you provided an show page url.  You must provide '
+                        'an episode page url or movie page url')
+                    raise ExtractorError(msg, expected=True)
+
+                # Success
                 break
 
+            # Continue retrying if moviestorm database is currently unstable
             if self.retry_count < self.max_retries:
                 self.retry_count += 1
                 sleep(self.retry_wait)
@@ -102,25 +133,39 @@ class MovieStormIE(InfoExtractor):
                 msg = 'The moviestorm database is currently unstable.  Please try again later.'
                 raise ExtractorError(msg, expected=True)
 
-        # scrape WATCH button links from moviestorm page
+        # Scrape WATCH button links from moviestorm page
         self.to_screen(': Extracting watch page urls')
-        watch_urls = MovieStormHTMLParser.extract_watch_urls(farmpage)
+        watch_urls = MovieStormHTMLParser.custom_parse(
+            farmpage,
+            'watch_urls'
+        )
 
-        # get direct urls from scraped watch pages
+        # Get direct urls from scraped watch pages
         self.to_screen(': Extracting direct links from watch pages')
-        for watch_url in watch_urls:
-            (_, _, token) = self._parse_target(watch_url)
-            watchpage = self._download_webpage(
-                watch_url, token,
-                note=False,
-                errnote='Unable to download link farm watch page',
-                fatal=False
-            )
+        direct_url_count = 1
 
-            if watchpage is not None:
-                direct_url = MovieStormHTMLParser.extract_direct_url(watchpage)
-                if direct_url:
-                    self.direct_urls.append(direct_url)
+        for watch_url in watch_urls:
+            # Stop after gathering 50 urls, moviestorm sends 503 if
+            # request too many in rapid succession
+            if direct_url_count < 50:
+                (_, _, token) = self._parse_target(watch_url)
+                watchpage = self._download_webpage(
+                    watch_url, token,
+                    note=False,
+                    errnote='Unable to download link farm watch page',
+                    fatal=False
+                )
+
+                if watchpage is not None:
+                    direct_url = MovieStormHTMLParser.custom_parse(
+                        watchpage,
+                        'direct_url'
+                    )
+
+                    if direct_url:
+                        self.direct_urls.append(direct_url)
+
+            direct_url_count += 1
 
         self.to_screen(': Passing off farmed links to InfoExtractors')
         return list(set(self.direct_urls))

--- a/youtube_dl/extractor/moviestorm.py
+++ b/youtube_dl/extractor/moviestorm.py
@@ -82,6 +82,7 @@ class MovieStormIE(InfoExtractor):
     max_retries = 5
     retry_wait = 5
     direct_urls = []
+    direct_url_max = 50
 
     def _parse_target(self, target):
         uri = compat_urlparse.urlparse(target)
@@ -149,7 +150,7 @@ class MovieStormIE(InfoExtractor):
         for watch_url in watch_urls:
             # Stop after gathering 50 urls, moviestorm sends 503 if
             # request too many in rapid succession
-            if direct_url_count < 50:
+            if direct_url_count < self.direct_url_max:
                 (_, _, token) = self._parse_target(watch_url)
                 watchpage = self._download_webpage(
                     watch_url, token,


### PR DESCRIPTION
The moviestorm InfoExtractor is unique when compared to the other extractors in that it is designed to handle a link farm page, moviestorm.eu pages to be specific.  The handler performs some basic web scraping to pull a list of up to 50 external links ('direct_urls') from the given moviestorm page.  It is currently limited to pulling 50 links, as moviestorm throttles user access after making 50+ rapid succession requests, at which point it starts returning 503 responses.

After scraping the direct_urls, MovieStormIE returns the list back to its parent YoutubeDL object.  I have added a check to the YoutubeDL object that, before proceeding with any IE's response, checks to see if that IE is a link farm IE by checking if said IE has a _LINK_FARM variable defined and set to True.  Right now moviestorm is the only link farm IE, but hopefully there will be more soon that can use this basic framework, which we can identify with _LINK_FARM = True.

When YoutubeDL knows its dealing with a response from a link farm extractor, it passes the extractor's result to a new 'process_farmed_links' method that I added to the YoutubeDL object.  This method basically combs through the list and weeds out any urls that cannot be handled by one of youtube-dl's various extractors.  Then, the method loops over that culled list and feeds the urls to their corresponding extractor.  If the extractor succeeds in downloading the resource, the process ends when the download is complete.  If, however, the extractor fails on the provided link (sometimes bad links are submitted it moviestorm, or sometimes they are old), the process_farmed_links method reports an error about the failure, then moves on to the next link in the culled list, passing it off to its corresponding handler, and so on.

I've outlined some info in the MovieStormIE docstring.  But basically, there are two types of moviestorm links that can work here, a movie page, or an episode page.  Since the generic extractor will always fail on any moviestorm link, I've made MovieStormIE._VALID_URL extremely greedy.  It will pull in any http://moviestorm.eu links, as falling back to generic on them will fail, and it does some checking afterwards.  If the extractor notices that the link is not an episode or movie page, it raises an error informing the user what went wrong and what type of moviestorm links are valid to process.  Here are some example links:

    [GOOD: movie page]     http://moviestorm.eu/view/5269-watch-taken-3-online.html
    [GOOD: episode page]  http://moviestorm.eu/view/5821-watch-portlandia/season-1/episode-1
    [BAD: series page]         http://moviestorm.eu/view/5821-watch-portlandia.html

The extractor does not currently attempt to handle a series page because there are many episodes therein, and there is no way to know which one the user wants.  If it seems like a good idea to everyone else, there could be future development done to allow the extractor to handle to series page and attempt to download all episodes available, kind of like a youtube playlist.  This might be a bit more complicated, but I don't see why it wouldn't be be do-able.

I think it would be nice to add similar link farm handlers for other sites.  Moviestorm.eu is nice because of its structure where all links are listed on a single page, and the content is quote-un-quote guaranteed.  alluc.to is also a nice link farm, but scraping their search result page could suck in results that aren't what the user is looking for.  If other's know of sites similar in format to moviestorm where links are cleanly structured by series/episode, I'm all ears.

One last note.  It seems like the folks at moviestorm might have a funky drupal configuration, as every now and then when you try to load a series page or episode page, you will get a blank page with 'MySQL server has gone away' as the only response.  The MovieStormIE extractor currently detects this and will wait 5 seconds, then try again.  It will attempt 5 retries.  If all of those fail, it will give up and inform the user of what's up.  That MySQL response is a bit flakey and sometimes moviestorm will return that, but simply refreshing the page a few times in a browser (or having the extractor retry) gets around the error.  Some pages seem to exhibit the issue more frequently than others.  I've noticed it as particularly prevent on the Simpsons series page (http://moviestorm.eu/view/218-watch-the-simpsons.html) and its subsequent episode pages.  The issue is worse on some days/times than others, but over the past few weeks regular business hours EST seem to be the worst.