### PR TITLE
Support for untitled videos (Issue #7186)

### DIFF
--- a/youtube_dl/extractor/jeuxvideo.py
+++ b/youtube_dl/extractor/jeuxvideo.py
@@ -29,6 +29,8 @@ class JeuxVideoIE(InfoExtractor):
         title = mobj.group(1)
         webpage = self._download_webpage(url, title)
         title = self._html_search_meta('name', webpage)
+        if title == None:
+            title = 'untitled'
         config_url = self._html_search_regex(
             r'data-src="(/contenu/medias/video.php.*?)"',
             webpage, 'config URL')


### PR DESCRIPTION
title is set to 'untitled' rather than None, which throws an error