### PR TITLE
[qqmusic] Clean description/lyrics

### DIFF
--- a/youtube_dl/extractor/qqmusic.py
+++ b/youtube_dl/extractor/qqmusic.py
@@ -60,6 +60,7 @@ class QQMusicIE(InfoExtractor):
         lrc_content = self._html_search_regex(
             r'<div class="content" id="lrc_content"[^<>]*>([^<>]+)</div>',
             detail_info_page, 'LRC lyrics', default=None)
+        lrc_content = re.sub(r"\\n", "\n", lrc_content)
 
         guid = self.m_r_get_ruin()
 


### PR DESCRIPTION
The extractor puts lyrics into the description and it's really useful. However the lyrics are filled with lots of extraneous "\n", not linebreaks but actual text, "\" (slash) and "n", making it difficult to read since it looks like just a big block of text.
```
$ youtube-dl --get-description "http://y.qq.com/#type=song&mid=001LmqZ03vqdCg"
[ti:Infinity]\n[ar:Mariah Carey]\n[al:#1 To Infinity]\n[by:]\n[offset:0]\n[00:00.10]Infinity - Mariah Carey\n[00:00.20]\n[00:04.12]Ooh Aah, Ooh Aah, Ooh Aah, Ooh Aah\n[00:10.18]\n[00:10.74]Ooh Aah, Ooh Aah, Ooh Aah, Ooh Aah\n[00:17.19]\n[00:18.40]Why you mad\n[00:19.15]\n[00:19.66]Talkin' 'bout you're mad\n[00:20.79]\n[00:21.49]Could it be that you just lost the best you've ever had\n[00:24.62]<-- snip -->
```
This change replaces the \n with real linebreaks. After patching, it also looks to be a valid [LRC] (http://en.wikipedia.org/wiki/LRC_%28file_format%29) format.
```
$ python -m youtube_dl --get-description "http://y.qq.com/#type=song&mid=001LmqZ03vqdCg"
[ti:Infinity]
[ar:Mariah Carey]
[al:#1 To Infinity]
[by:]
[offset:0]
[00:00.10]Infinity - Mariah Carey
[00:00.20]
[00:04.12]Ooh Aah, Ooh Aah, Ooh Aah, Ooh Aah
[00:10.18]
[00:10.74]Ooh Aah, Ooh Aah, Ooh Aah, Ooh Aah
[00:17.19]
[00:18.40]Why you mad
[00:19.15]
[00:19.66]Talkin' 'bout you're mad
[00:20.79]
[00:21.49]Could it be that you just lost the best you've ever had
# -- snip --
```
