### PR TITLE
Save webpage_url to 'copyright' metadata field as well; 'purl' is flv-only

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -364,6 +364,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
             metadata['comment'] = info['description']
         if info.get('webpage_url') is not None:
             metadata['purl'] = info['webpage_url']
+            metadata['copyright'] = info['webpage_url']
         if info.get('album') is not None:
             metadata['album'] = info['album']
 


### PR DESCRIPTION
youtube-dl --add-metadata fails to save webpage_url in all cases except .flv. Since
'copyright' is unused, yet supported in all formats that support metadata, this makes
use of it. Example of issue from video saved with varying combinations of -f and -x,
(with this patch applied)

for i in *;do ext=${i##*.};mediainfo -f "$i"|egrep '://.+bbc'|sed "s/^/$ext  /";done

flv  copyright                        : http://www.bbc.com/news/world-asia-33179629
flv  purl                             : http://www.bbc.com/news/world-asia-33179629
m4a  Copyright                        : http://www.bbc.com/news/world-asia-33179629
mp3  Copyright                        : http://www.bbc.com/news/world-asia-33179629
mp4  Copyright                        : http://www.bbc.com/news/world-asia-33179629
wav  Copyright                        : http://www.bbc.com/news/world-asia-33179629

More info at http://wiki.multimedia.cx/index.php?title=FFmpeg_Metadata

Another option is to append the url to 'description' however this will be truncated
in some cases due to desc length and media format, and hard to programmatically extract
in others, due to urls in the desc itself.