### PR TITLE
[EroProfile] Fix 403 (due to bad URL)

### DIFF
--- a/youtube_dl/extractor/eroprofile.py
+++ b/youtube_dl/extractor/eroprofile.py
@@ -76,7 +76,7 @@ class EroProfileIE(InfoExtractor):
             webpage, 'video id', default=None)
 
         video_url = self._search_regex(
-            r'<source src="([^"]+)', webpage, 'video url')
+            r'<source src="([^"]+)', webpage, 'video url').replace("&amp;", "&")
         title = self._html_search_regex(
             r'Title:</th><td>([^<]+)</td>', webpage, 'title')
         thumbnail = self._search_regex(


### PR DESCRIPTION
Before:

$ python test/test_download.py TestDownload.test_EroProfile
...
ERROR: unable to download video data: HTTP Error 403: Forbidden

After:

$ python test/test_download.py TestDownload.test_EroProfile
...
OK