### PR TITLE
fix (workaround) not well-formed xml error

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -930,7 +930,10 @@ class GenericIE(InfoExtractor):
                 urlrs, playlist_id=video_id, playlist_title=video_title)
 
         # Look for BrightCove:
-        bc_urls = BrightcoveIE._extract_brightcove_urls(webpage)
+        try:
+            bc_urls = BrightcoveIE._extract_brightcove_urls(webpage)
+        except:
+            bc_urls = None
         if bc_urls:
             self.to_screen('Brightcove video detected.')
             entries = [{


### PR DESCRIPTION
This command: youtube-dl http://www.stern.de/wissen/natur/anhaengliches-reptil-wasserschildkroete-rueckt-taucher-nicht-von-der-pelle-2186820.html
errors out with:
[...]
  File "C:\dev\Anaconda3\lib\site-packages\youtube_dl-2015.4.9-py3.4.egg\youtube_dl\extractor\generic.py", line 933, in _real_extract
    bc_urls = BrightcoveIE._extract_brightcove_urls(webpage)
  File "C:\dev\Anaconda3\lib\site-packages\youtube_dl-2015.4.9-py3.4.egg\youtube_dl\extractor\brightcove.py", line 188, in _extract_brightcove_urls
    return [cls._build_brighcove_url(m) for m in matches]
  File "C:\dev\Anaconda3\lib\site-packages\youtube_dl-2015.4.9-py3.4.egg\youtube_dl\extractor\brightcove.py", line 188, in <listcomp>
    return [cls._build_brighcove_url(m) for m in matches]
  File "C:\dev\Anaconda3\lib\site-packages\youtube_dl-2015.4.9-py3.4.egg\youtube_dl\extractor\brightcove.py", line 120, in _build_brighcove_url
    object_doc = xml.etree.ElementTree.fromstring(object_str.encode('utf-8'))
  File "C:\dev\Anaconda3\lib\xml\etree\ElementTree.py", line 1325, in XML
    parser.feed(text)
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 26, column 41

This PR "fixes" this error and allows to download the video.