### PR TITLE
[player.pl] new extractor

### DIFF
--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -438,6 +438,7 @@ from .pinkbike import PinkbikeIE
 from .planetaplay import PlanetaPlayIE
 from .pladform import PladformIE
 from .played import PlayedIE
+from .playerpl import PlayerPLIE
 from .playfm import PlayFMIE
 from .playvid import PlayvidIE
 from .playwire import PlaywireIE

--- a/youtube_dl/extractor/playerpl.py
+++ b/youtube_dl/extractor/playerpl.py
@@ -1,0 +1,63 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import (
+    ExtractorError,
+    qualities,
+    parse_duration,
+    parse_iso8601,
+    unescapeHTML,
+)
+
+
+class PlayerPLIE(InfoExtractor):
+    IE_NAME = 'player.pl'
+    _VALID_URL = r'http://player\.pl/[a-z\-]+/[A-Za-z,0-9\-]+/[A-Za-z,0-9\-]+,(?P<id>\d+)\.html'
+
+    _TESTS = [{
+        'url': 'http://player.pl/programy-online/agencja-odcinki,1137/odcinek-1,zaginiony-brylant,S00E01,16830.html',
+        'info_dict': {
+            'id': '16830',
+            'ext': 'mp4',
+            'duration': 2665,
+            'title': 'Zaginiony brylant',
+            'description': 'Nasz agent, "Piękny Lolo", znalazł się w potrzasku. W trakcie wykonywania zadania musiał ukryć się w szafie. Nikt nie może go przyłapać na przeszukiwaniu willi bogatej rozwódki. Jego zadaniem jest odnaleźć zaginiony brylant należący do jej byłóego męża. Niestety zjawia się gosposia, która utrudnia ucieczką z mieszkania. To dopiero początek, bo w drugiej willi czeka go dramatyczna przeprawa \r\nz prawdziwym drapieżnikiem.\r\n',
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        json_url = ('http://player.pl/api/'
+            '?platform=ConnectedTV&terminal=Samsung&format=json&v=2.0&authKey=ba786b315508f0920eca1c34d65534cd'
+            '&type=episode&id=%s&sort=newest&m=getItem&deviceScreenHeight=1080&deviceScreenWidth=1920') % (video_id)
+
+        get_quality = qualities(['Bardzo niska', 'Niska', 'Średnia', 'Standard', 'Wysoka', 'Bardzo wysoka', 'HD'])
+
+        result = self._download_json(json_url, video_id)
+        if result['status'] != 'success':
+            raise ExtractorError('Player.pl returned an error: %r' % (result))
+        if not result['item']:
+            raise ExtractorError('Player.pl returned success, but item is empty', expected=True)
+
+        thumbnails = None # [{ 'url': thumb['url'] } for thumb in result['item'].get('thumbnail', ())] # XXX: relative URLs, but relative to what?
+
+        formats = []
+        for stream in result['item']['videos']['main']['video_content']:
+            stream_url = self._download_webpage(stream['url'], video_id, 'Downloading "%s" stream URL' % (stream['profile_name']))
+            formats.append({
+                'url': stream_url,
+                'quality': get_quality(stream['profile_name']),
+                'resolution': stream['profile_name'],
+            })
+        self._sort_formats(formats)
+
+        return {
+            'id': video_id,
+            'title': result['item']['title'] or ('%s: S%sE%s' % (result['item']['serie_title'], result['item']['season'] or '1', result['item']['episode'])),
+            'description': unescapeHTML(result['item'].get('lead')),
+            'duration': parse_duration(result['item']['run_time']),
+            'timestamp': parse_iso8601(result['item']['start_date'] + ':00', delimiter=' '), # XXX: timezone='Europe/Warsaw'
+            'formats': formats,
+            'thumbnail': thumbnails,
+        }


### PR DESCRIPTION
This should resolve #6396. I've ran into two metadata issues, so please take a look before merging.
1. One is that I couldn't get the full path to thumbnails from the data downloaded. There's a relative path in the JSON, but I couldn't find out to what it is relative. I gave up trying to download them and left a comment. Maybe someone else can figure this out; it's hardly critical anyway.
2. The other is timestamps. All timestamps are in the `Europe/Warsaw` time zone (which, depending on DST, is either CET (UTC+1) or CEST (UTC+2)), however `parse_iso8601` seems to only support a fixed time zone offset, irrespective of DST. I parse the timestamps as UTC; this way, instead of being wrong half of the time, it's wrong consistently. Proper support for time zones would probably necessitate adding a package like `pytz` as a dependency.
