### PR TITLE
[ffmpeg] adding exception catching for call to os.utime in run_ffmpeg_multiple_files

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -146,7 +146,11 @@ class FFmpegPostProcessor(PostProcessor):
             stderr = stderr.decode('utf-8', 'replace')
             msg = stderr.strip().split('\n')[-1]
             raise FFmpegPostProcessorError(msg)
-        os.utime(encodeFilename(out_path), (oldest_mtime, oldest_mtime))
+        try:
+            os.utime(encodeFilename(out_path), (oldest_mtime, oldest_mtime))
+        except Exception:
+            self._downloader.report_warning('Cannot update utime of file')
+
         if self._deletetempfiles:
             for ipath in input_paths:
                 os.remove(ipath)


### PR DESCRIPTION
Related to previous pull request.
https://github.com/rg3/youtube-dl/pull/5241

Debian running on Android VM, downloads video fine. When extracting audio to mp3 and calling ffmpeg, postprocessor/ffmpeg.py calls os.utime, which is not permitted under the sandboxed app.


Latest mainline verbose output

[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'--extract-audio', u'--audio-format', u'mp3', u'-k', u'-a', u'/sdcard/clipboard', u'--verbose']
[debug] Batch file urls: [u'http://youtu.be/teGhgwGq2hc']
[debug] Encodings: locale UTF-8, fs UTF-8, out None, pref UTF-8
[debug] youtube-dl version 2015.04.03
[debug] Python version 2.7.3 - Linux-3.4.42-gb89c9dd-armv7l-with-debian-7.5
[debug] exe versions: avconv 10.1-6, avprobe 10.1-6, ffmpeg 0.8.17-6
[debug] Proxy map: {}
[youtube] teGhgwGq2hc: Downloading webpage
[youtube] teGhgwGq2hc: Extracting video information
[youtube] {43} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {18} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {5} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {36} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {17} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {135} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {244} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {134} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {243} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {133} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {242} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {160} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {140} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] {171} signature length 41.40, html5 player en_US-vfl20EdcH
[youtube] teGhgwGq2hc: Downloading DASH manifest
[debug] Invoking downloader on u'https://r1---sn-cn3tc-ac5s.googlevideo.com/videoplayback?itag=18&key=yt5&ratebypass=yes&upn=SRVYcbR0f5o&source=youtube&expire=1428456248&sparams=dur%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Cmime%2Cmm%2Cms%2Cmv%2Cpl%2Cratebypass%2Crequiressl%2Csource%2Cupn%2Cexpire&fexp=900720%2C906220%2C907263%2C916632%2C932631%2C934954%2C9407002%2C9408033%2C9408090%2C9408102%2C9408474%2C947243%2C948124%2C948703%2C951703%2C952612%2C957201%2C961404%2C961406%2C963201%2C964605%2C966201&sver=3&initcwndbps=1266250&dur=232.501&ms=au&mv=m&mt=1428434497&requiressl=yes&ip=90.213.214.111&ipbits=0&pl=22&id=o-AEt3aBG1b0jO0pKdLnSGDssrxzuLC13BORwF5PqjeWQb&mime=video%2Fmp4&mm=31&signature=72397AF4B692E6F3294FE583EF283CD152CC3290.BEE6209A2F7A6EE10DAF587DDCD6C99AEB63F999'
[download] Destination: Skuff And Inja - United Kingdom-teGhgwGq2hc.mp4

[download] 0.0% of 5.53MiB at 72.76KiB/s ETA 01:18
[download] 0.1% of 5.53MiB at 189.96KiB/s ETA 00:30
[download] 0.1% of 5.53MiB at 409.26KiB/s ETA 00:13
[download] 0.3% of 5.53MiB at 313.04KiB/s ETA 00:18
[download] 0.5% of 5.53MiB at 508.85KiB/s ETA 00:11
[download] 1.1% of 5.53MiB at 432.21KiB/s ETA 00:12
[download] 2.2% of 5.53MiB at 423.30KiB/s ETA 00:13
[download] 4.5% of 5.53MiB at 373.50KiB/s ETA 00:14
[download] 9.0% of 5.53MiB at 429.25KiB/s ETA 00:11
[download] 17.9% of 5.53MiB at 279.93KiB/s ETA 00:16
[download] 22.4% of 5.53MiB at 347.57KiB/s ETA 00:12
[download] 31.3% of 5.53MiB at 327.53KiB/s ETA 00:11
[download] 36.3% of 5.53MiB at 330.83KiB/s ETA 00:10
[download] 42.6% of 5.53MiB at 342.78KiB/s ETA 00:09
[download] 50.3% of 5.53MiB at 354.10KiB/s ETA 00:07
[download] 57.9% of 5.53MiB at 362.81KiB/s ETA 00:06
[download] 65.6% of 5.53MiB at 369.98KiB/s ETA 00:05
[download] 73.2% of 5.53MiB at 374.46KiB/s ETA 00:04
[download] 80.6% of 5.53MiB at 378.66KiB/s ETA 00:02
[download] 88.1% of 5.53MiB at 333.35KiB/s ETA 00:02
[download] 91.9% of 5.53MiB at 272.70KiB/s ETA 00:01
[download] 93.8% of 5.53MiB at 278.16KiB/s ETA 00:01
[download] 97.6% of 5.53MiB at 289.07KiB/s ETA 00:00
[download] 100.0% of 5.53MiB at 296.12KiB/s ETA 00:00
[download] 100% of 5.53MiB in 00:19
[debug] avconv command line: avprobe -show_streams 'Skuff And Inja - United Kingdom-teGhgwGq2hc.mp4'
[avconv] Destination: Skuff And Inja - United Kingdom-teGhgwGq2hc.mp3
[debug] ffmpeg command line: avconv -y -i 'Skuff And Inja - United Kingdom-teGhgwGq2hc.mp4' -vn -acodec libmp3lame -q:a 5 'Skuff And Inja - United Kingdom-teGhgwGq2hc.mp3'
ERROR: error running avconv
Traceback (most recent call last):
File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 1487, in post_process
keep_video_wish, info = pp.run(info)
File "/usr/local/bin/youtube-dl/youtube_dl/postprocessor/ffmpeg.py", line 279, in run
raise PostProcessingError('error running ' + self.basename)
PostProcessingError