### PR TITLE
[viewster] extract the api auth token

### DIFF
--- a/youtube_dl/extractor/viewster.py
+++ b/youtube_dl/extractor/viewster.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals
+from http import cookies
 
 from .common import InfoExtractor
 from ..compat import (
@@ -62,7 +63,6 @@ class ViewsterIE(InfoExtractor):
     }]
 
     _ACCEPT_HEADER = 'application/json, text/javascript, */*; q=0.01'
-    _AUTH_TOKEN = '/YqhSYsx8EaU9Bsta3ojlA=='
 
     def _download_json(self, url, video_id, note='Downloading JSON metadata', fatal=True):
         request = compat_urllib_request.Request(url)
@@ -72,6 +72,10 @@ class ViewsterIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
+        request = compat_urllib_request.urlopen(url)
+        C = cookies.SimpleCookie()
+        C.load(request.getheader('Set-Cookie'))
+        self._AUTH_TOKEN = compat_urllib_parse.unquote(C['api_token'].value)
 
         info = self._download_json(
             'https://public-api.viewster.com/search/%s' % video_id,


### PR DESCRIPTION
it should fix the 403 error like that:
```
youtube-dl -v http://www.viewster.com/serie/1152-12102-000/house-of-venus-show-season-1/
[debug] System config: []
[debug] User config: ['--external-downloader', 'aria2c', '--external-downloader-args', '-x 16 --check-certificate=false', '-f', 'best[height<=?720]', '--sub-lang', 'ar,en', '--write-sub']
[debug] Command-line args: ['-v', 'http://www.viewster.com/serie/1152-12102-000/house-of-venus-show-season-1/']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2015.07.21
[debug] Python version 3.4.3 - Linux-4.1.2-2-ARCH-x86_64-with-arch-Arch-Linux
[debug] exe versions: ffmpeg 2.7.2, ffprobe 2.7.2, rtmpdump 2.4
[debug] Proxy map: {}
[Viewster] 1152-12102-000: Downloading entry JSON
ERROR: Unable to download JSON metadata: HTTP Error 403: Forbidden (caused by HTTPError()); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
  File "/usr/lib/python3.4/site-packages/youtube_dl/extractor/common.py", line 314, in _request_webpage
    return self._downloader.urlopen(url_or_request)
  File "/usr/lib/python3.4/site-packages/youtube_dl/YoutubeDL.py", line 1731, in urlopen
    return self._opener.open(req, timeout=self._socket_timeout)
  File "/usr/lib/python3.4/urllib/request.py", line 469, in open
    response = meth(req, response)
  File "/usr/lib/python3.4/urllib/request.py", line 579, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.4/urllib/request.py", line 507, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.4/urllib/request.py", line 441, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.4/urllib/request.py", line 587, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
```
after the change
```
youtube-dl -v http://www.viewster.com/serie/1152-12102-000/house-of-venus-show-season-1/
[debug] System config: []
[debug] User config: ['--external-downloader', 'aria2c', '--external-downloader-args', '-x 16 --check-certificate=false', '-f', 'best[height<=?720]', '--sub-lang', 'ar,en', '--write-sub']
[debug] Command-line args: ['-v', 'http://www.viewster.com/serie/1152-12102-000/house-of-venus-show-season-1/']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2015.07.21
[debug] Python version 3.4.3 - Linux-4.1.2-2-ARCH-x86_64-with-arch-Arch-Linux
[debug] exe versions: ffmpeg 2.7.2, ffprobe 2.7.2, rtmpdump 2.4
[debug] Proxy map: {}
[Viewster] 1152-12102-000: Downloading entry JSON
[Viewster] 1152-12102-000: Downloading series JSON
[download] Downloading playlist: House of Venus Show - Season 1
[Viewster] playlist House of Venus Show - Season 1: Collected 6 video ids (downloading 6 of them)
[download] Downloading video 1 of 6
[Viewster] 1152-12102-001: Downloading entry JSON
[Viewster] 1152-12102-001: Downloading application/f4m+xml JSON
[Viewster] 1152-12102-001: Downloading f4m manifest
```
this what makes me think the problem is in the auth token
using the hard coded auth token:
```
curl 'https://public-api.viewster.com/search/1152-12102-000' -H 'Auth-token: /YqhSYsx8EaU9Bsta3ojlA=='
{"Message":"Authentication token is not valid."}
```
using an auth token extracted from the browser:
```
curl 'https://public-api.viewster.com/search/1152-12102-000' -H 'Auth-token: 5pFXpdDMP06lsLe5K/zinw=='
{"Id":1468,"OriginId":"1152-12102-000","Title":"House of Venus Show - Season 1","Type":"Serie","Country":"Canada","Actors":"Amanda Lepore, Cotton, Dickey Doo, Jennifer Legge, Lady Miss Kier, Mark Kenneth Woods, Michael Venus","Directors":"Mark Kenneth Woods","Genres":[{"Id":9,"Name":"Documentary"}],"Synopsis":{"Id":1648,"Title":"House of Venus Show - Season 1","Language":"EN","Short":"\"The House of Venus Show\" is a half-hour variety show featuring comedic sketches, interviews and musical numbers.","Detailed":"\"The House of Venus Show\" is a half-hour variety show featuring comedic sketches, interviews and musical numbers. The show entertains by cleverly spoofing social and political phenomena and popular culture with a definite queer \"twist\". The show also incorporates guest performances by local and international artists."},"Duration":null,"ReleaseDate":"2005-07-05T00:00:00","LanguageSets":[{"Audio":"en","Subtitle":null}]}
```