### PR TITLE
Adds support for XviD output with extra parametrization

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ which means you can modify it, redistribute it or use it however you like.
     --audio-quality QUALITY          Specify ffmpeg/avconv audio quality, insert a value between 0 (better) and 9 (worse) for VBR or a specific bitrate like 128K (default
                                      5)
     --recode-video FORMAT            Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv|xvid)
-    --pp-params                      Extra parameters for video post-processor. The params will be splited on spaces.
+    --pp-params                      Extra parameters for video post-processor.
     -k, --keep-video                 Keep the video file on disk after the post-processing; the video is erased by default
     --no-post-overwrites             Do not overwrite post-processed files; the post-processed files are overwritten by default
     --embed-subs                     Embed subtitles in the video (only for mkv and mp4 videos)

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ which means you can modify it, redistribute it or use it however you like.
     --audio-format FORMAT            Specify audio format: "best", "aac", "vorbis", "mp3", "m4a", "opus", or "wav"; "best" by default
     --audio-quality QUALITY          Specify ffmpeg/avconv audio quality, insert a value between 0 (better) and 9 (worse) for VBR or a specific bitrate like 128K (default
                                      5)
-    --recode-video FORMAT            Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv)
+    --recode-video FORMAT            Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv|xvid)
+    --pp-params                      Extra parameters for video post-processor. The params will be splited on spaces.
     -k, --keep-video                 Keep the video file on disk after the post-processing; the video is erased by default
     --no-post-overwrites             Do not overwrite post-processed files; the post-processed files are overwritten by default
     --embed-subs                     Embed subtitles in the video (only for mkv and mp4 videos)

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ which means you can modify it, redistribute it or use it however you like.
     --audio-quality QUALITY          Specify ffmpeg/avconv audio quality, insert a value between 0 (better) and 9 (worse) for VBR or a specific bitrate like 128K (default
                                      5)
     --recode-video FORMAT            Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv|xvid)
-    --pp-params                      Extra parameters for video post-processor.
+    --postprocessor-args             Extra parameters for video post-processor.
     -k, --keep-video                 Keep the video file on disk after the post-processing; the video is erased by default
     --no-post-overwrites             Do not overwrite post-processed files; the post-processed files are overwritten by default
     --embed-subs                     Embed subtitles in the video (only for mkv and mp4 videos)

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -261,6 +261,7 @@ class YoutubeDL(object):
     The following options are used by the post processors:
     prefer_ffmpeg:     If True, use ffmpeg instead of avconv if both are available,
                        otherwise prefer avconv.
+    pp_params:         Extra parameters for external apps, like avconv.
     """
 
     params = None

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -261,7 +261,7 @@ class YoutubeDL(object):
     The following options are used by the post processors:
     prefer_ffmpeg:     If True, use ffmpeg instead of avconv if both are available,
                        otherwise prefer avconv.
-    pp_params:         Extra parameters for external apps, like avconv.
+    postprocessor_args: Extra parameters for external apps, like avconv.
     """
 
     params = None

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -171,8 +171,10 @@ def _real_main(argv=None):
     if opts.recodevideo is not None:
         if opts.recodevideo not in ['mp4', 'flv', 'webm', 'ogg', 'mkv', 'xvid']:
             parser.error('invalid video recode format specified')
-    if opts.pp_params is not None:
-        opts.pp_params = opts.pp_params.split()
+    if opts.pp_params is None:
+        opts.pp_params = []
+    else:
+        opts.pp_params = shlex.split(opts.pp_params)
     if opts.convertsubtitles is not None:
         if opts.convertsubtitles not in ['srt', 'vtt', 'ass']:
             parser.error('invalid subtitle format specified')

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -171,10 +171,6 @@ def _real_main(argv=None):
     if opts.recodevideo is not None:
         if opts.recodevideo not in ['mp4', 'flv', 'webm', 'ogg', 'mkv', 'xvid']:
             parser.error('invalid video recode format specified')
-    if opts.pp_params is None:
-        opts.pp_params = []
-    else:
-        opts.pp_params = shlex.split(opts.pp_params)
     if opts.convertsubtitles is not None:
         if opts.convertsubtitles not in ['srt', 'vtt', 'ass']:
             parser.error('invalid subtitle format specified')
@@ -231,7 +227,7 @@ def _real_main(argv=None):
         postprocessors.append({
             'key': 'FFmpegVideoConvertor',
             'preferedformat': opts.recodevideo,
-            'extra_params': opts.pp_params
+            'extra_cmd_args': opts.postprocessor_args,
         })
     if opts.convertsubtitles:
         postprocessors.append({

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -169,8 +169,10 @@ def _real_main(argv=None):
         if not opts.audioquality.isdigit():
             parser.error('invalid audio quality specified')
     if opts.recodevideo is not None:
-        if opts.recodevideo not in ['mp4', 'flv', 'webm', 'ogg', 'mkv']:
+        if opts.recodevideo not in ['mp4', 'flv', 'webm', 'ogg', 'mkv', 'xvid']:
             parser.error('invalid video recode format specified')
+    if opts.pp_params is not None:
+        opts.pp_params = opts.pp_params.split()
     if opts.convertsubtitles is not None:
         if opts.convertsubtitles not in ['srt', 'vtt', 'ass']:
             parser.error('invalid subtitle format specified')
@@ -227,6 +229,7 @@ def _real_main(argv=None):
         postprocessors.append({
             'key': 'FFmpegVideoConvertor',
             'preferedformat': opts.recodevideo,
+            'extra_params': opts.pp_params
         })
     if opts.convertsubtitles:
         postprocessors.append({

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -227,7 +227,6 @@ def _real_main(argv=None):
         postprocessors.append({
             'key': 'FFmpegVideoConvertor',
             'preferedformat': opts.recodevideo,
-            'extra_cmd_args': opts.postprocessor_args,
         })
     if opts.convertsubtitles:
         postprocessors.append({
@@ -354,6 +353,7 @@ def _real_main(argv=None):
         'extract_flat': opts.extract_flat,
         'merge_output_format': opts.merge_output_format,
         'postprocessors': postprocessors,
+        'postprocessor_args': shlex.split(opts.postprocessor_args or ''),
         'fixup': opts.fixup,
         'source_address': opts.source_address,
         'call_home': opts.call_home,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -686,7 +686,11 @@ def parseOpts(overrideArguments=None):
     postproc.add_option(
         '--recode-video',
         metavar='FORMAT', dest='recodevideo', default=None,
-        help='Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv)')
+        help='Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv|xvid)')
+    postproc.add_option(
+        '--pp-params',
+        dest='pp_params', default=None,
+        help='Extra parameters for video post-processor. The params will be splited on spaces.')
     postproc.add_option(
         '-k', '--keep-video',
         action='store_true', dest='keepvideo', default=False,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -689,8 +689,8 @@ def parseOpts(overrideArguments=None):
         help='Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv|xvid)')
     postproc.add_option(
         '--pp-params',
-        dest='pp_params', default=None,
-        help='Extra parameters for video post-processor. The params will be splited on spaces.')
+        dest='pp_params', default=None, metavar='ARGS',
+        help='Extra parameters for video post-processor.')
     postproc.add_option(
         '-k', '--keep-video',
         action='store_true', dest='keepvideo', default=False,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -688,8 +688,8 @@ def parseOpts(overrideArguments=None):
         metavar='FORMAT', dest='recodevideo', default=None,
         help='Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv|xvid)')
     postproc.add_option(
-        '--pp-params',
-        dest='pp_params', default=None, metavar='ARGS',
+        '--postprocessor-args',
+        dest='postprocessor_args', default=None, metavar='ARGS',
         help='Extra parameters for video post-processor.')
     postproc.add_option(
         '-k', '--keep-video',

--- a/youtube_dl/postprocessor/common.py
+++ b/youtube_dl/postprocessor/common.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import os
+import shlex
 
 from ..utils import (
     PostProcessingError,
@@ -23,12 +24,13 @@ class PostProcessor(object):
 
     PostProcessor objects follow a "mutual registration" process similar
     to InfoExtractor objects. And it can receive parameters from CLI trough
-    --pp-params.
+    --postprocessor-args.
     """
 
     _downloader = None
 
-    def __init__(self, downloader=None):
+    def __init__(self, downloader=None, extra_cmd_args=None):
+        self._extra_cmd_args = shlex.split(extra_cmd_args or '')
         self._downloader = downloader
 
     def set_downloader(self, downloader):

--- a/youtube_dl/postprocessor/common.py
+++ b/youtube_dl/postprocessor/common.py
@@ -22,7 +22,8 @@ class PostProcessor(object):
     of the chain is reached.
 
     PostProcessor objects follow a "mutual registration" process similar
-    to InfoExtractor objects.
+    to InfoExtractor objects. And it can receive parameters from CLI trough
+    --pp-params.
     """
 
     _downloader = None

--- a/youtube_dl/postprocessor/common.py
+++ b/youtube_dl/postprocessor/common.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import os
-import shlex
 
 from ..utils import (
     PostProcessingError,
@@ -29,8 +28,8 @@ class PostProcessor(object):
 
     _downloader = None
 
-    def __init__(self, downloader=None, extra_cmd_args=None):
-        self._extra_cmd_args = shlex.split(extra_cmd_args or '')
+    def __init__(self, downloader=None):
+        self._extra_cmd_args = downloader.params.get('postprocessor_args')
         self._downloader = downloader
 
     def set_downloader(self, downloader):

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -29,8 +29,8 @@ class FFmpegPostProcessorError(PostProcessingError):
 
 
 class FFmpegPostProcessor(PostProcessor):
-    def __init__(self, downloader=None, extra_cmd_args=None):
-        PostProcessor.__init__(self, downloader, extra_cmd_args)
+    def __init__(self, downloader=None):
+        PostProcessor.__init__(self, downloader)
         self._determine_executables()
 
     def check_version(self):
@@ -287,8 +287,8 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
 
 
 class FFmpegVideoConvertorPP(FFmpegPostProcessor):
-    def __init__(self, downloader=None, preferedformat=None, extra_cmd_args=None):
-        super(FFmpegVideoConvertorPP, self).__init__(downloader, extra_cmd_args)
+    def __init__(self, downloader=None, preferedformat=None):
+        super(FFmpegVideoConvertorPP, self).__init__(downloader)
         self._preferedformat = preferedformat
 
     def run(self, information):

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -287,22 +287,28 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
 
 
 class FFmpegVideoConvertorPP(FFmpegPostProcessor):
-    def __init__(self, downloader=None, preferedformat=None):
+    def __init__(self, downloader=None, preferedformat=None, extra_params=[]):
         super(FFmpegVideoConvertorPP, self).__init__(downloader)
         self._preferedformat = preferedformat
+        self._extra_params = extra_params
 
     def run(self, information):
         path = information['filepath']
         prefix, sep, ext = path.rpartition('.')
-        outpath = prefix + sep + self._preferedformat
+        ext = self._preferedformat
+        options = self._extra_params
+        if self._preferedformat == 'xvid':
+            ext = 'avi'
+            options.extend(['-c:v', 'libxvid', '-vtag', 'XVID'])
+        outpath = prefix + sep + ext
         if information['ext'] == self._preferedformat:
             self._downloader.to_screen('[ffmpeg] Not converting video file %s - already is in target format %s' % (path, self._preferedformat))
             return [], information
         self._downloader.to_screen('[' + 'ffmpeg' + '] Converting video from %s to %s, Destination: ' % (information['ext'], self._preferedformat) + outpath)
-        self.run_ffmpeg(path, outpath, [])
+        self.run_ffmpeg(path, outpath, options)
         information['filepath'] = outpath
         information['format'] = self._preferedformat
-        information['ext'] = self._preferedformat
+        information['ext'] = ext
         return [path], information
 
 

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -29,8 +29,8 @@ class FFmpegPostProcessorError(PostProcessingError):
 
 
 class FFmpegPostProcessor(PostProcessor):
-    def __init__(self, downloader=None):
-        PostProcessor.__init__(self, downloader)
+    def __init__(self, downloader=None, extra_cmd_args=None):
+        PostProcessor.__init__(self, downloader, extra_cmd_args)
         self._determine_executables()
 
     def check_version(self):
@@ -287,16 +287,15 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
 
 
 class FFmpegVideoConvertorPP(FFmpegPostProcessor):
-    def __init__(self, downloader=None, preferedformat=None, extra_params=[]):
-        super(FFmpegVideoConvertorPP, self).__init__(downloader)
+    def __init__(self, downloader=None, preferedformat=None, extra_cmd_args=None):
+        super(FFmpegVideoConvertorPP, self).__init__(downloader, extra_cmd_args)
         self._preferedformat = preferedformat
-        self._extra_params = extra_params
 
     def run(self, information):
         path = information['filepath']
         prefix, sep, ext = path.rpartition('.')
         ext = self._preferedformat
-        options = self._extra_params
+        options = self._extra_cmd_args
         if self._preferedformat == 'xvid':
             ext = 'avi'
             options.extend(['-c:v', 'libxvid', '-vtag', 'XVID'])


### PR DESCRIPTION
As the "LG Time Machine" (a (not so) smart TV) has a limitation for video dimensions (as for codecs), I take to implement an extra parameter `--pp-params` where we can send extra parameterization for the video converter (post-processor).

Example:
```
$ youtube-dl --recode-video=xvid --pp-params='-s 720x480' -c https://www.youtube.com/watch?v=BE7Qoe2ZiXE
```
That works fine on a 4yo LG Time Machine.

Closes #5733