### PR TITLE
[downloader/external] Respect --no-check-certificate for curl and aria2c and --proxy for curl

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -53,6 +53,14 @@ class ExternalFD(FileDownloader):
             return [command_option]
         return [command_option, param]
 
+    def _bool_option(self, command_option, param, true_value='true', false_value='false', separator=None):
+        param = self.params.get(param)
+        if not isinstance(param, bool):
+            return []
+        if separator:
+            return [command_option + separator + (true_value if param else false_value)]
+        return [command_option, true_value if param else false_value]
+
     def _configuration_args(self, default=[]):
         ex_args = self.params.get('external_downloader_args')
         if ex_args is None:
@@ -123,7 +131,7 @@ class Aria2cFD(ExternalFD):
             cmd += ['--header', '%s: %s' % (key, val)]
         cmd += self._option('--interface', 'source_address')
         cmd += self._option('--all-proxy', 'proxy')
-        cmd += self._option('--check-certificate=false', 'nocheckcertificate')
+        cmd += self._bool_option('--check-certificate', 'nocheckcertificate', 'false', 'true', '=')
         cmd += ['--', info_dict['url']]
         return cmd
 

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -47,7 +47,7 @@ class ExternalFD(FileDownloader):
 
     def _option(self, command_option, param):
         param = self.params.get(param)
-        if param is None:
+        if param is None or param is False:
             return []
         if isinstance(param, bool):
             return [command_option]
@@ -80,6 +80,8 @@ class CurlFD(ExternalFD):
         for key, val in info_dict['http_headers'].items():
             cmd += ['--header', '%s: %s' % (key, val)]
         cmd += self._option('--interface', 'source_address')
+        cmd += self._option('--proxy', 'proxy')
+        cmd += self._option('--insecure', 'nocheckcertificate')
         cmd += self._configuration_args()
         cmd += ['--', info_dict['url']]
         return cmd
@@ -121,6 +123,7 @@ class Aria2cFD(ExternalFD):
             cmd += ['--header', '%s: %s' % (key, val)]
         cmd += self._option('--interface', 'source_address')
         cmd += self._option('--all-proxy', 'proxy')
+        cmd += self._option('--check-certificate=false', 'nocheckcertificate')
         cmd += ['--', info_dict['url']]
         return cmd
 

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -47,7 +47,7 @@ class ExternalFD(FileDownloader):
 
     def _option(self, command_option, param):
         param = self.params.get(param)
-        if param is None or param is False:
+        if param is None:
             return []
         return [command_option, param]
 
@@ -59,7 +59,7 @@ class ExternalFD(FileDownloader):
             return [command_option + separator + (true_value if param else false_value)]
         return [command_option, true_value if param else false_value]
 
-    def _argless_option(self, command_option, param, expected_value=True):
+    def _valueless_option(self, command_option, param, expected_value=True):
         param = self.params.get(param)
         return [command_option] if param == expected_value else []
 
@@ -91,7 +91,7 @@ class CurlFD(ExternalFD):
             cmd += ['--header', '%s: %s' % (key, val)]
         cmd += self._option('--interface', 'source_address')
         cmd += self._option('--proxy', 'proxy')
-        cmd += self._argless_option('--insecure', 'nocheckcertificate')
+        cmd += self._valueless_option('--insecure', 'nocheckcertificate')
         cmd += self._configuration_args()
         cmd += ['--', info_dict['url']]
         return cmd
@@ -114,7 +114,7 @@ class WgetFD(ExternalFD):
             cmd += ['--header', '%s: %s' % (key, val)]
         cmd += self._option('--bind-address', 'source_address')
         cmd += self._option('--proxy', 'proxy')
-        cmd += self._argless_option('--no-check-certificate', 'nocheckcertificate')
+        cmd += self._valueless_option('--no-check-certificate', 'nocheckcertificate')
         cmd += self._configuration_args()
         cmd += ['--', info_dict['url']]
         return cmd

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -49,8 +49,6 @@ class ExternalFD(FileDownloader):
         param = self.params.get(param)
         if param is None or param is False:
             return []
-        if isinstance(param, bool):
-            return [command_option]
         return [command_option, param]
 
     def _bool_option(self, command_option, param, true_value='true', false_value='false', separator=None):
@@ -60,6 +58,10 @@ class ExternalFD(FileDownloader):
         if separator:
             return [command_option + separator + (true_value if param else false_value)]
         return [command_option, true_value if param else false_value]
+
+    def _argless_option(self, command_option, param, expected_value=True):
+        param = self.params.get(param)
+        return [command_option] if param == expected_value else []
 
     def _configuration_args(self, default=[]):
         ex_args = self.params.get('external_downloader_args')
@@ -89,7 +91,7 @@ class CurlFD(ExternalFD):
             cmd += ['--header', '%s: %s' % (key, val)]
         cmd += self._option('--interface', 'source_address')
         cmd += self._option('--proxy', 'proxy')
-        cmd += self._option('--insecure', 'nocheckcertificate')
+        cmd += self._argless_option('--insecure', 'nocheckcertificate')
         cmd += self._configuration_args()
         cmd += ['--', info_dict['url']]
         return cmd
@@ -112,7 +114,7 @@ class WgetFD(ExternalFD):
             cmd += ['--header', '%s: %s' % (key, val)]
         cmd += self._option('--bind-address', 'source_address')
         cmd += self._option('--proxy', 'proxy')
-        cmd += self._option('--no-check-certificate', 'nocheckcertificate')
+        cmd += self._argless_option('--no-check-certificate', 'nocheckcertificate')
         cmd += self._configuration_args()
         cmd += ['--', info_dict['url']]
         return cmd


### PR DESCRIPTION
if i didn't set `--no-check-certificate` the value of `param` is `False` then it pass this condition:
```python
if isinstance(param, bool):
```
that makes it apply regardless of setting it or not.
so i added this condition to fix it:
```python
or param is False
```