### PR TITLE
[vidme] Better error message for suspended vidme videos

### DIFF
--- a/youtube_dl/extractor/vidme.py
+++ b/youtube_dl/extractor/vidme.py
@@ -114,6 +114,12 @@ class VidmeIE(InfoExtractor):
 
         video = response['video']
 
+        if video.get('state') == 'user-disabled':
+            raise ExtractorError(
+                'Vidme said: This video has been suspended either due to a copyright claim, '
+                'or for violating the terms of use.',
+                expected=True)
+
         formats = [{
             'format_id': f.get('type'),
             'url': f['uri'],


### PR DESCRIPTION
```
$ PYTHONPATH=`pwd`  ./bin/youtube-dl --verbose --list-formats 'https://vid.me/dzGJ'
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'--verbose', u'--list-formats', u'https://vid.me/dzGJ']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2015.10.16
[debug] Git HEAD: dd84175
[debug] Python version 2.7.9 - Linux-3.19.0-30-generic-x86_64-with-Ubuntu-15.04-vivid
[debug] exe versions: ffmpeg 2.5.8-0ubuntu0.15.04.1, ffprobe 2.5.8-0ubuntu0.15.04.1, rtmpdump 2.4
[debug] Proxy map: {}
[Vidme] dzGJ: Downloading JSON metadata
ERROR: No video formats found; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/home/lukas/work/youtube-dl/youtube_dl/YoutubeDL.py", line 660, in extract_info
    ie_result = ie.extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/common.py", line 290, in extract
    return self._real_extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/vidme.py", line 124, in _real_extract
    self._sort_formats(formats)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/common.py", line 766, in _sort_formats
    raise ExtractorError('No video formats found')
ExtractorError: No video formats found; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

vs

```
$ PYTHONPATH=`pwd`  ./bin/youtube-dl --verbose --list-formats 'https://vid.me/dzGJ'
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'--verbose', u'--list-formats', u'https://vid.me/dzGJ']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2015.10.16
[debug] Git HEAD: 59fe482
[debug] Python version 2.7.9 - Linux-3.19.0-30-generic-x86_64-with-Ubuntu-15.04-vivid
[debug] exe versions: ffmpeg 2.5.8-0ubuntu0.15.04.1, ffprobe 2.5.8-0ubuntu0.15.04.1, rtmpdump 2.4
[debug] Proxy map: {}
[Vidme] dzGJ: Downloading JSON metadata
ERROR: Vidme said: This video has been suspended either due to a copyright claim, or for violating the terms of use.
Traceback (most recent call last):
  File "/home/lukas/work/youtube-dl/youtube_dl/YoutubeDL.py", line 660, in extract_info
    ie_result = ie.extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/common.py", line 290, in extract
    return self._real_extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/vidme.py", line 121, in _real_extract
    expected=True)
ExtractorError: Vidme said: This video has been suspended either due to a copyright claim, or for violating the terms of use.
```