### PR TITLE
Use thumbnails downloaded by YoutubeDL in EmbedThumbnailPP

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1848,7 +1848,7 @@ class YoutubeDL(object):
             thumb_ext = determine_ext(t['url'], 'jpg')
             suffix = '_%s' % t['id'] if len(thumbnails) > 1 else ''
             thumb_display_id = '%s ' % t['id'] if len(thumbnails) > 1 else ''
-            thumb_filename = os.path.splitext(filename)[0] + suffix + '.' + thumb_ext
+            t['filename'] = thumb_filename = os.path.splitext(filename)[0] + suffix + '.' + thumb_ext
 
             if self.params.get('nooverwrites', False) and os.path.exists(encodeFilename(thumb_filename)):
                 self.to_screen('[%s] %s: Thumbnail %sis already present' %

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -240,7 +240,13 @@ def _real_main(argv=None):
     if opts.xattrs:
         postprocessors.append({'key': 'XAttrMetadata'})
     if opts.embedthumbnail:
-        postprocessors.append({'key': 'EmbedThumbnail'})
+        already_have_thumbnail = opts.writethumbnail or opts.write_all_thumbnails
+        postprocessors.append({
+            'key': 'EmbedThumbnail',
+            'already_have_thumbnail': already_have_thumbnail
+        })
+        if not already_have_thumbnail:
+            opts.writethumbnail = True
     # Please keep ExecAfterDownload towards the bottom as it allows the user to modify the final file in any way.
     # So if the user is able to remove the file before your postprocessor runs it might cause a few problems.
     if opts.exec_cmd:

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -9,6 +9,7 @@ from .ffmpeg import FFmpegPostProcessor
 
 from ..utils import (
     check_executable,
+    encodeArgument,
     encodeFilename,
     PostProcessingError,
     prepend_extension,
@@ -52,7 +53,12 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             if not check_executable('AtomicParsley', ['-v']):
                 raise EmbedThumbnailPPError('AtomicParsley was not found. Please install.')
 
-            cmd = ['AtomicParsley', filename, '--artwork', thumbnail_filename, '-o', temp_filename]
+            cmd = [encodeFilename('AtomicParsley', True),
+                   encodeFilename(filename, True),
+                   encodeArgument('--artwork'),
+                   encodeFilename(thumbnail_filename, True),
+                   encodeArgument('-o'),
+                   encodeFilename(temp_filename, True)]
 
             self._downloader.to_screen('[atomicparsley] Adding thumbnail to "%s"' % filename)
 

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -36,12 +36,12 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
         if info['ext'] == 'mp3':
             options = [
-                '-i', thumbnail_filename, '-c', 'copy', '-map', '0', '-map', '1',
+                '-c', 'copy', '-map', '0', '-map', '1',
                 '-metadata:s:v', 'title="Album cover"', '-metadata:s:v', 'comment="Cover (Front)"']
 
             self._downloader.to_screen('[ffmpeg] Adding thumbnail to "%s"' % filename)
 
-            self.run_ffmpeg(filename, temp_filename, options)
+            self.run_ffmpeg_multiple_files([filename, thumbnail_filename], temp_filename, options)
 
             if not self._already_have_thumbnail:
                 os.remove(encodeFilename(thumbnail_filename))


### PR DESCRIPTION
Current ```EmbedThumbnailPP``` first downloads the necessary thumbnail, and then merges it into the audio file. Thus in the following invocation:
```
youtube-dl --verbose --embed-thumbnail --no-overwrite --write-all-thumbnails test:xuite
```
Thumbnails are downloaded twice. One in ```YoutubeDL``` and another in ```EmbedThumbnailPP```. I try to fix the scenario in this PR.

There's a deeper advantage from this fix. I believe all resources needed by postprocessors should be downloaded by ```YoutubeDL```, and my implementation conforms to the principle. I think this principle is helpful for solving the problem mentioned by @dstftw in https://github.com/rg3/youtube-dl/commit/1c7e2e64f6328024711d5fa999d4498396f4cb5c#commitcomment-11157068

There are 2 potential issues in my implementation:
1. It's always the highest quality thumbnail being embedded. Users may want to embed a lower quality image, but I think it's rare.
2. If a user invoke youtube-dl consecutively with the 2 following commands:
```
youtube-dl --verbose --write-thumbnail test:xuite
```
```
youtube-dl --verbose --embed-thumbnail test:xuite
```
A thumbnail is downloaded in the first command but deleted in the second command. This issue can be solved by adding a 'already_exists' field for each thumbnail of ```info_dict['thumbnails']```, but I think such checking makes the code too complicated.

cc: @pulpe Most major work in embedthumbnail.py (and previously atomicparsley.py) are done by you, and I'd like to hear some comments from you.