### PR TITLE
Francetv: use m3u8 when f4m video isn't available

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -815,10 +815,14 @@ class InfoExtractor(object):
         self.to_screen(msg)
         time.sleep(timeout)
 
-    def _extract_f4m_formats(self, manifest_url, video_id, preference=None, f4m_id=None):
+    def _extract_f4m_formats(self, manifest_url, video_id, preference=None, f4m_id=None, fatal=True):
         manifest = self._download_xml(
-            manifest_url, video_id, 'Downloading f4m manifest',
-            'Unable to download f4m manifest')
+            manifest_url, video_id, note='Downloading f4m manifest',
+            errnote='Unable to download f4m manifest', fatal=fatal)
+
+        if manifest is False:
+            assert not fatal
+            return []
 
         formats = []
         manifest_version = '1.0'
@@ -846,7 +850,7 @@ class InfoExtractor(object):
 
     def _extract_m3u8_formats(self, m3u8_url, video_id, ext=None,
                               entry_protocol='m3u8', preference=None,
-                              m3u8_id=None, note=None, errnote=None):
+                              m3u8_id=None, note=None, errnote=None, fatal=True):
 
         formats = [{
             'format_id': '-'.join(filter(None, [m3u8_id, 'meta'])),
@@ -866,7 +870,13 @@ class InfoExtractor(object):
         m3u8_doc = self._download_webpage(
             m3u8_url, video_id,
             note=note or 'Downloading m3u8 information',
-            errnote=errnote or 'Failed to download m3u8 information')
+            errnote=errnote or 'Failed to download m3u8 information',
+            fatal=fatal)
+
+        if m3u8_doc is False:
+            assert not fatal
+            return []
+
         last_info = None
         last_media = None
         kv_rex = re.compile(

--- a/youtube_dl/extractor/francetv.py
+++ b/youtube_dl/extractor/francetv.py
@@ -45,6 +45,7 @@ class FranceTVBaseInfoExtractor(InfoExtractor):
             georestricted = False
 
         formats = []
+        fatal = len(info['videos']) == 1
         for video in info['videos']:
             if video['statut'] != 'ONLINE':
                 continue
@@ -63,9 +64,9 @@ class FranceTVBaseInfoExtractor(InfoExtractor):
                     'http://hdfauth.francetv.fr/esi/urltokengen2.html?url=%s' % video_url_parsed.path,
                     video_id, 'Downloading f4m manifest token', fatal=False)
                 if f4m_url:
-                    formats.extend(self._extract_f4m_formats(f4m_url, video_id, 1, format_id))
+                    formats.extend(self._extract_f4m_formats(f4m_url, video_id, 1, format_id, fatal))
             elif ext == 'm3u8':
-                formats.extend(self._extract_m3u8_formats(video_url, video_id, 'mp4', m3u8_id=format_id))
+                formats.extend(self._extract_m3u8_formats(video_url, video_id, 'mp4', m3u8_id=format_id, fatal=fatal))
             elif video_url.startswith('rtmp'):
                 formats.append({
                     'url': video_url,


### PR DESCRIPTION
Fixes #5981

I didn't investigate why f4m format doesn't work.