### PR TITLE
Copy change: "skipping" to "all done" with -x

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -265,7 +265,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
         # If we download foo.mp3 and convert it to... foo.mp3, then don't delete foo.mp3, silly.
         if (new_path == path or
                 (self._nopostoverwrites and os.path.exists(encodeFilename(new_path)))):
-            self._downloader.to_screen('[youtube] Post-process file %s exists, skipping' % new_path)
+            self._downloader.to_screen('[youtube] Post-process file %s exists, all done' % new_path)
             return [], information
 
         try:


### PR DESCRIPTION
A copy change.

This happens when you specify -x for a YT video and an acceptable format (.m4a)
could be downloaded directly.