### PR TITLE
Get audio first when downloading DASH media

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1116,7 +1116,7 @@ class YoutubeDL(object):
                                 if self.params.get('merge_output_format') is None
                                 else self.params['merge_output_format'])
                             selected_format = {
-                                'requested_formats': formats_info,
+                                'requested_formats': (formats_info[1], formats_info[0]),
                                 'format': '%s+%s' % (formats_info[0].get('format'),
                                                      formats_info[1].get('format')),
                                 'format_id': '%s+%s' % (formats_info[0].get('format_id'),

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -584,7 +584,7 @@ class FFmpegMergerPP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
-        args = ['-c', 'copy', '-map', '0:v:0', '-map', '1:a:0']
+        args = ['-c', 'copy', '-map', '1:v:0', '-map', '0:a:0']
         self._downloader.to_screen('[ffmpeg] Merging formats into "%s"' % filename)
         self.run_ffmpeg_multiple_files(info['__files_to_merge'], temp_filename, args)
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))


### PR DESCRIPTION
The reason is twofold: audio data is usually smaller (more "dense", i.e. has a higher bitrate), and often more important than video data (e.g. when downloading talk show episodes). A partial audio download is therefore usually more useful, as in the same amount of time youtube-dl could capture a larger timeslice of a more valuable part of the media stream.

All of this matters little for a completed download, of course.