### PR TITLE
[theplatform] prefer hls streams

### DIFF
--- a/youtube_dl/downloader/hls.py
+++ b/youtube_dl/downloader/hls.py
@@ -28,12 +28,12 @@ class HlsFD(FileDownloader):
             return False
         ffpp.check_version()
 
-        cookies = ''
-        for cookie in self.ydl.cookiejar:
-            cookies += '%s=%s; path=%s; domain=%s;\r\n' % (cookie.name, cookie.value, cookie.path, cookie.domain)
+        headers = ''
+        for key, val in info_dict['http_headers'].items():
+            headers += '%s: %s\r\n' % (key, val)
         args = [
             encodeArgument(opt)
-            for opt in (ffpp.executable, '-y', '-user-agent', info_dict['http_headers']['User-Agent'], '-cookies', cookies,'-i', url, '-f', 'mp4', '-c', 'copy', '-bsf:a', 'aac_adtstoasc')]
+            for opt in (ffpp.executable, '-y', '-headers', headers, '-i', url, '-f', 'mp4', '-c', 'copy', '-bsf:a', 'aac_adtstoasc')]
         args.append(encodeFilename(tmpfilename, True))
 
         retval = subprocess.call(args)

--- a/youtube_dl/downloader/hls.py
+++ b/youtube_dl/downloader/hls.py
@@ -28,9 +28,12 @@ class HlsFD(FileDownloader):
             return False
         ffpp.check_version()
 
+        cookies = ''
+        for cookie in self.ydl.cookiejar:
+            cookies += '%s=%s; path=%s; domain=%s;\r\n' % (cookie.name, cookie.value, cookie.path, cookie.domain)
         args = [
             encodeArgument(opt)
-            for opt in (ffpp.executable, '-y', '-i', url, '-f', 'mp4', '-c', 'copy', '-bsf:a', 'aac_adtstoasc')]
+            for opt in (ffpp.executable, '-y', '-user-agent', info_dict['http_headers']['User-Agent'], '-cookies', cookies,'-i', url, '-f', 'mp4', '-c', 'copy', '-bsf:a', 'aac_adtstoasc')]
         args.append(encodeFilename(tmpfilename, True))
 
         retval = subprocess.call(args)

--- a/youtube_dl/extractor/cbs.py
+++ b/youtube_dl/extractor/cbs.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
-
+from ..utils import smuggle_url
 
 class CBSIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?(?:cbs\.com/shows/[^/]+/(?:video|artist)|colbertlateshow\.com/(?:video|podcasts))/[^/]+/(?P<id>[^/]+)'
@@ -10,30 +10,20 @@ class CBSIE(InfoExtractor):
         'url': 'http://www.cbs.com/shows/garth-brooks/video/_u7W953k6la293J7EPTd9oHkSPs6Xn6_/connect-chat-feat-garth-brooks/',
         'info_dict': {
             'id': '4JUVEwq3wUT7',
-            'display_id': 'connect-chat-feat-garth-brooks',
             'ext': 'flv',
             'title': 'Connect Chat feat. Garth Brooks',
             'description': 'Connect with country music singer Garth Brooks, as he chats with fans on Wednesday November 27, 2013. Be sure to tune in to Garth Brooks: Live from Las Vegas, Friday November 29, at 9/8c on CBS!',
             'duration': 1495,
-        },
-        'params': {
-            # rtmp download
-            'skip_download': True,
         },
         '_skip': 'Blocked outside the US',
     }, {
         'url': 'http://www.cbs.com/shows/liveonletterman/artist/221752/st-vincent/',
         'info_dict': {
             'id': 'WWF_5KqY3PK1',
-            'display_id': 'st-vincent',
             'ext': 'flv',
             'title': 'Live on Letterman - St. Vincent',
             'description': 'Live On Letterman: St. Vincent in concert from New York\'s Ed Sullivan Theater on Tuesday, July 16, 2014.',
             'duration': 3221,
-        },
-        'params': {
-            # rtmp download
-            'skip_download': True,
         },
         '_skip': 'Blocked outside the US',
     }, {
@@ -50,9 +40,4 @@ class CBSIE(InfoExtractor):
         real_id = self._search_regex(
             [r"video\.settings\.pid\s*=\s*'([^']+)';", r"cbsplayer\.pid\s*=\s*'([^']+)';"],
             webpage, 'real video ID')
-        return {
-            '_type': 'url_transparent',
-            'ie_key': 'ThePlatform',
-            'url': 'theplatform:%s' % real_id,
-            'display_id': display_id,
-        }
+        return self.url_result(smuggle_url('http://link.theplatform.com/s/dJ5BDC/%s/meta.smil?format=smil&mbr=true&manifest=f4m' % real_id, {'force_smil_url': True}))

--- a/youtube_dl/extractor/cbssports.py
+++ b/youtube_dl/extractor/cbssports.py
@@ -9,12 +9,16 @@ class CBSSportsIE(InfoExtractor):
     _VALID_URL = r'http://www\.cbssports\.com/video/player/(?P<section>[^/]+)/(?P<id>[^/]+)'
 
     _TEST = {
-        'url': 'http://www.cbssports.com/video/player/tennis/318462531970/0/us-open-flashbacks-1990s',
+        'url': 'http://www.cbssports.com/video/player/tennis/482755139719/0/serena-williams-wins-2015-wimbledon-championship',
         'info_dict': {
-            'id': '_d5_GbO8p1sT',
+            'id': 'GQGZp_4tBqW6',
             'ext': 'flv',
-            'title': 'US Open flashbacks: 1990s',
-            'description': 'Bill Macatee relives the best moments in US Open history from the 1990s.',
+            'title': 'Serena Williams wins 2015 Wimbledon Championship',
+            'description': 'Serena Williams completed the Serena Slam on Saturday and now holds all four major titles. Jamie Erdahl has the latest on what the win means for Serena.',
+        },
+        'params': {
+            # rtmp download
+            'skip_download': True,
         },
     }
 

--- a/youtube_dl/extractor/cnet.py
+++ b/youtube_dl/extractor/cnet.py
@@ -29,14 +29,15 @@ class CNETIE(InfoExtractor):
         'url': 'http://www.cnet.com/videos/whiny-pothole-tweets-at-local-government-when-hit-by-cars-tomorrow-daily-187/',
         'info_dict': {
             'id': '56527b93-d25d-44e3-b738-f989ce2e49ba',
-            'ext': 'flv',
+            'ext': 'm3u8',
             'description': 'Khail and Ashley wonder what other civic woes can be solved by self-tweeting objects, investigate a new kind of VR camera and watch an origami robot self-assemble, walk, climb, dig and dissolve. #TDPothole',
             'uploader_id': 'b163284d-6b73-44fc-b3e6-3da66c392d40',
             'uploader': 'Ashley Esqueda',
             'title': 'Whiny potholes tweet at local government when hit by cars (Tomorrow Daily 187)',
         },
         'params': {
-            'skip_download': True,  # requires rtmpdump
+            # m3u8 download
+            'skip_download': True,
         },
     }]
 

--- a/youtube_dl/extractor/foxsports.py
+++ b/youtube_dl/extractor/foxsports.py
@@ -11,7 +11,7 @@ class FoxSportsIE(InfoExtractor):
         'url': 'http://www.foxsports.com/video?vid=432609859715',
         'info_dict': {
             'id': 'gA0bHB3Ladz3',
-            'ext': 'flv',
+            'ext': 'm3u8',
             'title': 'Courtney Lee on going up 2-0 in series vs. Blazers',
             'description': 'Courtney Lee talks about Memphis being focused.',
         },
@@ -29,4 +29,4 @@ class FoxSportsIE(InfoExtractor):
             video_id)
 
         return self.url_result(smuggle_url(
-            config['releaseURL'] + '&manifest=f4m', {'force_smil_url': True}))
+            config['releaseURL'] + '&manifest=m3u', {'force_smil_url': True}))

--- a/youtube_dl/extractor/foxsports.py
+++ b/youtube_dl/extractor/foxsports.py
@@ -16,6 +16,10 @@ class FoxSportsIE(InfoExtractor):
             'description': 'Courtney Lee talks about Memphis being focused.',
         },
         'add_ie': ['ThePlatform'],
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        },
     }
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -814,10 +814,14 @@ class GenericIE(InfoExtractor):
             'url': 'http://www.riderfans.com/forum/showthread.php?121827-Freeman&s=e98fa1ea6dc08e886b1678d35212494a',
             'info_dict': {
                 'id': 'ln7x1qSThw4k',
-                'ext': 'flv',
+                'ext': 'm3u8',
                 'title': "PFT Live: New leader in the 'new-look' defense",
                 'description': 'md5:65a19b4bbfb3b0c0c5768bed1dfad74e',
             },
+            'params': {
+                # m3u8 downloads
+                'skip_download': True,
+            }
         },
         # UDN embed
         {

--- a/youtube_dl/extractor/nationalgeographic.py
+++ b/youtube_dl/extractor/nationalgeographic.py
@@ -15,21 +15,29 @@ class NationalGeographicIE(InfoExtractor):
             'url': 'http://video.nationalgeographic.com/video/news/150210-news-crab-mating-vin?source=featuredvideo',
             'info_dict': {
                 'id': '4DmDACA6Qtk_',
-                'ext': 'flv',
+                'ext': 'm3u8',
                 'title': 'Mating Crabs Busted by Sharks',
                 'description': 'md5:16f25aeffdeba55aaa8ec37e093ad8b3',
             },
             'add_ie': ['ThePlatform'],
+            'params': {
+                # m3u8 download
+                'skip_download': True,
+            },
         },
         {
             'url': 'http://video.nationalgeographic.com/wild/when-sharks-attack/the-real-jaws',
             'info_dict': {
                 'id': '_JeBD_D7PlS5',
-                'ext': 'flv',
+                'ext': 'm3u8',
                 'title': 'The Real Jaws',
                 'description': 'md5:8d3e09d9d53a85cd397b4b21b2c77be6',
             },
             'add_ie': ['ThePlatform'],
+            'params': {
+                # m3u8 download
+                'skip_download': True,
+            },
         },
     ]
 
@@ -48,7 +56,7 @@ class NationalGeographicIE(InfoExtractor):
         theplatform_id = url_basename(content.attrib.get('url'))
 
         return self.url_result(smuggle_url(
-            'http://link.theplatform.com/s/ngs/%s?format=SMIL&formats=MPEG4&manifest=f4m' % theplatform_id,
+            'http://link.theplatform.com/s/ngs/%s?format=SMIL&formats=MPEG4&manifest=m3u' % theplatform_id,
             # For some reason, the normal links don't work and we must force
-            # the use of f4m
+            # the use of m3u8
             {'force_smil_url': True}))

--- a/youtube_dl/extractor/nbc.py
+++ b/youtube_dl/extractor/nbc.py
@@ -81,14 +81,19 @@ class NBCSportsVPlayerIE(InfoExtractor):
         'url': 'https://vplayer.nbcsports.com/p/BxmELC/nbcsports_share/select/9CsDKds0kvHI',
         'info_dict': {
             'id': '9CsDKds0kvHI',
-            'ext': 'flv',
+            'ext': 'm3u8',
             'description': 'md5:df390f70a9ba7c95ff1daace988f0d8d',
             'title': 'Tyler Kalinoski hits buzzer-beater to lift Davidson',
-        }
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        },
     }, {
         'url': 'http://vplayer.nbcsports.com/p/BxmELC/nbc_embedshare/select/_hqLjQ95yx8Z',
         'only_matching': True,
-    }]
+    },
+    ]
 
     @staticmethod
     def _extract_url(webpage):
@@ -112,10 +117,14 @@ class NBCSportsIE(InfoExtractor):
         'url': 'http://www.nbcsports.com//college-basketball/ncaab/tom-izzo-michigan-st-has-so-much-respect-duke',
         'info_dict': {
             'id': 'PHJSaFWbrTY9',
-            'ext': 'flv',
+            'ext': 'm3u8',
             'title': 'Tom Izzo, Michigan St. has \'so much respect\' for Duke',
             'description': 'md5:ecb459c9d59e0766ac9c7d5d0eda8113',
-        }
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        },
     }
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/nbc.py
+++ b/youtube_dl/extractor/nbc.py
@@ -24,9 +24,13 @@ class NBCIE(InfoExtractor):
             # md5 checksum is not stable
             'info_dict': {
                 'id': 'c9xnCo0YPOPH',
-                'ext': 'flv',
+                'ext': 'm3u8',
                 'title': 'Jimmy Fallon Surprises Fans at Ben & Jerry\'s',
                 'description': 'Jimmy gives out free scoops of his new "Tonight Dough" ice cream flavor by surprising customers at the Ben & Jerry\'s scoop shop.',
+            },
+            'params': {
+                # m3u8 download
+                'skip_download': True,
             },
         },
         {

--- a/youtube_dl/extractor/sbs.py
+++ b/youtube_dl/extractor/sbs.py
@@ -15,11 +15,15 @@ class SBSIE(InfoExtractor):
         'md5': '3150cf278965eeabb5b4cea1c963fe0a',
         'info_dict': {
             'id': '320403011771',
-            'ext': 'mp4',
+            'ext': 'm3u8',
             'title': 'Dingo Conservation (The Feed)',
             'description': 'md5:f250a9856fca50d22dec0b5b8015f8a5',
             'thumbnail': 're:http://.*\.jpg',
             'duration': 308,
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
         },
     }, {
         'url': 'http://www.sbs.com.au/ondemand/video/320403011771/Dingo-Conservation-The-Feed',

--- a/youtube_dl/extractor/syfy.py
+++ b/youtube_dl/extractor/syfy.py
@@ -1,46 +1,31 @@
 from __future__ import unicode_literals
 
-import re
-
 from .common import InfoExtractor
 
 
 class SyfyIE(InfoExtractor):
-    _VALID_URL = r'https?://www\.syfy\.com/(?:videos/.+?vid:(?P<id>[0-9]+)|(?!videos)(?P<video_name>[^/]+)(?:$|[?#]))'
+    _VALID_URL = r'https?://www\.syfy\.com/[^/]+/videos/(?:\d+-)?(?P<id>[A-Za-z0-9-]+)'
 
     _TESTS = [{
-        'url': 'http://www.syfy.com/videos/Robot%20Combat%20League/Behind%20the%20Scenes/vid:2631458',
+        'url': 'http://www.syfy.com/sharknado3/videos/sharknado-3-trailer',
         'info_dict': {
-            'id': 'NmqMrGnXvmO1',
-            'ext': 'flv',
-            'title': 'George Lucas has Advice for his Daughter',
-            'description': 'Listen to what insights George Lucas give his daughter Amanda.',
-        },
-        'add_ie': ['ThePlatform'],
-    }, {
-        'url': 'http://www.syfy.com/wilwheaton',
-        'md5': '94dfa54ee3ccb63295b276da08c415f6',
-        'info_dict': {
-            'id': '4yoffOOXC767',
-            'ext': 'flv',
-            'title': 'The Wil Wheaton Project - Premiering May 27th at 10/9c.',
-            'description': 'The Wil Wheaton Project premieres May 27th at 10/9c. Don\'t miss it.',
+            'id': 'Sueh0V5Eh6L6',
+            'ext': 'm3u8',
+            'title': 'Sharknado 3: Trailer',
+            'description': 'This time, the entire east coast isn\'t safe. Sharknado 3 premieres July 22 at 9/8c on Syfy.',
         },
         'add_ie': ['ThePlatform'],
         'skip': 'Blocked outside the US',
+        'params': {
+            # rtmp download
+            'skip_download': True,
+        }
     }]
 
     def _real_extract(self, url):
-        mobj = re.match(self._VALID_URL, url)
-        video_name = mobj.group('video_name')
-        if video_name:
-            generic_webpage = self._download_webpage(url, video_name)
-            video_id = self._search_regex(
-                r'<iframe.*?class="video_iframe_page"\s+src="/_utils/video/thP_video_controller.php.*?_vid([0-9]+)">',
-                generic_webpage, 'video ID')
-            url = 'http://www.syfy.com/videos/%s/%s/vid:%s' % (
-                video_name, video_name, video_id)
-        else:
-            video_id = mobj.group('id')
-        webpage = self._download_webpage(url, video_id)
-        return self.url_result(self._og_search_video_url(webpage))
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
+        releaseURL = self._parse_json(self._html_search_regex(
+            r'"syfy_mpx"\s*:\s*({[^}]+?})',
+            webpage, 'syfy_mpx'), display_id)['releaseURL']
+        return self.url_result(releaseURL)

--- a/youtube_dl/extractor/theplatform.py
+++ b/youtube_dl/extractor/theplatform.py
@@ -148,15 +148,15 @@ class ThePlatformIE(InfoExtractor):
         if node is None:
             node = body.find(_x('smil:seq/smil:video'))
         if node is not None and '.m3u8' in node.attrib['src']:
-                formats = self._extract_m3u8_formats(node.attrib['src'], video_id)
+            formats = self._extract_m3u8_formats(node.attrib['src'], video_id)
         if node is not None and '.f4m' in node.attrib['src']:
-                f4m_url = node.attrib['src']
-                if 'manifest.f4m?' not in f4m_url:
-                    f4m_url += '?'
-                # the parameters are from syfy.com, other sites may use others,
-                # they also work for nbc.com
-                f4m_url += '&g=UXWGVKRWHFSP&hdcore=3.0.3'
-                formats = self._extract_f4m_formats(f4m_url, video_id)
+            f4m_url = node.attrib['src']
+            if 'manifest.f4m?' not in f4m_url:
+                f4m_url += '?'
+            # the parameters are from syfy.com, other sites may use others,
+            # they also work for nbc.com
+            f4m_url += '&g=UXWGVKRWHFSP&hdcore=3.0.3'
+            formats = self._extract_f4m_formats(f4m_url, video_id)
         else:
             formats = []
             switch = body.find(_x('smil:switch'))

--- a/youtube_dl/extractor/theplatform.py
+++ b/youtube_dl/extractor/theplatform.py
@@ -144,11 +144,12 @@ class ThePlatformIE(InfoExtractor):
         head = meta.find(_x('smil:head'))
         body = meta.find(_x('smil:body'))
 
+        formats = []
         node = body.find(_x('smil:seq//smil:video'))
         if node is None:
             node = body.find(_x('smil:seq/smil:video'))
         if node is not None and '.m3u8' in node.attrib['src']:
-            formats = self._extract_m3u8_formats(node.attrib['src'], video_id)
+            formats.extend(self._extract_m3u8_formats(node.attrib['src'], video_id))
         if node is not None and '.f4m' in node.attrib['src']:
             f4m_url = node.attrib['src']
             if 'manifest.f4m?' not in f4m_url:
@@ -156,9 +157,8 @@ class ThePlatformIE(InfoExtractor):
             # the parameters are from syfy.com, other sites may use others,
             # they also work for nbc.com
             f4m_url += '&g=UXWGVKRWHFSP&hdcore=3.0.3'
-            formats = self._extract_f4m_formats(f4m_url, video_id)
+            formats.extend(self._extract_f4m_formats(f4m_url, video_id))
         else:
-            formats = []
             switch = body.find(_x('smil:switch'))
             if switch is None:
                 switch = body.find(_x('smil:par//smil:switch'))

--- a/youtube_dl/extractor/theplatform.py
+++ b/youtube_dl/extractor/theplatform.py
@@ -108,7 +108,7 @@ class ThePlatformIE(InfoExtractor):
             config_url = config_url.replace('swf/', 'config/')
             config_url = config_url.replace('onsite/', 'onsite/config/')
             config = self._download_json(config_url, video_id, 'Downloading config')
-            smil_url = config['releaseUrl'] + '&format=SMIL&formats=MPEG4&manifest=f4m'
+            smil_url = config['releaseUrl'] + '&format=SMIL&formats=MPEG4&manifest=m3u'
         else:
             smil_url = 'http://link.theplatform.com/s/%s/meta.smil?format=smil&mbr=true&manifest=m3u' % path
 

--- a/youtube_dl/extractor/theplatform.py
+++ b/youtube_dl/extractor/theplatform.py
@@ -150,7 +150,7 @@ class ThePlatformIE(InfoExtractor):
             node = body.find(_x('smil:seq/smil:video'))
         if node is not None and '.m3u8' in node.attrib['src']:
             formats.extend(self._extract_m3u8_formats(node.attrib['src'], video_id))
-        if node is not None and '.f4m' in node.attrib['src']:
+        elif node is not None and '.f4m' in node.attrib['src']:
             f4m_url = node.attrib['src']
             if 'manifest.f4m?' not in f4m_url:
                 f4m_url += '?'

--- a/youtube_dl/extractor/theplatform.py
+++ b/youtube_dl/extractor/theplatform.py
@@ -60,10 +60,14 @@ class ThePlatformIE(InfoExtractor):
         'url': 'https://player.theplatform.com/p/D6x-PC/pulse_preview/embed/select/media/yMBg9E8KFxZD',
         'info_dict': {
             'id': 'yMBg9E8KFxZD',
-            'ext': 'mp4',
+            'ext': 'm3u8',
             'description': 'md5:644ad9188d655b742f942bf2e06b002d',
             'title': 'HIGHLIGHTS: USA bag first ever series Cup win',
-        }
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        },
     }, {
         'url': 'http://player.theplatform.com/p/NnzsPC/widget/select/media/4Y0TlYUr_ZT7',
         'only_matching': True,

--- a/youtube_dl/extractor/theplatform.py
+++ b/youtube_dl/extractor/theplatform.py
@@ -147,10 +147,9 @@ class ThePlatformIE(InfoExtractor):
         node = body.find(_x('smil:seq//smil:video'))
         if node is None:
             node = body.find(_x('smil:seq/smil:video'))
-        if node is not None:
-            if '.m3u8' in node.attrib['src']:
+        if node is not None and '.m3u8' in node.attrib['src']:
                 formats = self._extract_m3u8_formats(node.attrib['src'], video_id)
-            if '.f4m' in node.attrib['src']:
+        if node is not None and '.f4m' in node.attrib['src']:
                 f4m_url = node.attrib['src']
                 if 'manifest.f4m?' not in f4m_url:
                     f4m_url += '?'


### PR DESCRIPTION
this is for 2 reasons.
- it solves the problem happen in many sites that use the platform like the one heppen in #3811 seamusphelan already talk about downloading m3u manifest.
i didn't test it in SBS but i try it in USA Network and FOX and it works(some sites need some tweaks like in usa network the user agent should be the one from curl) if the change accepted i will try to add extractors for fox.com and usanetwork.
i know that it's possible to download from these sites with f4m with more changes(the f4m url should be changed manually if the change doesn't accepted i'll try to fix the platform f4m downloading) but there is also the second reason.
- the hls stream is better in streaming with video players like mpv and vlc.