### PR TITLE
[bandcamp] fix video_id parsing

### DIFF
--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -72,7 +72,7 @@ class BandcampIE(InfoExtractor):
 
         download_link = m_download.group(1)
         video_id = self._search_regex(
-            r'(?ms)var TralbumData = {.*?id: (?P<id>\d+),?$',
+            r'(?ms)var TralbumData = .*?[{,]\s*id: (?P<id>\d+),?$',
             webpage, 'video id')
 
         download_webpage = self._download_webpage(download_link, video_id, 'Downloading free downloads page')


### PR DESCRIPTION
Hi,
this should fix https://github.com/rg3/youtube-dl/issues/4861
The problem was that the regex stopped at the first occurrence of id:, which could be art_id: for example.