### PR TITLE
Added functionality to retrieve information from YoutubeDL object as

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,9 +542,14 @@ import youtube_dl
 ydl_opts = {}
 with youtube_dl.YoutubeDL(ydl_opts) as ydl:
     ydl.download(['http://www.youtube.com/watch?v=BaW_jenozKc'])
+	print ydl.url
+	print ydl.format
+	ydl_jsonobject = ydl.info_dict_json
 ```
 
 Most likely, you'll want to use various options. For a list of what can be done, have a look at [youtube_dl/YoutubeDL.py](https://github.com/rg3/youtube-dl/blob/master/youtube_dl/YoutubeDL.py#L69). For a start, if you want to intercept youtube-dl's output, set a `logger` object.
+Alternatively, you may access some of the parameters that would be normally be printed to the console due to the specific options passed 
+(e.g force-url, force-filename, forcejson) as similary named objects as shown above.
 
 Here's a more complete example of a program that outputs only errors (and a short message after the download is finished), and downloads/converts the video to an mp3 file:
 

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -282,6 +282,27 @@ class YoutubeDL(object):
         self._screen_file = [sys.stdout, sys.stderr][params.get('logtostderr', False)]
         self._err_file = sys.stderr
         self.params = params
+        
+        #For use like an API rather than just a CLI tool; This helps to return useful parameters as objects rather than just print to console
+        # inspired by
+        # opts.geturl or opts.gettitle or opts.getid or opts.getthumbnail or opts.getdescription or opts.getfilename or opts.getformat or opts.getduration or opts.dumpjson or opts.dump_single_json
+        # any_printing = opts.print_json    
+        self.url = ""
+        self.play_path = ""
+        self.urls =[]   #TODO
+        self.title = ""
+        self.id = ""
+        self.thumbail = ""
+        self.description = ""
+        self.filename=""
+        self.format = ""
+        self.formats = [] #TODO
+          
+        self.ie_result = []
+        self.info_dict = []
+        self.info_dict_json = ""
+       
+      
         self.cache = Cache(self)
 
         if params.get('bidi_workaround', False):
@@ -1075,6 +1096,7 @@ class YoutubeDL(object):
             # element in the 'formats' field in info_dict is info_dict itself,
             # wich can't be exported to json
             info_dict['formats'] = formats
+            self.formats = formats
         if self.params.get('listformats'):
             self.list_formats(info_dict)
             return
@@ -1232,27 +1254,60 @@ class YoutubeDL(object):
         info_dict['_filename'] = filename = self.prepare_filename(info_dict)
 
         # Forced printings
+        self.title = info_dict['fulltitle']
         if self.params.get('forcetitle', False):
             self.to_stdout(info_dict['fulltitle'])
+        
+        self.id = info_dict['id']
         if self.params.get('forceid', False):
             self.to_stdout(info_dict['id'])
+            
+         
+        
         if self.params.get('forceurl', False):
-            if info_dict.get('requested_formats') is not None:
-                for f in info_dict['requested_formats']:
+             self.to_stdout(self.url)
+         
+        if info_dict.get('requested_formats') is not None:
+            for f in info_dict['requested_formats']:
+                self.urls.append((f['url'] + f.get('play_path', '')))
+                if self.params.get('forceurl', False):
                     self.to_stdout(f['url'] + f.get('play_path', ''))
-            else:
-                # For RTMP URLs, also include the playpath
-                self.to_stdout(info_dict['url'] + info_dict.get('play_path', ''))
+        else:
+            # For RTMP URLs, also include the playpath
+            self.url = info_dict['url'] + info_dict.get('play_path', '') 
+            self.play_path = info_dict.get('play_path', '') 
+            if self.params.get('forceurl', False):     
+                self.to_stdout(self.url)        
+          
+#         if self.params.get('forceurl', False):
+#             if info_dict.get('requested_formats') is not None:
+#                 for f in info_dict['requested_formats']:
+#                     self.to_stdout(f['url'] + f.get('play_path', ''))
+#             else:
+#                 # For RTMP URLs, also include the playpath
+#                 self.to_stdout(info_dict['url'] + info_dict.get('play_path', ''))
+        
         if self.params.get('forcethumbnail', False) and info_dict.get('thumbnail') is not None:
             self.to_stdout(info_dict['thumbnail'])
+        
         if self.params.get('forcedescription', False) and info_dict.get('description') is not None:
             self.to_stdout(info_dict['description'])
-        if self.params.get('forcefilename', False) and filename is not None:
-            self.to_stdout(filename)
+          
+        if filename is not None:  
+            self.filename = filename
+            if self.params.get('forcefilename', False): 
+                self.to_stdout(filename)
+            
         if self.params.get('forceduration', False) and info_dict.get('duration') is not None:
             self.to_stdout(formatSeconds(info_dict['duration']))
+            
+        self.format = info_dict['format']   
         if self.params.get('forceformat', False):
             self.to_stdout(info_dict['format'])
+        
+        self.info_dict = info_dict
+        self.info_dict_json = json.dumps(info_dict)
+        
         if self.params.get('forcejson', False):
             self.to_stdout(json.dumps(info_dict))
 


### PR DESCRIPTION
I have added the functionality to retrieve relevant information from the YoutubeDL object. This information, such as url, filename and formats would normally be written to the console if the options to do so have been set. However, with this patch an application which embeds Youtube-DL could just access an field of YoutubeDL object with that information ( even without the options to print to screen being set). This enhances YoutubeDL as an API (as well as the helpful tool that is is).
e.g:
     print ydl.url, ydl.format, ydl.formats
etc