### PR TITLE
[gdcvault] Add support for audio extraction

### DIFF
--- a/youtube_dl/extractor/gdcvault.py
+++ b/youtube_dl/extractor/gdcvault.py
@@ -10,6 +10,7 @@ from ..compat import (
 from ..utils import (
     remove_end,
     determine_ext,
+    HEADRequest,
 )
 
 
@@ -150,8 +151,8 @@ class GDCVaultIE(InfoExtractor):
                 r'<td><strong>Session Name</strong></td>\s*<td>(.*?)</td>',
                 start_page, 'title')
             video_url = 'http://www.gdcvault.com' + direct_url
-            request = compat_urllib_request.Request(video_url, method='HEAD')
-            head = compat_urllib_request.urlopen(request)
+            request = HEADRequest(video_url)
+            head = self._request_webpage(request, video_id)
 
             return {
                 'id': video_id,

--- a/youtube_dl/extractor/gdcvault.py
+++ b/youtube_dl/extractor/gdcvault.py
@@ -7,7 +7,10 @@ from ..compat import (
     compat_urllib_parse,
     compat_urllib_request,
 )
-from ..utils import remove_end
+from ..utils import (
+    remove_end,
+    determine_ext,
+)
 
 
 class GDCVaultIE(InfoExtractor):
@@ -73,10 +76,20 @@ class GDCVaultIE(InfoExtractor):
         return video_formats
 
     def _parse_flv(self, xml_description):
-        video_formats = []
+        formats = []
         akamai_url = xml_description.find('./metadata/akamaiHost').text
+        audios = xml_description.find('./metadata/audios')
+        if audios is not None:
+            for audio in audios:
+                formats.append({
+                    'url': 'rtmp://%s/ondemand?ovpfv=1.1' % akamai_url,
+                    'play_path': remove_end(audio.get('url'), '.flv'),
+                    'ext': 'flv',
+                    'vcodec': 'none',
+                    'format_id': audio.get('code'),
+                })
         slide_video_path = xml_description.find('./metadata/slideVideo').text
-        video_formats.append({
+        formats.append({
             'url': 'rtmp://%s/ondemand?ovpfv=1.1' % akamai_url,
             'play_path': remove_end(slide_video_path, '.flv'),
             'ext': 'flv',
@@ -86,7 +99,7 @@ class GDCVaultIE(InfoExtractor):
             'format_id': 'slides',
         })
         speaker_video_path = xml_description.find('./metadata/speakerVideo').text
-        video_formats.append({
+        formats.append({
             'url': 'rtmp://%s/ondemand?ovpfv=1.1' % akamai_url,
             'play_path': remove_end(speaker_video_path, '.flv'),
             'ext': 'flv',
@@ -95,7 +108,7 @@ class GDCVaultIE(InfoExtractor):
             'preference': -1,
             'format_id': 'speaker',
         })
-        return video_formats
+        return formats
 
     def _login(self, webpage_url, display_id):
         (username, password) = self._get_login_info()
@@ -133,16 +146,18 @@ class GDCVaultIE(InfoExtractor):
             r's1\.addVariable\("file",\s*encodeURIComponent\("(/[^"]+)"\)\);',
             start_page, 'url', default=None)
         if direct_url:
-            video_url = 'http://www.gdcvault.com/' + direct_url
             title = self._html_search_regex(
                 r'<td><strong>Session Name</strong></td>\s*<td>(.*?)</td>',
                 start_page, 'title')
+            video_url = 'http://www.gdcvault.com' + direct_url
+            request = compat_urllib_request.Request(video_url, method='HEAD')
+            head = compat_urllib_request.urlopen(request)
 
             return {
                 'id': video_id,
                 'display_id': display_id,
                 'url': video_url,
-                'ext': 'flv',
+                'ext': determine_ext(head.geturl()),
                 'title': title,
             }
 


### PR DESCRIPTION
related to this issue https://github.com/rg3/youtube-dl/issues/5784.
about keeping the flv extension for audio it's because when downloading it,ffprobe said that the container is flv but the audio codec is mp3 did i have to change the ext even if it is different from the container.
this is the output of ffprobe for the audio file:
```
Input #0, flv, from 'How to Create a Good Game - From My Experience of Designing Pac-Man-1014631.flv.part':
  Metadata:
    author          : 
    copyright       : 
    description     : 
    keywords        : 
    rating          : 
    title           : 
    presetname      : Custom
    audiodevice     : USB Audio CODEC 
    audiochannels   : 1
    audioinputvolume: 75
    canSeekToEnd    : false
    createdby       : FMS 3.5
    creationdate    : Wed Mar 02 16:30:34 2011
  Duration: 01:12:56.81, start: 0.000000, bitrate: 1 kb/s
    Stream #0:0: Audio: mp3, 22050 Hz, mono, s16p, 32 kb/s
```