### PR TITLE
Add support for QQ music

### DIFF
--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -384,7 +384,10 @@ from .promptfile import PromptFileIE
 from .prosiebensat1 import ProSiebenSat1IE
 from .puls4 import Puls4IE
 from .pyvideo import PyvideoIE
-from .qqmusic import QQMusicIE
+from .qqmusic import (
+    QQMusicIE,
+    QQMusicSingerIE
+)
 from .quickvid import QuickVidIE
 from .r7 import R7IE
 from .radiode import RadioDeIE

--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -384,6 +384,7 @@ from .promptfile import PromptFileIE
 from .prosiebensat1 import ProSiebenSat1IE
 from .puls4 import Puls4IE
 from .pyvideo import PyvideoIE
+from .qqmusic import QQMusicIE
 from .quickvid import QuickVidIE
 from .r7 import R7IE
 from .radiode import RadioDeIE

--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -386,7 +386,8 @@ from .puls4 import Puls4IE
 from .pyvideo import PyvideoIE
 from .qqmusic import (
     QQMusicIE,
-    QQMusicSingerIE
+    QQMusicSingerIE,
+    QQMusicAlbumIE,
 )
 from .quickvid import QuickVidIE
 from .r7 import R7IE

--- a/youtube_dl/extractor/qqmusic.py
+++ b/youtube_dl/extractor/qqmusic.py
@@ -1,12 +1,11 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import random
+import time
+
 from .common import InfoExtractor
 from ..utils import strip_jsonp
-
-# guid is a random number generated in javascript, but seems a fixed number
-# also works
-guid = '1'
 
 
 class QQMusicIE(InfoExtractor):
@@ -22,6 +21,13 @@ class QQMusicIE(InfoExtractor):
             'creator': '林俊杰',
         }
     }]
+
+    # Reference: m_r_GetRUin() in top_player.js
+    # http://imgcache.gtimg.cn/music/portal_v3/y/top_player.js
+    @staticmethod
+    def m_r_get_ruin():
+        curMs = int(time.time() * 1000) % 1000
+        return int(round(random.random() * 2147483647) * curMs % 1E10)
 
     def _real_extract(self, url):
         mid = self._match_id(url)
@@ -40,6 +46,8 @@ class QQMusicIE(InfoExtractor):
 
         singer = self._html_search_regex(
             r"singer:\s*'([^']+)", detail_info_page, 'singer')
+
+        guid = self.m_r_get_ruin()
 
         vkey = self._download_json(
             'http://base.music.qq.com/fcgi-bin/fcg_musicexpress.fcg?json=3&guid=%s' % guid,

--- a/youtube_dl/extractor/qqmusic.py
+++ b/youtube_dl/extractor/qqmusic.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import strip_jsonp
+
+# guid is a random number generated in javascript, but seems a fixed number
+# also works
+guid = '1'
+
+
+class QQMusicIE(InfoExtractor):
+    _VALID_URL = r'http://y.qq.com/#type=song&mid=(?P<id>[0-9A-Za-z]+)'
+    _TESTS = [{
+        'url': 'http://y.qq.com/#type=song&mid=004295Et37taLD',
+        'md5': 'bed90b6db2a7a7a7e11bc585f471f63a',
+        'info_dict': {
+            'id': '004295Et37taLD',
+            'ext': 'm4a',
+            'title': '可惜没如果',
+            'upload_date': '20141227',
+            'creator': '林俊杰',
+        }
+    }]
+
+    def _real_extract(self, url):
+        mid = self._match_id(url)
+
+        detail_info_page = self._download_webpage(
+            'http://s.plcloud.music.qq.com/fcgi-bin/fcg_yqq_song_detail_info.fcg?songmid=%s&play=0' % mid,
+            mid, note='Download sont detail info',
+            errnote='Unable to get song detail info')
+
+        song_name = self._html_search_regex(
+            r"songname:\s*'([^']+)'", detail_info_page, 'song name')
+
+        publish_time = self._html_search_regex(
+            r'发行时间：(\d{4}-\d{2}-\d{2})', detail_info_page,
+            'publish time').replace('-', '')
+
+        singer = self._html_search_regex(
+            r"singer:\s*'([^']+)", detail_info_page, 'singer')
+
+        vkey = self._download_json(
+            'http://base.music.qq.com/fcgi-bin/fcg_musicexpress.fcg?json=3&guid=%s' % guid,
+            mid, note='Retrieve vkey', errnote='Unable to get vkey',
+            transform_source=strip_jsonp)['key']
+        song_url = 'http://cc.stream.qqmusic.qq.com/C200%s.m4a?vkey=%s&guid=%s&fromtag=0' % (mid, vkey, guid)
+
+        return {
+            'id': mid,
+            'url': song_url,
+            'title': song_name,
+            'upload_date': publish_time,
+            'creator': singer,
+        }

--- a/youtube_dl/extractor/qqmusic.py
+++ b/youtube_dl/extractor/qqmusic.py
@@ -24,7 +24,7 @@ class QQMusicIE(InfoExtractor):
             'title': '可惜没如果',
             'upload_date': '20141227',
             'creator': '林俊杰',
-            'description': 'md5:242c97c2847e0495583b7b13764f7106',
+            'description': 'md5:4348ff1dd24036906baa7b6f973f8d30',
         }
     }]
 
@@ -41,7 +41,7 @@ class QQMusicIE(InfoExtractor):
         detail_info_page = self._download_webpage(
             'http://s.plcloud.music.qq.com/fcgi-bin/fcg_yqq_song_detail_info.fcg?songmid=%s&play=0' % mid,
             mid, note='Download song detail info',
-            errnote='Unable to get song detail info')
+            errnote='Unable to get song detail info', encoding='gbk')
 
         song_name = self._html_search_regex(
             r"songname:\s*'([^']+)'", detail_info_page, 'song name')

--- a/youtube_dl/extractor/qqmusic.py
+++ b/youtube_dl/extractor/qqmusic.py
@@ -24,6 +24,7 @@ class QQMusicIE(InfoExtractor):
             'title': '可惜没如果',
             'upload_date': '20141227',
             'creator': '林俊杰',
+            'description': 'md5:242c97c2847e0495583b7b13764f7106',
         }
     }]
 
@@ -47,10 +48,16 @@ class QQMusicIE(InfoExtractor):
 
         publish_time = self._html_search_regex(
             r'发行时间：(\d{4}-\d{2}-\d{2})', detail_info_page,
-            'publish time').replace('-', '')
+            'publish time', default=None)
+        if publish_time:
+            publish_time = publish_time.replace('-', '')
 
         singer = self._html_search_regex(
-            r"singer:\s*'([^']+)", detail_info_page, 'singer')
+            r"singer:\s*'([^']+)", detail_info_page, 'singer', default=None)
+
+        lrc_content = self._html_search_regex(
+            r'<div class="content" id="lrc_content"[^<>]*>([^<>]+)</div>',
+            detail_info_page, 'LRC lyrics', default=None)
 
         guid = self.m_r_get_ruin()
 
@@ -66,6 +73,7 @@ class QQMusicIE(InfoExtractor):
             'title': song_name,
             'upload_date': publish_time,
             'creator': singer,
+            'description': lrc_content,
         }
 
 
@@ -74,10 +82,6 @@ class QQPlaylistBaseIE(InfoExtractor):
     def qq_static_url(category, mid):
         return 'http://y.qq.com/y/static/%s/%s/%s/%s.html' % (category, mid[-2], mid[-1], mid)
 
-    @staticmethod
-    def qq_song_url(mid):
-        return 'http://y.qq.com/#type=song&mid=%s' % mid
-
     @classmethod
     def get_entries_from_page(cls, page):
         entries = []
@@ -85,7 +89,8 @@ class QQPlaylistBaseIE(InfoExtractor):
         for item in re.findall(r'class="data"[^<>]*>([^<>]+)</', page):
             song_mid = unescapeHTML(item).split('|')[-5]
             entries.append(cls.url_result(
-                cls.qq_song_url(song_mid), 'QQMusic', song_mid))
+                'http://y.qq.com/#type=song&mid=' + song_mid, 'QQMusic',
+                song_mid))
 
         return entries
 


### PR DESCRIPTION
Brief: y.qq.com is a Chinese music publishing platform.

In this PR, I add an ```encoding``` parameter to all ```_download_*``` helper functions in extractor/common.py so that an info extractor can specify an encoding for a specific page. In QQMusic, ```detail_info_page``` is marked as gb2312 (through ```<meta charset="gb2312" />```), but it's actually gbk, a superset of gb2312. Without explicitly specified encodings, the ```description``` field in the info dict is different in python 2 and python 3, where both incorrect. I'm not sure if it's the best implementation. If there's a better one, please replace it.

Another issue is legality. According to news listed in references[1][2], I have a strong belief that Tancent (the company behind y.qq.com) has legal rights over the songs it distributes. In the browser, these songs are only available in China, but the mechanism for checking geolocation is separated from the retrieval of song URLs. As a result, songs from y.qq.com can be downloaded without specifying ```--proxy``` or ```--cn-verification-proxy```.

[1] http://www.wsj.com/articles/warner-music-tencent-in-china-distribution-deal-1415869222
[2] http://www.reuters.com/article/2014/12/16/us-tencent-sony-music-idUSKBN0JU0UN20141216