### PR TITLE
[YoutubeDL] Support DASH manifest downloading

### DIFF
--- a/youtube_dl/downloader/__init__.py
+++ b/youtube_dl/downloader/__init__.py
@@ -8,6 +8,7 @@ from .hls import NativeHlsFD
 from .http import HttpFD
 from .rtsp import RtspFD
 from .rtmp import RtmpFD
+from .dash import DashSegmentsFD
 
 from ..utils import (
     determine_protocol,
@@ -20,6 +21,7 @@ PROTOCOL_MAP = {
     'mms': RtspFD,
     'rtsp': RtspFD,
     'f4m': F4mFD,
+    'dash_segments': DashSegmentsFD,
 }
 
 

--- a/youtube_dl/downloader/__init__.py
+++ b/youtube_dl/downloader/__init__.py
@@ -21,7 +21,7 @@ PROTOCOL_MAP = {
     'mms': RtspFD,
     'rtsp': RtspFD,
     'f4m': F4mFD,
-    'dash_segments': DashSegmentsFD,
+    'http_dash_segments': DashSegmentsFD,
 }
 
 

--- a/youtube_dl/downloader/dash.py
+++ b/youtube_dl/downloader/dash.py
@@ -1,0 +1,50 @@
+from __future__ import unicode_literals
+from .common import FileDownloader
+from ..compat import compat_urllib_request
+
+import re
+
+
+class DashSegmentsFD(FileDownloader):
+    """
+    Download segments in a DASH manifest
+    """
+    def real_download(self, filename, info_dict):
+        self.report_destination(filename)
+        tmpfilename = self.temp_name(filename)
+        base_url = info_dict['url']
+        segment_urls = info_dict['segment_urls']
+
+        self.byte_counter = 0
+
+        def append_url_to_file(outf, target_url, target_name):
+            self.to_screen('[DashSegments] %s: Downloading %s' % (info_dict['id'], target_name))
+            req = compat_urllib_request.Request(target_url)
+            data = self.ydl.urlopen(req).read()
+            outf.write(data)
+            self.byte_counter += len(data)
+
+        def combine_url(base_url, target_url):
+            if re.match(r'^https?://', target_url):
+                return target_url
+            return '%s/%s' % (base_url, target_url)
+
+        with open(tmpfilename, 'wb') as outf:
+            append_url_to_file(
+                outf, combine_url(base_url, info_dict['initialization_url']),
+                'initialization segment')
+            for i, segment_url in enumerate(segment_urls):
+                append_url_to_file(
+                    outf, combine_url(base_url, segment_url),
+                    'segment %d / %d' % (i + 1, len(segment_urls)))
+
+        self.try_rename(tmpfilename, filename)
+
+        self._hook_progress({
+            'downloaded_bytes': self.byte_counter,
+            'total_bytes': self.byte_counter,
+            'filename': filename,
+            'status': 'finished',
+        })
+
+        return True

--- a/youtube_dl/downloader/dash.py
+++ b/youtube_dl/downloader/dash.py
@@ -16,14 +16,14 @@ class DashSegmentsFD(FileDownloader):
         base_url = info_dict['url']
         segment_urls = info_dict['segment_urls']
 
-        self.byte_counter = 0
+        byte_counter = 0
 
         def append_url_to_file(outf, target_url, target_name):
             self.to_screen('[DashSegments] %s: Downloading %s' % (info_dict['id'], target_name))
             req = compat_urllib_request.Request(target_url)
             data = self.ydl.urlopen(req).read()
             outf.write(data)
-            self.byte_counter += len(data)
+            return len(data)
 
         def combine_url(base_url, target_url):
             if re.match(r'^https?://', target_url):
@@ -35,15 +35,16 @@ class DashSegmentsFD(FileDownloader):
                 outf, combine_url(base_url, info_dict['initialization_url']),
                 'initialization segment')
             for i, segment_url in enumerate(segment_urls):
-                append_url_to_file(
+                segment_len = append_url_to_file(
                     outf, combine_url(base_url, segment_url),
                     'segment %d / %d' % (i + 1, len(segment_urls)))
+                byte_counter += segment_len
 
         self.try_rename(tmpfilename, filename)
 
         self._hook_progress({
-            'downloaded_bytes': self.byte_counter,
-            'total_bytes': self.byte_counter,
+            'downloaded_bytes': byte_counter,
+            'total_bytes': byte_counter,
             'filename': filename,
             'status': 'finished',
         })

--- a/youtube_dl/downloader/dash.py
+++ b/youtube_dl/downloader/dash.py
@@ -16,12 +16,21 @@ class DashSegmentsFD(FileDownloader):
         base_url = info_dict['url']
         segment_urls = info_dict['segment_urls']
 
+        is_test = self.params.get('test', False)
+        remaining_bytes = self._TEST_FILE_SIZE if is_test else None
         byte_counter = 0
 
-        def append_url_to_file(outf, target_url, target_name):
+        def append_url_to_file(outf, target_url, target_name, remaining_bytes=None):
             self.to_screen('[DashSegments] %s: Downloading %s' % (info_dict['id'], target_name))
             req = compat_urllib_request.Request(target_url)
+            if remaining_bytes is not None:
+                req.add_header('Range', 'bytes=0-%d' % (remaining_bytes - 1))
+
             data = self.ydl.urlopen(req).read()
+
+            if remaining_bytes is not None:
+                data = data[:remaining_bytes]
+
             outf.write(data)
             return len(data)
 
@@ -37,8 +46,13 @@ class DashSegmentsFD(FileDownloader):
             for i, segment_url in enumerate(segment_urls):
                 segment_len = append_url_to_file(
                     outf, combine_url(base_url, segment_url),
-                    'segment %d / %d' % (i + 1, len(segment_urls)))
+                    'segment %d / %d' % (i + 1, len(segment_urls)),
+                    remaining_bytes)
                 byte_counter += segment_len
+                if remaining_bytes is not None:
+                    remaining_bytes -= segment_len
+                    if remaining_bytes <= 0:
+                        break
 
         self.try_rename(tmpfilename, filename)
 

--- a/youtube_dl/downloader/dash.py
+++ b/youtube_dl/downloader/dash.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
-from .common import FileDownloader
-from ..compat import compat_urllib_request
 
 import re
+
+from .common import FileDownloader
+from ..compat import compat_urllib_request
 
 
 class DashSegmentsFD(FileDownloader):

--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -6,7 +6,6 @@ import socket
 import time
 
 from .common import FileDownloader
-from .dash import DashSegmentsFD
 from ..compat import (
     compat_urllib_request,
     compat_urllib_error,
@@ -20,9 +19,6 @@ from ..utils import (
 
 class HttpFD(FileDownloader):
     def real_download(self, filename, info_dict):
-        if info_dict.get('initialization_url') and list(filter(None, info_dict.get('segment_urls', []))):
-            return DashSegmentsFD(self.ydl, self.params).real_download(filename, info_dict)
-
         url = info_dict['url']
         tmpfilename = self.temp_name(filename)
         stream = None

--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -6,6 +6,7 @@ import socket
 import time
 
 from .common import FileDownloader
+from .dash import DashSegmentsFD
 from ..compat import (
     compat_urllib_request,
     compat_urllib_error,
@@ -19,6 +20,9 @@ from ..utils import (
 
 class HttpFD(FileDownloader):
     def real_download(self, filename, info_dict):
+        if info_dict.get('initialization_url') and list(filter(None, info_dict.get('segment_urls', []))):
+            return DashSegmentsFD(self.ydl, self.params).real_download(filename, info_dict)
+
         url = info_dict['url']
         tmpfilename = self.temp_name(filename)
         stream = None

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -819,7 +819,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     if segment_list:
                         f.update({
                             'initialization_url': segment_list.find('{urn:mpeg:DASH:schema:MPD:2011}Initialization').attrib['sourceURL'],
-                            'segment_urls': [segment.attrib.get('media') for segment in segment_list.findall('{urn:mpeg:DASH:schema:MPD:2011}SegmentURL')]
+                            'segment_urls': [segment.attrib.get('media') for segment in segment_list.findall('{urn:mpeg:DASH:schema:MPD:2011}SegmentURL')],
+                            'protocol': 'dash_segments',
                         })
                     try:
                         existing_format = next(

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -816,7 +816,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         'filesize': filesize,
                         'fps': int_or_none(r.attrib.get('frameRate')),
                     }
-                    if segment_list:
+                    if len(segment_list):
                         f.update({
                             'initialization_url': segment_list.find('{urn:mpeg:DASH:schema:MPD:2011}Initialization').attrib['sourceURL'],
                             'segment_urls': [segment.attrib.get('media') for segment in segment_list.findall('{urn:mpeg:DASH:schema:MPD:2011}SegmentURL')],

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -820,7 +820,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         f.update({
                             'initialization_url': segment_list.find('{urn:mpeg:DASH:schema:MPD:2011}Initialization').attrib['sourceURL'],
                             'segment_urls': [segment.attrib.get('media') for segment in segment_list.findall('{urn:mpeg:DASH:schema:MPD:2011}SegmentURL')],
-                            'protocol': 'dash_segments',
+                            'protocol': 'http_dash_segments',
                         })
                     try:
                         existing_format = next(

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -802,6 +802,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     # TODO implement WebVTT downloading
                     pass
                 elif mime_type.startswith('audio/') or mime_type.startswith('video/'):
+                    segment_list = r.find('{urn:mpeg:DASH:schema:MPD:2011}SegmentList')
                     format_id = r.attrib['id']
                     video_url = url_el.text
                     filesize = int_or_none(url_el.attrib.get('{http://youtube.com/yt/2012/10/10}contentLength'))
@@ -815,6 +816,11 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         'filesize': filesize,
                         'fps': int_or_none(r.attrib.get('frameRate')),
                     }
+                    if segment_list:
+                        f.update({
+                            'initialization_url': segment_list.find('{urn:mpeg:DASH:schema:MPD:2011}Initialization').attrib['sourceURL'],
+                            'segment_urls': [segment.attrib.get('media') for segment in segment_list.findall('{urn:mpeg:DASH:schema:MPD:2011}SegmentURL')]
+                        })
                     try:
                         existing_format = next(
                             fo for fo in formats

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -816,7 +816,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         'filesize': filesize,
                         'fps': int_or_none(r.attrib.get('frameRate')),
                     }
-                    if len(segment_list):
+                    if segment_list is not None:
                         f.update({
                             'initialization_url': segment_list.find('{urn:mpeg:DASH:schema:MPD:2011}Initialization').attrib['sourceURL'],
                             'segment_urls': [segment.attrib.get('media') for segment in segment_list.findall('{urn:mpeg:DASH:schema:MPD:2011}SegmentURL')],

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -516,6 +516,24 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 'skip_download': 'requires avconv',
             }
         },
+        # DASH manifest with segment_list
+        {
+            'url': 'https://www.youtube.com/embed/CsmdDsKjzN8',
+            'md5': '8ce563a1d667b599d21064e982ab9e31',
+            'info_dict': {
+                'id': 'CsmdDsKjzN8',
+                'ext': 'mp4',
+                'upload_date': '20150510',
+                'uploader': 'Airtek',
+                'description': 'Retransmisión en directo de la XVIII media maratón de Zaragoza.',
+                'uploader_id': 'UCzTzUmjXxxacNnL8I3m4LnQ',
+                'title': 'Retransmisión XVIII Media maratón Zaragoza 2015',
+            },
+            'params': {
+                'youtube_include_dash_manifest': True,
+                'format': '135',  # bestvideo
+            }
+        }
     ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
In some videos from youtube, the DASH manifest contains multiple segments URLs for each itag. Existing reports are #5884, #5703, #5702 (the first video is not accessible now, but I remember its DASH manifest contains segments), and I believe #5545, #5754 are affected by the same problem. In fact, downloading any DASH format from a currently live youtube video causes an error.

There are some issues:
1. Is it really needed? For all videos in aforementioned issues, ```-f best``` works fine.
2. My implementation is based on ```NativeHlsFD```, and the two looks similar. Maybe moving common codes to some base class is better.
3. Is it necessary to document ```initialization_url``` and ```segment_urls``` explicitly, in ```common.py``` or so?