### PR TITLE
[SBS] fixes due to website changes

### DIFF
--- a/youtube_dl/extractor/sbs.py
+++ b/youtube_dl/extractor/sbs.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import re
 from .common import InfoExtractor
-from ..utils import (
-    js_to_json,
-    remove_end,
-)
+from ..utils import remove_end
 
 
 class SBSIE(InfoExtractor):
@@ -34,18 +30,22 @@ class SBSIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        webpage = self._download_webpage(url, video_id)
+        # the video is in the following iframe
+        iframe_url = 'http://www.sbs.com.au/ondemand/video/single/' + video_id + '?context=web'
+        webpage = self._download_webpage(iframe_url, video_id)
 
-        player = self._search_regex(
-            r'(?s)playerParams\.releaseUrls\s*=\s*(\{.*?\n\});\n',
-            webpage, 'player')
-        player = re.sub(r"'\s*\+\s*[\da-zA-Z_]+\s*\+\s*'", '', player)
+        player_params = self._search_regex(
+            r'(?s)(playerParams.+?releaseUrls.+?\n)',
+            webpage, 'playerParams')
+        player_params_js = self._search_regex(
+            r'({.*})',
+            player_params, 'player_param_js')
 
-        release_urls = self._parse_json(js_to_json(player), video_id)
+        player_params_json = self._parse_json(player_params_js, video_id)
 
-        theplatform_url = release_urls.get('progressive') or release_urls['standard']
+        theplatform_url = player_params_json.get('releaseUrls')['progressive'] or player_params_json.get('releaseUrls')['standard']
 
-        title = remove_end(self._og_search_title(webpage), ' (The Feed)')
+        title = remove_end(self._og_search_title(webpage, default=video_id, fatal=False), ' (The Feed)')
         description = self._html_search_meta('description', webpage)
         thumbnail = self._og_search_thumbnail(webpage)
 


### PR DESCRIPTION
The SBS website format has changed. I didn't see an issue for it (should I have created one??). This change fixes the SBS extractor.  
NB 1 - The thumbnail and description are now missing.
NB 2 - There is an existing problem with the SBS extractor #3811. youtube-dl now fails when it gets to this point.

Here is the output from the latest youtube-dl 

```
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'--verbose', u'http://www.sbs.com.au/news/video/471395907773/The-Feed-July-9']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2015.07.07
[debug] Python version 2.7.9 - Linux-3.19.0-15-generic-i686-with-Ubuntu-15.04-vivid
[debug] exe versions: avconv 11.2-6, avprobe 11.2-6, ffmpeg 2.5.6-0ubuntu0.15.04.1, ffprobe 2.5.6-0ubuntu0.15.04.1, rtmpdump 2.4
[debug] Proxy map: {}
[generic] The-Feed-July-9: Requesting header
WARNING: Falling back on generic information extractor.
[generic] The-Feed-July-9: Downloading webpage
[generic] The-Feed-July-9: Extracting information
[SBS] 471395907773: Downloading webpage
ERROR: Unable to extract player; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/usr/local/sp/bin/youtube-dl_sp/youtube_dl/YoutubeDL.py", line 654, in extract_info
    ie_result = ie.extract(url)
  File "/usr/local/sp/bin/youtube-dl_sp/youtube_dl/extractor/common.py", line 273, in extract
    return self._real_extract(url)
  File "/usr/local/sp/bin/youtube-dl_sp/youtube_dl/extractor/sbs.py", line 41, in _real_extract
    webpage, 'player')
  File "/usr/local/sp/bin/youtube-dl_sp/youtube_dl/extractor/common.py", line 555, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
RegexNotFoundError: Unable to extract player; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

Here is the output of youtube-dl withthis change.

```
[generic] The-Feed-July-9: Requesting header
WARNING: Falling back on generic information extractor.
[generic] The-Feed-July-9: Downloading webpage
[generic] The-Feed-July-9: Extracting information
[SBS] 471395907773: Downloading webpage
WARNING: unable to extract description; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
WARNING: unable to extract thumbnail url; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
[ThePlatform] GhPOVyHFTicn: Downloading XML
[ThePlatform] GhPOVyHFTicn: Downloading webpage
ERROR: unable to download video data: HTTP Error 403: Forbidden
``` 

 