### PR TITLE
ensure that the bitrate is always an integer

### DIFF
--- a/youtube_dl/extractor/prosiebensat1.py
+++ b/youtube_dl/extractor/prosiebensat1.py
@@ -280,7 +280,7 @@ class ProSiebenSat1IE(InfoExtractor):
                     'play_path': mobj.group('playpath'),
                     'player_url': 'http://livepassdl.conviva.com/hf/ver/2.79.0.17083/LivePassModuleMain.swf',
                     'page_url': 'http://www.prosieben.de',
-                    'vbr': fix_bitrate(source['bitrate']),
+                    'vbr': fix_bitrate(int(source['bitrate'])),
                     'ext': 'mp4',
                     'format_id': '%s_%s' % (source['cdn'], source['bitrate']),
                 })


### PR DESCRIPTION
This fixes Pro7 for newer episodes of "Germany's Next Topmodel" like the following:

http://www.prosieben.de/tv/germanys-next-topmodel/video/108-episode-8-unter-wasser-teil-1-ganze-folge
http://www.prosieben.de/tv/germanys-next-topmodel/video/108-episode-8-unter-wasser-teil-2-ganze-folge

The error was:

user@host$ ./youtube-dl http://www.prosieben.de/tv/germanys-next-topmodel/video/108-episode-8-unter-wasser-teil-2-ganze-folge
[prosiebensat1] tv/germanys-next-topmodel/video/108-episode-8-unter-wasser-teil-2-ganze-folge: Downloading webpage
[prosiebensat1] 3753379: Downloading videos JSON
[prosiebensat1] 3753379: Downloading sources JSON
[prosiebensat1] 3753379: Downloading urls JSON
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "./youtube-dl/__main__.py", line 19, in <module>
  File "./youtube-dl/youtube_dl/__init__.py", line 389, in main
  File "./youtube-dl/youtube_dl/__init__.py", line 379, in _real_main
  File "./youtube-dl/youtube_dl/YoutubeDL.py", line 1441, in download
  File "./youtube-dl/youtube_dl/YoutubeDL.py", line 643, in extract_info
  File "./youtube-dl/youtube_dl/extractor/common.py", line 275, in extract
  File "./youtube-dl/youtube_dl/extractor/prosiebensat1.py", line 329, in _real_extract
  File "./youtube-dl/youtube_dl/extractor/prosiebensat1.py", line 283, in _extract_clip
  File "./youtube-dl/youtube_dl/extractor/prosiebensat1.py", line 269, in fix_bitrate
TypeError: not all arguments converted during string formatting
