### PR TITLE
[hitbox] Extractor parses valid url now

### DIFF
--- a/youtube_dl/extractor/hitbox.py
+++ b/youtube_dl/extractor/hitbox.py
@@ -97,7 +97,7 @@ class HitboxIE(InfoExtractor):
             video_id)
 
         clip = player_config.get('clip')
-        video_url = clip.get('url')
+        video_url = clip.get('bitrates', [])[0].get('url')
         res = clip.get('bitrates', [])[0].get('label')
 
         metadata['resolution'] = res


### PR DESCRIPTION
On master, it seems the hitbox VOD extractor is returning an invalid URL which cannot be downloaded (returns a 404). To reproduce, try to hit a hitbox VOD with youtube-dl. For instance, youtube-dl http://www.hitbox.tv/video/495145.

Looks like the extractor is only getting a path and not a full URL from the config JSON. Included is a simple one-line fix that uses the same logic that is currently grabbing the resolution.