### PR TITLE
More title extraction fixing.

### DIFF
--- a/youtube_dl/extractor/xhamster.py
+++ b/youtube_dl/extractor/xhamster.py
@@ -64,7 +64,7 @@ class XHamsterIE(InfoExtractor):
         webpage = self._download_webpage(mrss_url, video_id)
 
         title = self._html_search_regex(
-            [r'<title>(?P<title>.+?)(?:, Free Porn: xHamster| - xHamster\.com)</title>',
+            [r'<title>(?P<title>.+?)(?:, (?:[^,]+? )?Porn: xHamster| - xHamster\.com)</title>',
              r'<h1>([^<]+)</h1>'], webpage, 'title')
 
         # Only a few videos have an description


### PR DESCRIPTION
xHamster does not just use “Free Porn”. The fix for #6944 in 4395ca2 is not complete. If you look at the titles from the `_TESTS` in the extractor file you will find:

* (%title), HD Porn: xHamster
* (%title), Free Celebrity Porn: xHamster
* (%title), Free Amateur Porn: xHamster

Some others I have seen:

* (%title), Free Asian Porn: xHamster
* (%title), Porn: xHamster

The new title structure is “Porn: xHamster” with an **optional** one or 2 word descriptor. I think this pull should cover all possible titles.