### PR TITLE
[extractor/common] do not process f4m manifest that contain akamai playerVerificationChallenge

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -856,6 +856,13 @@ class InfoExtractor(object):
             # (see https://github.com/rg3/youtube-dl/issues/6215#issuecomment-121704244)
             transform_source=transform_source)
 
+        # currently youtube-dl cannot decode the playerVerificationChallenge as Akamai uses Adobe Alchemy
+        akamai_pv = manifest.find('{http://ns.adobe.com/f4m/1.0}pv-2.0')
+        if akamai_pv is not None and ';' in akamai_pv.text:
+            playerVerificationChallenge = akamai_pv.text.split(';')[0]
+            if playerVerificationChallenge.strip() != '':
+                return []
+
         formats = []
         manifest_version = '1.0'
         media_nodes = manifest.findall('{http://ns.adobe.com/f4m/1.0}media')


### PR DESCRIPTION
this is related to this issue https://github.com/rg3/youtube-dl/issues/4142 it should prevent the 403 problem.
do not extract formats from manifest that need to decrypt the playerVerificationChallenge
for example this manifest from this url http://pluzz.francetv.fr/videos/des_jours_et_des_vies_ep3799_,125800219.html contain this pv-2.0:
```
ZXhwPTE0MzgzNTM0MTh+YWNsPSUyZip+ZGF0YT1wdmMsc35obWFjPWQ0NjJhNTBmYTQ3NjY3YTNhOTNjNmFmYjkyMTZkMzY5Y2Y2ODE5MjJlOTVlMWQ4NmU1MGM1OTZjY2MxMDcwYWU=;hdntl=exp=1438353418~acl=%2fz%2fstreaming-adaptatif_media-secure_france-dom-tom%2f2015%2fS31%2fJ3%2f125800219-55b882629a8d2-,standard1,standard2,standard3,standard4,standard5,.mp4.csmil*~data=hdntl~hmac=df6e06dc773f6b93d80e9352b4eef4048d138c88c68416b37b20ae0f027d29e3
```
the first part before the `;` is the playerVerificationChallenge and it is difficult to decrypt it and extract the pvtoken parameter because akamai use Adobe Alchemy.
this is another url http://pluzz.francetv.fr/videos/defile_du_14_juillet_f2_,125177628.html from the same site but it doesn't contain the playerVerificationChallenge youtube-dl can handle this type of pv-2.0:
```
;hdntl=exp=1438355588~acl=%2fz%2fstreaming-adaptatif%2f2015%2fS29%2fJ2%2f125177628-20150714-,398k,632k,934k,.mp4.csmil*~data=hdntl~hmac=cc2d1c764be50f46a6b95aa18fb249a517279736ed00d71663f81290570fcc08
```
this is the youtube-dl output for extracting the available formats of url that conatin manifest with playerVerificationChallenge:
before the change:
```
youtube-dl -F http://pluzz.francetv.fr/videos/des_jours_et_des_vies_ep3799_,125800219.html
[pluzz.francetv.fr] des_jours_et_des_vies_ep3799_,125800219: Downloading webpage
[pluzz.francetv.fr] 125800219: Downloading video JSON
[pluzz.francetv.fr] 125800219: Downloading f4m manifest token
[pluzz.francetv.fr] 125800219: Downloading f4m manifest
[pluzz.francetv.fr] 125800219: Downloading m3u8 information
[pluzz.francetv.fr] 125800219: Downloading m3u8 information
[info] Available formats for 125800219:
format code         extension  resolution note
hls_v5_os-meta      mp4        multiple   Quality selection URL 
m3u8-download-meta  mp4        multiple   Quality selection URL 
hls_v5_os-180       mp4        256x144     180k , avc1,  mp4a
m3u8-download-180   mp4        256x144     180k , avc1,  mp4a
hls_v5_os-303       mp4        320x180     303k , avc1,  mp4a
m3u8-download-303   mp4        320x180     303k , avc1,  mp4a
hls_v5_os-575       mp4        512x288     575k , avc1,  mp4a
m3u8-download-575   mp4        512x288     575k , avc1,  mp4a
hls_v5_os-831       mp4        704x396     831k , avc1,  mp4a
m3u8-download-831   mp4        704x396     831k , avc1,  mp4a
hls_v5_os-1467      mp4        1024x576   1467k , avc1,  mp4a
m3u8-download-1467  mp4        1024x576   1467k , avc1,  mp4a
hds_akamai-180      flv        unknown     180k 
hds_akamai-303      flv        unknown     303k 
hds_akamai-575      flv        unknown     575k 
hds_akamai-831      flv        unknown     831k 
hds_akamai-1467     flv        unknown    1467k  (best)
```
after the change:
```
youtube-dl -F http://pluzz.francetv.fr/videos/des_jours_et_des_vies_ep3799_,125800219.html
[pluzz.francetv.fr] des_jours_et_des_vies_ep3799_,125800219: Downloading webpage
[pluzz.francetv.fr] 125800219: Downloading video JSON
[pluzz.francetv.fr] 125800219: Downloading f4m manifest token
[pluzz.francetv.fr] 125800219: Downloading f4m manifest
[pluzz.francetv.fr] 125800219: Downloading m3u8 information
[pluzz.francetv.fr] 125800219: Downloading m3u8 information
[info] Available formats for 125800219:
format code         extension  resolution note
hls_v5_os-meta      mp4        multiple   Quality selection URL 
m3u8-download-meta  mp4        multiple   Quality selection URL 
hls_v5_os-180       mp4        256x144     180k , avc1,  mp4a
m3u8-download-180   mp4        256x144     180k , avc1,  mp4a
hls_v5_os-303       mp4        320x180     303k , avc1,  mp4a
m3u8-download-303   mp4        320x180     303k , avc1,  mp4a
hls_v5_os-575       mp4        512x288     575k , avc1,  mp4a
m3u8-download-575   mp4        512x288     575k , avc1,  mp4a
hls_v5_os-831       mp4        704x396     831k , avc1,  mp4a
m3u8-download-831   mp4        704x396     831k , avc1,  mp4a
hls_v5_os-1467      mp4        1024x576   1467k , avc1,  mp4a
m3u8-download-1467  mp4        1024x576   1467k , avc1,  mp4a (best)
```
and it still working for manifests that don't contain playerVerificationChallenge:
```
youtube-dl -F http://pluzz.francetv.fr/videos/defile_du_14_juillet_f2_,125177628.html
[pluzz.francetv.fr] defile_du_14_juillet_f2_,125177628: Downloading webpage
[pluzz.francetv.fr] 125177628: Downloading video JSON
[pluzz.francetv.fr] 125177628: Downloading f4m manifest token
[pluzz.francetv.fr] 125177628: Downloading f4m manifest
[pluzz.francetv.fr] 125177628: Downloading m3u8 information
[pluzz.francetv.fr] 125177628: Downloading m3u8 information
[info] Available formats for 125177628:
format code         extension  resolution note
hls_v5_os-meta      mp4        multiple   Quality selection URL 
m3u8-download-meta  mp4        multiple   Quality selection URL 
hls_v5_os-303       mp4        320x180     303k , avc1,  mp4a
m3u8-download-303   mp4        320x180     303k , avc1,  mp4a
hls_v5_os-575       mp4        512x288     575k , avc1,  mp4a
m3u8-download-575   mp4        512x288     575k , avc1,  mp4a
hls_v5_os-832       mp4        704x396     832k , avc1,  mp4a
m3u8-download-832   mp4        704x396     832k , avc1,  mp4a
hds_akamai-303      flv        unknown     303k 
hds_akamai-575      flv        unknown     575k 
hds_akamai-832      flv        unknown     832k  (best)
```