### PR TITLE
[youtube] Don't use the DASH manifest from 'get_video_info' if 'use_cipher_signature' is True (#5118)

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -967,7 +967,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         video_id, note=False,
                         errnote='unable to download video info webpage')
                     get_video_info = compat_parse_qs(video_info_webpage)
-                    add_dash_mpd(get_video_info)
+                    if get_video_info.get('use_cipher_signature') != ['True']:
+                        add_dash_mpd(get_video_info)
                     if not video_info:
                         video_info = get_video_info
                     if 'token' in get_video_info:


### PR DESCRIPTION
Currently they give a 403 Forbidden error.

I don't know if it's worth trying to find a way to download those manifests, but at least we can skip one network request and won't get more issue reports.