### PR TITLE
faststart

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -216,7 +216,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
                 # Lossless, but in another container
                 acodec = 'copy'
                 extension = 'm4a'
-                more_opts = ['-bsf:a', 'aac_adtstoasc']
+                more_opts = ['-bsf:a', 'aac_adtstoasc', '-movflags', 'faststart']
             elif filecodec in ['aac', 'mp3', 'vorbis', 'opus']:
                 # Lossless if possible
                 acodec = 'copy'
@@ -567,7 +567,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         temp_filename = prepend_extension(filename, 'temp')
 
         if info['ext'] == 'm4a':
-            options = ['-vn', '-acodec', 'copy']
+            options = ['-vn', '-acodec', 'copy', '-movflags', 'faststart']
         else:
             options = ['-c', 'copy']
 
@@ -619,7 +619,7 @@ class FFmpegFixupM4aPP(FFmpegPostProcessor):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
 
-        options = ['-c', 'copy', '-f', 'mp4']
+        options = ['-c', 'copy', '-f', 'mp4', '-movflags', 'faststart']
         self._downloader.to_screen('[ffmpeg] Correcting container in "%s"' % filename)
         self.run_ffmpeg(filename, temp_filename, options)
 


### PR DESCRIPTION
If I run this command

~~~
youtube-dl -f 22 -x --add-metadata --id 8ATu1BiOPZA
~~~

It does almost everything I need

- downloads the file with the highest quality audio (192k)
- extracts said audio without re-encoding
- adds metadata

However using `-x` invokes FFmpeg. FFmpeg by default will not set [`faststart`](http://multimedia.cx/eggs/improving-qt-faststart)
in fact if a file already has `faststart` it will even be removed. Without
`faststart` these files will not play in my car. This can only be remedied by
running FFmpeg with [the correct flag](http://superuser.com/a/616799)

~~~
ffmpeg -i 8ATu1BiOPZA.m4a -c copy -movflags faststart outfile.m4a
~~~

It would be nice if `youtube-dl` had this as an option, or perhaps even
as the default when using FFmpeg.