### PR TITLE
Make the native hls downloader use disk space more efficiently

### DIFF
--- a/youtube_dl/downloader/fragment.py
+++ b/youtube_dl/downloader/fragment.py
@@ -49,7 +49,10 @@ class FragmentFD(FileDownloader):
 
     def _start_frag_download(self, ctx):
         total_frags = ctx['total_frags']
-        downloaded_bytes = os.path.getsize(ctx['tmpfilename']) if ctx.get('continue_dl') else 0
+        try:
+            downloaded_bytes = os.path.getsize(ctx['tmpfilename']) if ctx.get('continue_dl') else 0
+        except os.error as e:
+            downloaded_bytes = 0
         frag_index = ctx['continue_fragment'] + 1 if ctx.get('continue_fragment') else 0
         # This dict stores the download progress, it's updated by the progress
         # hook

--- a/youtube_dl/downloader/fragment.py
+++ b/youtube_dl/downloader/fragment.py
@@ -21,11 +21,11 @@ class FragmentFD(FileDownloader):
     A base file downloader class for fragmented media (e.g. f4m/m3u8 manifests).
     """
 
-    def _prepare_and_start_frag_download(self, ctx, continue_dl=False, continue_fragment=None):
-        self._prepare_frag_download(ctx, continue_dl)
-        self._start_frag_download(ctx, continue_fragment)
+    def _prepare_and_start_frag_download(self, ctx):
+        self._prepare_frag_download(ctx)
+        self._start_frag_download(ctx)
 
-    def _prepare_frag_download(self, ctx, continue_dl=False):
+    def _prepare_frag_download(self, ctx):
         self.to_screen('[%s] Total fragments: %d' % (self.FD_NAME, ctx['total_frags']))
         self.report_destination(ctx['filename'])
         dl = HttpQuietDownloader(
@@ -40,20 +40,17 @@ class FragmentFD(FileDownloader):
             }
         )
         tmpfilename = self.temp_name(ctx['filename'])
-        dest_stream, tmpfilename = sanitize_open(tmpfilename, 'ab' if continue_dl else 'wb')
+        dest_stream, tmpfilename = sanitize_open(tmpfilename, 'ab' if ctx.get('continue_dl') else 'wb')
         ctx.update({
             'dl': dl,
             'dest_stream': dest_stream,
             'tmpfilename': tmpfilename,
         })
 
-    def _start_frag_download(self, ctx, continue_fragment=None):
-        # continue_fragment is the last fragment that was already downloaded
-        # when continuing an old download or None when not continuing
-
+    def _start_frag_download(self, ctx):
         total_frags = ctx['total_frags']
-        downloaded_bytes = 0 if continue_fragment is None else os.path.getsize(ctx['tmpfilename'])
-        frag_index = 0 if continue_fragment is None else continue_fragment + 1
+        downloaded_bytes = os.path.getsize(ctx['tmpfilename']) if ctx.get('continue_dl') else 0
+        frag_index = ctx['continue_fragment'] + 1 if ctx.get('continue_fragment') else 0
         # This dict stores the download progress, it's updated by the progress
         # hook
         state = {

--- a/youtube_dl/downloader/hls.py
+++ b/youtube_dl/downloader/hls.py
@@ -111,9 +111,11 @@ class NativeHlsFD(FragmentFD):
         ctx = {
             'filename': filename,
             'total_frags': skipped_fragments + len(fragment_urls),
+            'continue_dl': True,
+            'continue_fragment': last_downloaded_segment
         }
 
-        self._prepare_and_start_frag_download(ctx, continue_dl=True, continue_fragment=last_downloaded_segment)
+        self._prepare_and_start_frag_download(ctx)
 
         for i, frag_url in enumerate(fragment_urls):
             frag_filename = '%s-Frag%d' % (ctx['tmpfilename'], skipped_fragments + i)


### PR DESCRIPTION
It now saves the url of the most recently completed segment to figure out from where it has to resume.
Before, it kept ALL segments which resulted in using double the disk space neccessary.
