### PR TITLE
[niconico] fixed bug for nm URLs when logged in

### DIFF
--- a/youtube_dl/extractor/niconico.py
+++ b/youtube_dl/extractor/niconico.py
@@ -89,7 +89,7 @@ class NiconicoIE(InfoExtractor):
         if self._AUTHENTICATED:
             # Get flv info
             flv_info_webpage = self._download_webpage(
-                'http://flapi.nicovideo.jp/api/getflv?v=' + video_id,
+                'http://flapi.nicovideo.jp/api/getflv/' + video_id + '?as3=1',
                 video_id, 'Downloading flv info')
         else:
             # Get external player info
@@ -97,7 +97,6 @@ class NiconicoIE(InfoExtractor):
                 'http://ext.nicovideo.jp/thumb_watch/' + video_id, video_id)
             thumb_play_key = self._search_regex(
                 r'\'thumbPlayKey\'\s*:\s*\'(.*?)\'', ext_player_info, 'thumbPlayKey')
-
             # Get flv info
             flv_info_data = compat_urllib_parse.urlencode({
                 'k': thumb_play_key,

--- a/youtube_dl/extractor/niconico.py
+++ b/youtube_dl/extractor/niconico.py
@@ -97,6 +97,7 @@ class NiconicoIE(InfoExtractor):
                 'http://ext.nicovideo.jp/thumb_watch/' + video_id, video_id)
             thumb_play_key = self._search_regex(
                 r'\'thumbPlayKey\'\s*:\s*\'(.*?)\'', ext_player_info, 'thumbPlayKey')
+
             # Get flv info
             flv_info_data = compat_urllib_parse.urlencode({
                 'k': thumb_play_key,


### PR DESCRIPTION
You couldn't download *nm* URL videos when you authenticated (you were able to when *not* authenticated)
I changed the download URL a bit; It shouldn't affect other than *nm* URLs.

for test
- *sm* URLs
http://www.nicovideo.jp/watch/sm25798024

- *nm* URLs
http://www.nicovideo.jp/watch/nm14296458