### PR TITLE
YouTube: Get titles from playlist (fix #6699)

### DIFF
--- a/test/test_youtube_lists.py
+++ b/test/test_youtube_lists.py
@@ -58,11 +58,20 @@ class TestYoutubeLists(unittest.TestCase):
         # Save generator output
         playlist = [v for v in result['entries']]
 
+        # Find videos in playlist
         for video in videos:
             matching_videos = [v for v in playlist if v['id'] == video['id']]
 
             self.assertEqual(len(matching_videos), 1)
             self.assertEqual(matching_videos[0]['title'], video['title'])
+
+        # TODO: It would be good to check that the videos are returned
+        # in the correct order (not necessarily back-to-back), which,
+        # of course, requires creating the test data in the correct
+        # order. The reason is that simple mistakes (like forgetting
+        # that dicts don't keep insertion order) can result in the
+        # order being wrong. This could be in a separate test, or it
+        # could go here.
 
     def test_youtube_playlist_noplaylist(self):
         dl = FakeYDL()

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1440,23 +1440,7 @@ class YoutubePlaylistIE(YoutubeBaseInfoExtractor):
                         ((?:PL|LL|EC|UU|FL|RD|UL)[0-9A-Za-z-_]{10,})
                      )"""
     _TEMPLATE_URL = 'https://www.youtube.com/playlist?list=%s'
-    _VIDEO_RE = re.compile(
-        r"""href="\s*/watch\?
-
-        # Video ID
-        v=(?P<id>[0-9A-Za-z_-]{11})&amp;
-
-        [^"]*?
-
-        # Index
-        index=(?P<index>\d+)[^>]+
-
-        # End of <a> tag
-        >
-
-        # Video title (optional)
-        (?P<title>[^<]+)?
-        """, re.VERBOSE)
+    _VIDEO_RE = re.compile(r'href="\s*/watch\?v=(?P<id>[0-9A-Za-z_-]{11})&amp;[^"]*?index=(?P<index>\d+)[^>]+>(?P<title>[^<]+)?')
     IE_NAME = 'youtube:playlist'
     _TESTS = [{
         'url': 'https://www.youtube.com/playlist?list=PLwiyx1dc3P2JR9N8gQaQN_BCvlSlap7re',


### PR DESCRIPTION
Parse video titles from playlist pages' HTML/JSON.  This broke a
while back when YouTube changed something.  Now running
"-j --flat-playlist" will return both IDs and titles of videos again.