### PR TITLE
Consider --audio-format when using --extract-audio to avoid lossy conversion

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -916,6 +916,23 @@ class YoutubeDL(object):
 
         return (new_format_spec, new_formats)
 
+    def _bestaudio_for_lossless_extract(self, audio_formats):
+        pps = self.params["postprocessors"]
+        if not pps:
+            return None
+        [pp for pp in pps if pp["key"] == "FFmpegExtractAudio"]
+        if not pp:
+            return None
+        pc = pp["preferredcodec"]
+        if pc == "m4a":
+            pc = "aac"
+        if not pc:
+            return None
+        for af in audio_formats:
+            if af["acodec"] == pc:
+                return af
+        return None
+
     def select_format(self, format_spec, available_formats):
         while format_spec.endswith(']'):
             format_spec, available_formats = self._apply_format_filter(
@@ -939,6 +956,9 @@ class YoutubeDL(object):
                 f for f in available_formats
                 if f.get('vcodec') == 'none']
             if audio_formats:
+                af = self._bestaudio_for_lossless_extract(audio_formats)
+                if af:
+                    return af
                 return audio_formats[-1]
         elif format_spec == 'worstaudio':
             audio_formats = [


### PR DESCRIPTION
My scenario is the following. I'm downloading audio files from YouTube and I need the audio files in one of the following formats: mp3, ogg, m4a.

When I want ogg I'm doing `youtube-dl.exe --extract-audio --audio-format vorbis <url>` and it works, with verbose output I can see that `-acodec copy` is used by ffmpeg.

If I want mp3, instead of vorbis I specify mp3 and ffmpeg converts the best audio it finds to mp3, so that works also.

However if I specify aac/m4a in both cases `-acodec aac` will be used by ffmpeg, however if I execute `youtube-dl --list-formats <url>` I can see the following entries:

    140          m4a        audio only DASH audio  128k , m4a_dash container, aac  @128k (44100Hz), 2.93MiB
    171          webm       audio only DASH audio  151k , vorbis@128k (44100Hz), 3.15MiB

The audio stream of the same quality is available in aac so if need and aac/m4a and the end of the day I should download that instead of ogg.

I've hooked into `YoutubeDL.select_format` and if "bestaudio" is selected *and* --extract-audio was used *and* a preferred audio format was given *then* I'll try to find the DASH stream for the preferred format and choose that or fallback to the original "bestaudio".

I'm not sure that hooking into "bestaudio" is the best way to do this. Maybe a new --format specifier should be created for this scenario? "bestlossles" or I don't know. My needs are satisfied for now, feel free to agree, disagree and give advices :)