### PR TITLE
[viewster] use head request to extract api token

### DIFF
--- a/youtube_dl/extractor/viewster.py
+++ b/youtube_dl/extractor/viewster.py
@@ -11,6 +11,7 @@ from ..utils import (
     determine_ext,
     int_or_none,
     parse_iso8601,
+    HEADRequest,
 )
 
 
@@ -73,7 +74,8 @@ class ViewsterIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         # Get 'api_token' cookie
-        self._request_webpage(url, video_id)
+        request = HEADRequest(url)
+        self._request_webpage(request, video_id)
         cookies = self._get_cookies(url)
         self._AUTH_TOKEN = compat_urllib_parse_unquote(cookies['api_token'].value)
 


### PR DESCRIPTION
since the request is made to extract the api token from the cookies and the content of the page is not needed it's better to use a head request it contain the api token and it load faster.
```
curl -I http://www.viewster.com/movie/1200-19447-000/riese/
HTTP/1.1 200 OK
Content-Length: 8067
Content-Type: text/html; charset=utf-8
Date: Fri, 31 Jul 2015 13:47:26 GMT
ETag: W/"1f83-bDxeKhrgGokQXHvrrNfaOA"
Last-Modified: Fri, 31 Jul 2015 13:47:26 GMT
Server: Microsoft-IIS/8.5
Set-Cookie: api_token=JTpk1J%2BcyUSgplJ4UWUcug%3D%3D; Max-Age=604800; Path=/; Expires=Fri, 07 Aug 2015 13:47:26 GMT
X-Powered-By: Express
X-Powered-By: ASP.NET
Connection: keep-alive
```