### PR TITLE
[f4m] Fix encode error by sanitizing fragment filenames

### DIFF
--- a/youtube_dl/downloader/f4m.py
+++ b/youtube_dl/downloader/f4m.py
@@ -396,18 +396,19 @@ class F4mFD(FileDownloader):
                 success = http_dl.download(frag_filename, {'url': url})
                 if not success:
                     return False
-                with open(frag_filename, 'rb') as down:
-                    down_data = down.read()
-                    reader = FlvReader(down_data)
-                    while True:
-                        _, box_type, box_data = reader.read_box_info()
-                        if box_type == b'mdat':
-                            dest_stream.write(box_data)
-                            break
+                (down, frag_sanitized) = sanitize_open(frag_filename, 'rb')
+                down_data = down.read()
+                down.close()
+                reader = FlvReader(down_data)
+                while True:
+                    _, box_type, box_data = reader.read_box_info()
+                    if box_type == b'mdat':
+                        dest_stream.write(box_data)
+                        break
                 if live:
-                    os.remove(frag_filename)
+                    os.remove(encodeFilename(frag_sanitized))
                 else:
-                    frags_filenames.append(frag_filename)
+                    frags_filenames.append(frag_sanitized)
             except (compat_urllib_error.HTTPError, ) as err:
                 if live and (err.code == 404 or err.code == 410):
                     # We didn't keep up with the live window. Continue
@@ -430,7 +431,7 @@ class F4mFD(FileDownloader):
         elapsed = time.time() - start
         self.try_rename(tmpfilename, filename)
         for frag_file in frags_filenames:
-            os.remove(frag_file)
+            os.remove(encodeFilename(frag_file))
 
         fsize = os.path.getsize(encodeFilename(filename))
         self._hook_progress({


### PR DESCRIPTION
When opening a fragment file for reading, we must apply the same encoding to the filename as http_dl.download() that wrote the file. Trying to open an unencoded fragment file name may raise an UnicodeEncodeError if the filename contains characters that can't be encoded on the current locale.

This test case attempts to download a video whose title contains UTF-8 characters on C locale:

```
export LOCALE=C
export LC_CTYPE=C
python -m youtube_dl 'http://www.svtplay.se/video/2662623/ett-harligare-liv/ett-harligare-liv-sasong-1-avsnitt-20'
```

Without this patch the downloading fails with the following backtrace:

```
[SVTPlay] 2662623: Downloading JSON metadata
[SVTPlay] 2662623: Downloading f4m manifest
[SVTPlay] 2662623: Downloading m3u8 information
[download] Downloading f4m manifest
[download] Destination: Avsnitt 20 - Filmstjrnedrmmen-2662623.flv
[download]   0.4% of ~565.26MiB at 747.22KiB/s ETA 13:18Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/antti/youtube-dl/youtube_dl/__main__.py", line 19, in <module>
    youtube_dl.main()
  File "youtube_dl/__init__.py", line 401, in main
    _real_main(argv)
  File "youtube_dl/__init__.py", line 391, in _real_main
    retcode = ydl.download(all_urls)
  File "youtube_dl/YoutubeDL.py", line 1482, in download
    res = self.extract_info(url)
  File "youtube_dl/YoutubeDL.py", line 661, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "youtube_dl/YoutubeDL.py", line 707, in process_ie_result
    return self.process_video_result(ie_result, download=download)
  File "youtube_dl/YoutubeDL.py", line 1153, in process_video_result
    self.process_info(new_info)
  File "youtube_dl/YoutubeDL.py", line 1415, in process_info
    success = dl(filename, info_dict)
  File "youtube_dl/YoutubeDL.py", line 1357, in dl
    return fd.download(name, info)
  File "youtube_dl/downloader/common.py", line 342, in download
    return self.real_download(filename, info_dict)
  File "youtube_dl/downloader/f4m.py", line 399, in real_download
    with open(frag_filename, 'rb') as down:
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 20: ordinal not in range(128)
```