### PR TITLE
[noco.tv] Fix issue #6066: title interpreted as integer

### DIFF
--- a/youtube_dl/extractor/noco.py
+++ b/youtube_dl/extractor/noco.py
@@ -195,7 +195,7 @@ class NocoIE(InfoExtractor):
         if episode_number:
             title += ' #' + compat_str(episode_number)
         if episode:
-            title += ' - ' + episode
+            title += ' - ' + compat_str(episode)
 
         description = show.get('show_resume') or show.get('family_resume')
 


### PR DESCRIPTION
Fixes error using `compat_str()` when the title is only a number (interpreted as integer instead of string):
`TypeError: Can't convert 'int' object to str implicitly`
More details in issue