### PR TITLE
Fix for unicode filenames

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -570,8 +570,8 @@ class YoutubeDL(object):
             # Temporary fix for #4787
             # 'Treat' all problem characters by passing filename through preferredencoding
             # to workaround encoding issues with subprocess on python2 @ Windows
-            if sys.version_info < (3, 0) and sys.platform == 'win32':
-                filename = encodeFilename(filename, True).decode(preferredencoding())
+            #if sys.version_info < (3, 0) and sys.platform == 'win32':
+            #    filename = encodeFilename(filename, True).decode(preferredencoding())
             return filename
         except ValueError as err:
             self.report_error('Error in output template: ' + str(err) + ' (encoding: ' + repr(preferredencoding()) + ')')

--- a/youtube_dl/postprocessor/hashNames.py
+++ b/youtube_dl/postprocessor/hashNames.py
@@ -1,0 +1,9 @@
+import os
+import hashlib
+
+#Hash the file names to drop unicode characters for FFMPEG
+def hashRename(fileN):
+    ext = os.path.splitext(fileN)
+    fileHash = hashlib.sha224(fileN.encode('utf-8')).hexdigest()
+    hash_name = fileHash+ext[1]
+    return hash_name


### PR DESCRIPTION
Fix for the issue of unicode file names discussed here: https://github.com/rg3/youtube-dl/issues/5527 https://github.com/rg3/youtube-dl/issues/4787 by hashing the input and output filenames before processing them and then restoring them.