### PR TITLE
add support for merging multiple audios

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -398,7 +398,9 @@ class FFmpegMergerPP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
-        args = ['-c', 'copy', '-map', '0:v:0', '-map', '1:a:0']
+        args = ['-c', 'copy', '-map', '0:v:0']
+        for i in range(1, len(info['__files_to_merge'][1:]) + 1):
+            args.extend(['-map', '%d:a:0' % (i)])
         self._downloader.to_screen('[ffmpeg] Merging formats into "%s"' % filename)
         self.run_ffmpeg_multiple_files(info['__files_to_merge'], temp_filename, args)
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))


### PR DESCRIPTION
related to this issue https://github.com/rg3/youtube-dl/issues/6430.
this is an example(it's not practical but the feature is good for video with multiple audio for different languages like the one in the issue):
```
youtube-dl --keep-video -f 136+249+250+251+140 https://www.youtube.com/watch?v=Vqfy4ScRXFQ
...
[ffmpeg] Merging formats into "Maher Zain - Ya Nabi Salam Alayka (Arabic) _ ماهر زين - يا نبي سلام عليك _ Official Music Video-Vqfy4ScRXFQ.mkv"
```
this is the result:
```
ffprobe Maher\ Zain\ -\ Ya\ Nabi\ Salam\ Alayka\ \(Arabic\)\ _\ ماهر\ زين\ -\ يا\ نبي\ سلام\ عليك\ _\ Official\ Music\ Video-Vqfy4ScRXFQ.mkv
...
Input #0, matroska,webm, from 'Maher Zain - Ya Nabi Salam Alayka (Arabic) _ ماهر زين - يا نبي سلام عليك _ Official Music Video-Vqfy4ScRXFQ.mkv':
  Metadata:
    COMPATIBLE_BRANDS: iso6avc1mp41
    MAJOR_BRAND     : dash
    MINOR_VERSION   : 0
    ENCODER         : Lavf56.36.100
  Duration: 00:05:36.43, start: 0.007000, bitrate: 1443 kb/s
    Stream #0:0(und): Video: h264 (Main), yuv420p, 1280x720 [SAR 1:1 DAR 16:9], 23.98 fps, 23.98 tbr, 1k tbn, 47.95 tbc (default)
    Metadata:
      CREATION_TIME   : 2015-05-31 03:01:04
      LANGUAGE        : und
      HANDLER_NAME    : VideoHandler
    Stream #0:1(eng): Audio: opus, 48000 Hz, stereo, fltp (default)
    Stream #0:2(eng): Audio: opus, 48000 Hz, stereo, fltp (default)
    Stream #0:3(eng): Audio: opus, 48000 Hz, stereo, fltp (default)
    Stream #0:4(und): Audio: aac (LC), 44100 Hz, stereo, fltp (default)
    Metadata:
      CREATION_TIME   : 2015-05-31 02:57:43
      LANGUAGE        : und
      HANDLER_NAME    : SoundHandler
```