### PR TITLE
Undo adaptive -> flash workaround

### DIFF
--- a/youtube_dl/extractor/rtlnl.py
+++ b/youtube_dl/extractor/rtlnl.py
@@ -86,12 +86,12 @@ class RtlNlIE(InfoExtractor):
         # NB: nowadays, recent ffmpeg and avconv can handle these encrypted streams, so
         # this adaptive -> flash workaround is not required in general, but it also
         # allows bypassing georestriction therefore is retained for now.
-        videopath = material['videopath'].replace('/adaptive/', '/flash/')
+        videopath = material['videopath']
         m3u8_url = meta.get('videohost', 'http://manifest.us.rtl.nl') + videopath
 
         formats = self._extract_m3u8_formats(m3u8_url, uuid, ext='mp4')
 
-        video_urlpart = videopath.split('/flash/')[1][:-5]
+        video_urlpart = videopath.split('/adaptive/')[1][:-5]
         PG_URL_TEMPLATE = 'http://pg.us.rtl.nl/rtlxl/network/%s/progressive/%s.mp4'
 
         formats.extend([


### PR DESCRIPTION
For a couple of days now rtlXL's non-DRM adaptive (m3u8) streams don't work anymore.
The beginning of a format specific m3u8-playlist now:
```
#EXTM3U
#EXT-X-VERSION:1
## Created with Unified Streaming Platform(version=1.6.6)
#EXT-X-MEDIA-SEQUENCE:1
#EXT-X-ALLOW-CACHE:NO
#EXT-X-TARGETDURATION:17
#EXTINF:11, no desc
http://hls.217.118.160.67/10/v166/none/flash/components/actueel/rtlnieuws/327202/2015w27/702
085ad-7464-4f30-8ef8.../702085ad-7464-4f30-8ef8-d84391972f18-audio=128000-video=2522000-1.ts
#EXTINF:10, no desc
http://hls.217.118.160.67/10/v166/none/flash/components/actueel/rtlnieuws/327202/2015w27/702
085ad-7464-4f30-8ef8.../702085ad-7464-4f30-8ef8-d84391972f18-audio=128000-video=2522000-2.ts
#EXTINF:10, no desc
http://hls.217.118.160.67/10/v166/none/flash/components/actueel/rtlnieuws/327202/2015w27/702
085ad-7464-4f30-8ef8.../702085ad-7464-4f30-8ef8-d84391972f18-audio=128000-video=2522000-3.ts
```
Notice the `hls.`? Deliberate atempt of RTL to force the DRM streams? But why not stop support for the non-DRM stream intirely then? Strange.

Anyway,... by undoing the adaptive -> flash workaround youtube-dl returns the DRM streams again.
The progressive streams still work fine.

Initially foreigners are out of luck because of a geoblock, but by removing `hls.` and saving the m3u8-playlist locally, the non-DRM streams still appear to work.
VLC can open the m3u8-file directly. For MPC-HC rename to `.ts` first.