### PR TITLE
YouTube: Output URLs in "url" field, not IDs

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1579,7 +1579,7 @@ class YoutubePlaylistIE(YoutubeBaseInfoExtractor):
                               if m.group('title').strip()]  # Ignore links without titles, which also prevents duplicates
 
                 for video in new_videos:
-                    yield self.url_result(video['id'], 'Youtube', video_id=video['id'], video_title=video['title'])
+                    yield self.url_result('https://youtu.be/%s' % video['id'], 'Youtube', video_id=video['id'], video_title=video['title'])
 
                 # Find link to load more videos
                 mobj = re.search(r'data-uix-load-more-href="/?(?P<more>[^"]+)"', more_widget_html)


### PR DESCRIPTION
`-j --flat-playlist` was outputting the video ID instead of the video URL in the "url" element of the JSON.  Now it outputs, e.g. 
```
{"url": "https://youtu.be/uhKejRHODOM", "_type": "url", "ie_key": "Youtube", "id": "uhKejRHODOM", "title": "The Overly Complicated Coffee Order"}
```