### PR TITLE
[utils] Strict HTTP responses (Closes #6727)

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -587,6 +587,11 @@ class ContentTooShortError(Exception):
 
 
 def _create_http_connection(ydl_handler, http_class, is_https, *args, **kwargs):
+    # Working around python 2 bug (see http://bugs.python.org/issue17849) by limiting
+    # expected HTTP responses to meet HTTP/1.0 or later (see also
+    # https://github.com/rg3/youtube-dl/issues/6727)
+    if sys.version_info < (3, 0):
+        kwargs['strict'] = True
     hc = http_class(*args, **kwargs)
     source_address = ydl_handler._params.get('source_address')
     if source_address is not None:


### PR DESCRIPTION
Working around [python 2 bug](http://bugs.python.org/issue17849) by limiting expected HTTP responses to meet HTTP/1.0 or later.