### PR TITLE
Quality note for niconico

### DIFF
--- a/youtube_dl/extractor/niconico.py
+++ b/youtube_dl/extractor/niconico.py
@@ -184,6 +184,11 @@ class NiconicoIE(InfoExtractor):
             extension = determine_ext(video_real_url)
         video_format = extension.upper()
 
+        if video_real_url.endswith('low'):
+            format_note = 'low'
+        else:
+            format_note = 'src'
+
         thumbnail = (
             xpath_text(video_info, './/thumbnail_url') or
             self._html_search_meta('image', webpage, 'thumbnail', default=None) or
@@ -242,6 +247,7 @@ class NiconicoIE(InfoExtractor):
             'title': title,
             'ext': extension,
             'format': video_format,
+            'format_note' : format_note,
             'thumbnail': thumbnail,
             'description': description,
             'uploader': uploader,


### PR DESCRIPTION
Niconico serves two different quality levels; source quality, and what they call 'eco.' This isn't an entirely complete way of listing the qualities as distinct. This patch does show either 'src' or 'low' under the quality note when run with -F. This way, users can at least tell which quality they will get. This resolves #5838 partially, or at least gives a bit more info to avoid the pitfalls of low quality. I can't go any further with this code, since I don't have a premium account to test anything further with. I've verified that the (minor) changes work and are non-invasive, so including it shouldn't be a big deal.