### PR TITLE
Remove redundant (and wrong) class parameters

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -576,11 +576,9 @@ class ContentTooShortError(Exception):
     download is too small for what the server announced first, indicating
     the connection was probably interrupted.
     """
-    # Both in bytes
-    downloaded = None
-    expected = None
 
     def __init__(self, downloaded, expected):
+        # Both in bytes
         self.downloaded = downloaded
         self.expected = expected
 


### PR DESCRIPTION
I just stumpled upon those two lines which are absolutely redundant, as the parameters are set in the constructor for every class instance. At the same time, class parameters and instance parameters are very different things in python so this might even cause harm :)