### PR TITLE
Add support of HTTPS for ina.fr

### DIFF
--- a/youtube_dl/extractor/ina.py
+++ b/youtube_dl/extractor/ina.py
@@ -7,7 +7,7 @@ from .common import InfoExtractor
 
 
 class InaIE(InfoExtractor):
-    _VALID_URL = r'http://(?:www\.)?ina\.fr/video/(?P<id>I?[A-Z0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?ina\.fr/video/(?P<id>I?[A-Z0-9]+)'
     _TEST = {
         'url': 'http://www.ina.fr/video/I12055569/francois-hollande-je-crois-que-c-est-clair-video.html',
         'md5': 'a667021bf2b41f8dc6049479d9bb38a3',


### PR DESCRIPTION
The extractor for ina.fr does not handle HTTPS URLs. I add this support.
alarig@airmure ~/tmp $ yt-dl https://www.ina.fr/video/RCC9712053545/la-canicule-et-la-biere-video.html
[generic] la-canicule-et-la-biere-video: Requesting header
WARNING: Falling back on generic information extractor.
[generic] la-canicule-et-la-biere-video: Downloading webpage
[generic] la-canicule-et-la-biere-video: Extracting information
ERROR: Unsupported URL: https://www.ina.fr/video/RCC9712053545/la-canicule-et-la-biere-video.html
alarig@airmure ~/tmp $ yt-dl http://www.ina.fr/video/RCC9712053545/la-canicule-et-la-biere-video.html
[Ina] RCC9712053545: Downloading XML
[Ina] RCC9712053545: Extracting information
[download] La canicule et la bière-RCC9712053545.mp4 has already been downloaded
[download] 100% of 12.64MiB
alarig@airmure ~/Documents/prog/py/youtube-dl $ python -m youtube_dl https://www.ina.fr/video/RCC9712053545/la-canicule-et-la-biere-video.html
[Ina] RCC9712053545: Downloading XML
[Ina] RCC9712053545: Extracting information
[download] Destination: La canicule et la bière-RCC9712053545.mp4
[download] 100% of 12.64MiB in 00:06