### PR TITLE
[kaltura] add html5 player urls

### DIFF
--- a/youtube_dl/extractor/kaltura.py
+++ b/youtube_dl/extractor/kaltura.py
@@ -14,11 +14,12 @@ from ..utils import (
 class KalturaIE(InfoExtractor):
     _VALID_URL = r'''(?x)
     (?:kaltura:|
-       https?://(:?(?:www|cdnapisec)\.)?kaltura\.com/index\.php/kwidget/(?:[^/]+/)*?wid/_
-    )(?P<partner_id>\d+)
-    (?::|
-       /(?:[^/]+/)*?entry_id/
-    )(?P<id>[0-9a-z_]+)'''
+        https?://(:?(?:www|cdnapisec)\.)?kaltura\.com/(?:
+            (?:index\.php/kwidget/(?:[^/]+/)*?wid/_)|
+            (?:html5/html5lib/v(?:[\d.]+)/mwEmbedFrame.php/p/\d+)
+        )
+    )(?P<partner_id>\d+)?(?::|/(?:[^/]+/)*?entry_id/)(?P<id>[0-9a-z_]+)
+    (?:\?wid=_(?P<partner_id_html5>\d+))?'''
     _API_BASE = 'http://cdnapi.kaltura.com/api_v3/index.php?'
     _TESTS = [
         {
@@ -43,6 +44,10 @@ class KalturaIE(InfoExtractor):
             'url': 'https://cdnapisec.kaltura.com/index.php/kwidget/wid/_557781/uiconf_id/22845202/entry_id/1_plr1syf3',
             'only_matching': True,
         },
+        {
+            'url': 'https://cdnapisec.kaltura.com/html5/html5lib/v2.30.2/mwEmbedFrame.php/p/1337/uiconf_id/20540612/entry_id/1_sf5ovm7u?wid=_243342',
+            'only_matching': True,
+        }
     ]
 
     def _kaltura_api_call(self, video_id, actions, *args, **kwargs):
@@ -107,7 +112,7 @@ class KalturaIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         mobj = re.match(self._VALID_URL, url)
-        partner_id, entry_id = mobj.group('partner_id'), mobj.group('id')
+        partner_id, entry_id = mobj.group('partner_id') or mobj.group('partner_id_html5'), mobj.group('id')
 
         info, source_data = self._get_video_info(entry_id, partner_id)
 


### PR DESCRIPTION
Kaltura has an HTML5 player with different, newer scheme of URLs. Luckily, the same API calls still work, but the numbers gotten from the URL are in different order, so the regex looks worse. I did my best...