### PR TITLE
Allow downloading DASH streams in any order

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1105,32 +1105,31 @@ class YoutubeDL(object):
                         formats_info = (self.select_format(format_1, formats),
                                         self.select_format(format_2, formats))
                         if all(formats_info):
-                            # The first format must contain the video and the
-                            # second the audio
-                            if formats_info[0].get('vcodec') == 'none':
-                                self.report_error('The first format must '
-                                                  'contain the video, try using '
-                                                  '"-f %s+%s"' % (format_2, format_1))
+                            try:
+                                vfmtinfo = [fmt for fmt in formats_info if fmt.get('vcodec') != 'none'][0]
+                                afmtinfo = [fmt for fmt in formats_info if fmt.get('acodec') != 'none'][0]
+                            except IndexError:
+                                self.report_error('You must specify a single video format and a single audio format')
                                 return
-                            output_ext = (
-                                formats_info[0]['ext']
-                                if self.params.get('merge_output_format') is None
-                                else self.params['merge_output_format'])
+
+                            output_ext = self.params.get('merge_output_format')
+                            if output_ext is None:
+                                output_ext = vfmtinfo['ext']
                             selected_format = {
                                 'requested_formats': formats_info,
-                                'format': '%s+%s' % (formats_info[0].get('format'),
-                                                     formats_info[1].get('format')),
-                                'format_id': '%s+%s' % (formats_info[0].get('format_id'),
-                                                        formats_info[1].get('format_id')),
-                                'width': formats_info[0].get('width'),
-                                'height': formats_info[0].get('height'),
-                                'resolution': formats_info[0].get('resolution'),
-                                'fps': formats_info[0].get('fps'),
-                                'vcodec': formats_info[0].get('vcodec'),
-                                'vbr': formats_info[0].get('vbr'),
-                                'stretched_ratio': formats_info[0].get('stretched_ratio'),
-                                'acodec': formats_info[1].get('acodec'),
-                                'abr': formats_info[1].get('abr'),
+                                'format': '%s+%s' % (vfmtinfo.get('format'),
+                                                     afmtinfo.get('format')),
+                                'format_id': '%s+%s' % (vfmtinfo.get('format_id'),
+                                                        afmtinfo.get('format_id')),
+                                'width': vfmtinfo.get('width'),
+                                'height': vfmtinfo.get('height'),
+                                'resolution': vfmtinfo.get('resolution'),
+                                'fps': vfmtinfo.get('fps'),
+                                'vcodec': vfmtinfo.get('vcodec'),
+                                'vbr': vfmtinfo.get('vbr'),
+                                'stretched_ratio': vfmtinfo.get('stretched_ratio'),
+                                'acodec': afmtinfo.get('acodec'),
+                                'abr': afmtinfo.get('abr'),
                                 'ext': output_ext,
                             }
                         else:

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -585,7 +585,12 @@ class FFmpegMergerPP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
-        args = ['-c', 'copy', '-map', '0:v:0', '-map', '1:a:0']
+        args = ['-c', 'copy']
+        for (i, fmt) in enumerate(info['requested_formats']):
+            if fmt.get('acodec') != 'none':
+                args.extend(['-map', '%u:a:0' % (i)])
+            if fmt.get('vcodec') != 'none':
+                args.extend(['-map', '%u:v:0' % (i)])
         self._downloader.to_screen('[ffmpeg] Merging formats into "%s"' % filename)
         self.run_ffmpeg_multiple_files(info['__files_to_merge'], temp_filename, args)
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))


### PR DESCRIPTION
In response to the discussion in #5575. Please note that the `'format'` and `'format_id'` fields in the `info_json` are normalised back to video+audio order; this may or may not be desirable.

I still think downloading audio first should be the default.