### PR TITLE
[ajazzera] skip test

### DIFF
--- a/youtube_dl/extractor/aljazeera.py
+++ b/youtube_dl/extractor/aljazeera.py
@@ -16,6 +16,7 @@ class AlJazeeraIE(InfoExtractor):
             'uploader': 'Al Jazeera English',
         },
         'add_ie': ['Brightcove'],
+        'skip': 'Not accessible from Travis CI server',
     }
 
     def _real_extract(self, url):


### PR DESCRIPTION
the video is working it just not accessible from travis-ci
```
http://www.aljazeera.com/programmes/the-slum/2014/08/deliverance-201482883754237240.html
[AlJazeera] deliverance-201482883754237240: Downloading webpage
[Brightcove] 3792260579001: Downloading webpage
[Brightcove] 3792260579001: Extracting information
[download] Destination: The Slum - Episode 1 - Deliverance-3792260579001.mp4
[#8402c7 8.0MiB/1.5GiB(0%) CN:16 DL:238KiB ETA:1h49m14s]
```
in travis-ci log:
```
======================================================================
ERROR: test_AlJazeera (test.test_download.TestDownload)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/rg3/youtube-dl/test/test_download.py", line 141, in test_template
    force_generic_extractor=params.get('force_generic_extractor', False))
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/YoutubeDL.py", line 671, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/YoutubeDL.py", line 724, in process_ie_result
    extra_info=extra_info)
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/YoutubeDL.py", line 675, in extract_info
    self.report_error(compat_str(de), de.format_traceback())
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/YoutubeDL.py", line 535, in report_error
    self.trouble(error_message, tb)
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/YoutubeDL.py", line 505, in trouble
    raise DownloadError(message, exc_info)
nose.proxy.DownloadError: [0;31mERROR:[0m brightcove said: The video you are trying to watch cannot be viewed from your current country or location.
-------------------- >> begin captured stdout << ---------------------
[AlJazeera] deliverance-201482883754237240: Downloading webpage
[Brightcove] 3792260579001: Downloading webpage
[0;31mERROR:[0m brightcove said: The video you are trying to watch cannot be viewed from your current country or location.
Traceback (most recent call last):
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/YoutubeDL.py", line 660, in extract_info
    ie_result = ie.extract(url)
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/extractor/common.py", line 287, in extract
    return self._real_extract(url)
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/extractor/brightcove.py", line 237, in _real_extract
    videoPlayer[0], query_str, query, referer=referer)
  File "/home/travis/build/rg3/youtube-dl/youtube_dl/extractor/brightcove.py", line 261, in _get_video_info
    'brightcove said: %s' % error_msg, expected=True)
youtube_dl.utils.ExtractorError: brightcove said: The video you are trying to watch cannot be viewed from your current country or location.


--------------------- >> end captured stdout << ----------------------
```