### PR TITLE
[pluralsight] prevent error 429 when sensing video formats

### DIFF
--- a/youtube_dl/extractor/pluralsight.py
+++ b/youtube_dl/extractor/pluralsight.py
@@ -138,6 +138,9 @@ class PluralsightIE(InfoExtractor):
                 format_id = '%s-%s' % (ext, quality)
                 clip_url = self._download_webpage(
                     request, display_id, 'Downloading %s URL' % format_id, fatal=False)
+                # #6989: sleep 3 seconds to avoid 429 errors.
+                # should help with #6842.
+                self._sleep(3, display_id)
                 if not clip_url:
                     continue
                 f.update({


### PR DESCRIPTION
Fetching urls for different qualities too fast causes pluralsight to return Error 429, which in turn causes script not to recognize the formats that returned an error. Decided to re-use sleep-interval option used for downloading files.