### PR TITLE
[iqiyi] fix iqiyi (2015-07-17), update the md5 salt (enc_key)

### DIFF
--- a/youtube_dl/extractor/iqiyi.py
+++ b/youtube_dl/extractor/iqiyi.py
@@ -212,20 +212,7 @@ class IqiyiIE(InfoExtractor):
         return raw_data
 
     def get_enc_key(self, swf_url, video_id):
-        filename, _ = os.path.splitext(url_basename(swf_url))
-        enc_key_json = self._downloader.cache.load('iqiyi-enc-key', filename)
-        if enc_key_json is not None:
-            return enc_key_json[0]
-
-        req = self._request_webpage(
-            swf_url, video_id, note='download swf content')
-        cn = req.read()
-        cn = zlib.decompress(cn[8:])
-        pt = re.compile(b'MixerRemote\x08(?P<enc_key>.+?)\$&vv')
-        enc_key = self._search_regex(pt, cn, 'enc_key').decode('utf8')
-
-        self._downloader.cache.store('iqiyi-enc-key', filename, [enc_key])
-
+        enc_key = '8e29ab5666d041c3a1ea76e06dabdffb'
         return enc_key
 
     def _real_extract(self, url):


### PR DESCRIPTION
Update the md5 salt (enc_key) to iqiyi lastest (2015-07-17) flash player. 

Recently iqiyi changes its md5 salt (the enc_key) frequently. 
But iqiyi tries to hide the salt with some complex methods. And auto extracting the salt is impossible. :-(

So just return the salt in `get_enc_key()` function. 

+ Before fix
  
  ```
$ python test/test_download.py TestDownload.test_Iqiyi
[iqiyi] temp_id: download video page
[iqiyi] 9c1fb1b99d192b21c559e5a1a2cb3c73: download swf content
ERROR: Unable to extract enc_key; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/YoutubeDL.py", line 656, in extract_info
    ie_result = ie.extract(url)
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/extractor/common.py", line 275, in extract
    return self._real_extract(url)
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/extractor/iqiyi.py", line 242, in _real_extract
    enc_key = self.get_enc_key(swf_url, video_id)
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/extractor/iqiyi.py", line 225, in get_enc_key
    enc_key = self._search_regex(pt, cn, 'enc_key').decode('utf8')
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/extractor/common.py", line 557, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
youtube_dl.utils.RegexNotFoundError: Unable to extract enc_key; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

E
======================================================================
ERROR: test_Iqiyi (__main__.TestDownload)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/YoutubeDL.py", line 656, in extract_info
    ie_result = ie.extract(url)
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/extractor/common.py", line 275, in extract
    return self._real_extract(url)
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/extractor/iqiyi.py", line 242, in _real_extract
    enc_key = self.get_enc_key(swf_url, video_id)
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/extractor/iqiyi.py", line 225, in get_enc_key
    enc_key = self._search_regex(pt, cn, 'enc_key').decode('utf8')
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/extractor/common.py", line 557, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
youtube_dl.utils.RegexNotFoundError: Unable to extract enc_key; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test/test_download.py", line 139, in test_template
    res_dict = ydl.extract_info(test_case['url'])
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/YoutubeDL.py", line 671, in extract_info
    self.report_error(compat_str(de), de.format_traceback())
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/YoutubeDL.py", line 531, in report_error
    self.trouble(error_message, tb)
  File "/home/d/u/home/sceext/_/r/ev/youtube_dl/youtube_dl/YoutubeDL.py", line 501, in trouble
    raise DownloadError(message, exc_info)
youtube_dl.utils.DownloadError: ERROR: Unable to extract enc_key; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

----------------------------------------------------------------------
Ran 1 test in 1.445s

FAILED (errors=1)
$ 
  ```

+ After fix
  
  ```
$ python test/test_download.py TestDownload.test_Iqiyi
[iqiyi] temp_id: download video page
[iqiyi] 9c1fb1b99d192b21c559e5a1a2cb3c73: Downloading JSON metadata
[iqiyi] 9c1fb1b99d192b21c559e5a1a2cb3c73: Download path key of segment 1 for format h5
[iqiyi] 9c1fb1b99d192b21c559e5a1a2cb3c73: Download video info of segment 1 for format h5
[iqiyi] 9c1fb1b99d192b21c559e5a1a2cb3c73: Download path key of segment 1 for format h6
[iqiyi] 9c1fb1b99d192b21c559e5a1a2cb3c73: Download video info of segment 1 for format h6
[info] Writing video description metadata as JSON to: 9c1fb1b99d192b21c559e5a1a2cb3c73.info.json
[debug] Invoking downloader on 'http://119.188.173.17/videos/v0/20150528/85/88/721ec4cc33c0ba0a1346c9908859b2fe.f4v?key=08809e0964fe75823b93056e08ba5f560&src=iqiyi.com&tn=1437193438&ct=&z=&su=fb2c2eb7c10144ada9471aa3e00314c9&qyid=66c96239c2fd4b2d9a5844b4a8ae3c15&bt=&client=&uuid=7b08c25f-55a9d4de-47'
[download] Destination: 9c1fb1b99d192b21c559e5a1a2cb3c73.f4v
[download] 100% of 10.00KiB in 00:00
.
----------------------------------------------------------------------
Ran 1 test in 2.176s

OK
$ 
  ```

