### PR TITLE
[qqmusic] Fix song extraction when certain formats are unavailable

### DIFF
--- a/youtube_dl/extractor/qqmusic.py
+++ b/youtube_dl/extractor/qqmusic.py
@@ -9,13 +9,8 @@ from .common import InfoExtractor
 from ..utils import (
     strip_jsonp,
     unescapeHTML,
-    HEADRequest,
-    ExtractorError,
 )
-from ..compat import (
-    compat_urllib_request,
-    compat_HTTPError,
-)
+from ..compat import compat_urllib_request
 
 
 class QQMusicIE(InfoExtractor):
@@ -104,24 +99,15 @@ class QQMusicIE(InfoExtractor):
 
         formats = []
         for format_id, details in self._FORMATS.items():
-            video_url = 'http://cc.stream.qqmusic.qq.com/%s%s.%s?vkey=%s&guid=%s&fromtag=0' \
-                        % (details['prefix'], mid, details['ext'], vkey, guid)
-            req = HEADRequest(video_url)
-            try:
-                res = self._request_webpage(
-                    req, mid, note='Testing %s video URL' % format_id, fatal=False)
-            except ExtractorError as e:
-                if isinstance(e.cause, compat_HTTPError) and e.cause.code in [400, 404]:
-                    self.report_warning('Invalid %s video URL' % format_id, mid)
-            else:
-                if res:
-                    formats.append({
-                        'url': video_url,
-                        'format': format_id,
-                        'format_id': format_id,
-                        'preference': details['preference'],
-                        'abr': details.get('abr'),
-                    })
+            formats.append({
+                'url': 'http://cc.stream.qqmusic.qq.com/%s%s.%s?vkey=%s&guid=%s&fromtag=0'
+                       % (details['prefix'], mid, details['ext'], vkey, guid),
+                'format': format_id,
+                'format_id': format_id,
+                'preference': details['preference'],
+                'abr': details.get('abr'),
+            })
+        self._check_formats(formats, mid)
         self._sort_formats(formats)
 
         return {

--- a/youtube_dl/extractor/qqmusic.py
+++ b/youtube_dl/extractor/qqmusic.py
@@ -89,7 +89,8 @@ class QQMusicIE(InfoExtractor):
 
         thumbnail_url = None
         albummid = self._search_regex(
-            [r'albummid:\'([0-9a-zA-Z]+)\'', r'"albummid":"([0-9a-zA-Z]+)"'], detail_info_page, 'album mid', default=None)
+            [r'albummid:\'([0-9a-zA-Z]+)\'', r'"albummid":"([0-9a-zA-Z]+)"'],
+            detail_info_page, 'album mid', default=None)
         if albummid:
             thumbnail_url = "http://i.gtimg.cn/music/photo/mid_album_500/%s/%s/%s.jpg" \
                             % (albummid[-2:-1], albummid[-1], albummid)


### PR DESCRIPTION
Some songs do not have hq (320k) versions available. This fixes it by checking if the url is valid before adding to formats.

Also includes a small change to get the thumbnail url for a song based on the album mid.