### PR TITLE
Extract config URL from (new?) React-based Vimeo's page

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -286,7 +286,14 @@ class VimeoIE(VimeoBaseInfoExtractor):
         try:
             try:
                 config_url = self._html_search_regex(
-                    r' data-config-url="(.+?)"', webpage, 'config URL')
+                    r' data-config-url="(.+?)"', webpage,
+                    'config URL', default=None)
+                if not config_url:
+                    # New react-based page
+                    vimeo_clip_page_config = self._search_regex(
+                        r'vimeo\.clip_page_config\s*=\s*({.+?});', webpage,
+                        'vimeo clip page config')
+                    config_url = self._parse_json(vimeo_clip_page_config, video_id)['player']['config_url']
                 config_json = self._download_webpage(config_url, video_id)
                 config = json.loads(config_json)
             except RegexNotFoundError:


### PR DESCRIPTION
It seems that Vimeo has a new page design, that is served only by some servers. Which makes this super hard to debug, but you repeat extracting info for a Vimeo video, you will get an error like this:

```
$ PYTHONPATH=`pwd`  ./bin/youtube-dl --verbose --list-formats 'https://vimeo.com/72895266'
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'--verbose', u'--list-formats', u'https://vimeo.com/72895266']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2015.10.16
[debug] Git HEAD: 350c948
[debug] Python version 2.7.9 - Linux-3.19.0-30-generic-x86_64-with-Ubuntu-15.04-vivid
[debug] exe versions: ffmpeg 2.5.8-0ubuntu0.15.04.1, ffprobe 2.5.8-0ubuntu0.15.04.1, rtmpdump 2.4
[debug] Proxy map: {}
[vimeo] 72895266: Downloading webpage
[vimeo] 72895266: Extracting information
ERROR: Unable to extract info section (caused by RegexNotFoundError(u'Unable to extract \x1b[0;34minfo section\x1b[0m; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/vimeo.py", line 301, in _real_extract
    flags=re.DOTALL)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/common.py", line 584, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
RegexNotFoundError: Unable to extract info section; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/home/lukas/work/youtube-dl/youtube_dl/YoutubeDL.py", line 660, in extract_info
    ie_result = ie.extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/common.py", line 290, in extract
    return self._real_extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/vimeo.py", line 315, in _real_extract
    cause=e)
ExtractorError: Unable to extract info section (caused by RegexNotFoundError(u'Unable to extract \x1b[0;34minfo section\x1b[0m; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

On the new page, there is a new JS block, from which we can extract the player config URL:

```
 <script>
 window.vimeo = window.vimeo || {};
 window.vimeo.clip_page_config = {"clip":{"id":72895266,"title":"Irene Dreayer - Your Child\u2019s Image","description":null,"uploaded_on":"2013-08-22 09:22:44","uploaded_on_relative":"2 years ago","uploaded_on_full":"Thursday, August 22, 2013 at 9:22 AM EST","privacy":{"is_public":true,"type":"anybody","description":"Public"},"duration":{"raw":195,"formatted":"03:15"},"is_liked":false},"owner":{"id":19321715,"display_name":"Stacie Kessler","account_type":"plus","badge":null,"portrait":{"src":"https:\/\/i.vimeocdn.com\/portrait\/6164538_75x75.jpg","src_2x":"https:\/\/i.vimeocdn.com\/portrait\/6164538_150x150.jpg"},"url":"\/user19321715","is_following":false},"ondemand":null,"brand_channel":null,"cur_user":null,"status":{"state":"ready"},"copyright_status":{"is_blocked":false,"title":null,"message":null,"infringements":null},"content_block_status":{"is_blocked":false,"message":null,"continuous_play_enabled":false},"player":{"config_url":"https:\/\/player.vimeo.com\/video\/72895266\/config?autoplay=0&byline=0&collections=0&context=clip.main_beta&default_to_hd=1&outro=beginning&portrait=0&title=0&watch_trailer=0&s=3a81c847e6ccd550d3db7df3a56d2e73040c9dbe","player_url":"player.vimeo.com","dimensions":{"height":540,"width":955},"poster":{"url":"https:\/\/i.vimeocdn.com\/video\/446855617.jpg?mw=2000&mh=1080&q=70"}},"continuous_play_enabled":false,"thumbnail":{"src":"https:\/\/i.vimeocdn.com\/video\/446855617_190x107.jpg","src_2x":"https:\/\/i.vimeocdn.com\/video\/446855617_380x214.jpg","width":190,"height":107},"ads":{"sponsored_links":{"pub_id":"iwon-vimeo","keywords":"Irene Dreayer - Your Child's Image"},"display_ad":{"network_id":"54549544","unit_name":"clip","sizes":[300,250],"custom_targeting":{"content_rating":{}}}},"content_rating":null,"stat_counts":{"total_likes":{"raw":0,"formatted":"0"},"total_credits":{"raw":1,"formatted":"1"},"total_collections":{"raw":0,"formatted":"0"},"total_plays":{"raw":1,"formatted":"1"}},"notifications":[],"categories_config":{"categories":null,"total_categories":0},"music_track":null,"credits":{"total_credits":0},"tags":[],"api_app":null,"cc_license":null,"additional_content":{"clips":[],"context_name":"","context_url":"","view_all_url":""}};
  </script>
```