### PR TITLE
[test/test_write_annotations] fix expected test filename

### DIFF
--- a/test/test_write_annotations.py
+++ b/test/test_write_annotations.py
@@ -33,7 +33,7 @@ params = get_params({
 
 
 TEST_ID = 'gr51aVj-mLg'
-ANNOTATIONS_FILE = TEST_ID + '.flv.annotations.xml'
+ANNOTATIONS_FILE = TEST_ID + '.annotations.xml'
 EXPECTED_ANNOTATIONS = ['Speech bubble', 'Note', 'Title', 'Spotlight', 'Label']
 
 


### PR DESCRIPTION
because `ext` is replaced here:https://github.com/rg3/youtube-dl/blob/master/youtube_dl/YoutubeDL.py#L1464