### PR TITLE
[iqiyi] Fix iqiyi (2015-07-30): update the md5 salt (enc key) and other improvements

### DIFF
--- a/youtube_dl/extractor/iqiyi.py
+++ b/youtube_dl/extractor/iqiyi.py
@@ -214,7 +214,7 @@ class IqiyiIE(InfoExtractor):
         return raw_data
 
     def get_enc_key(self, swf_url, video_id):
-        enc_key = '8e29ab5666d041c3a1ea76e06dabdffb'
+        enc_key = '7c4d2505ad0544b88c7679c65d6748a1'
         return enc_key
 
     def _real_extract(self, url):


### PR DESCRIPTION
iqiyi updated its flash player at 2015-07-30 and changed the md5 salt (enc key). 

According to iqiyi's habit, now the old salt is still usable. 
But soon (maybe tomorrow or several hours later) iqiyi will refuse the old salt. 
Then must use the new salt. 

Other improvements:
+ fix 1080p parse (#6367)
+ add some formats description (#6315)
