### PR TITLE
[dailymotion] Report errors from player v5

### DIFF
--- a/youtube_dl/extractor/dailymotion.py
+++ b/youtube_dl/extractor/dailymotion.py
@@ -96,6 +96,11 @@ class DailymotionIE(DailymotionBaseInfoExtractor):
                 'uploader': 'HotWaves1012',
                 'age_limit': 18,
             }
+        },
+        # geo-restricted, player v5
+        {
+            'url': 'http://www.dailymotion.com/video/xhza0o',
+            'only_matching': True,
         }
     ]
 
@@ -124,6 +129,9 @@ class DailymotionIE(DailymotionBaseInfoExtractor):
         if player_v5:
             player = self._parse_json(player_v5, video_id)
             metadata = player['metadata']
+
+            self._check_error(metadata)
+
             formats = []
             for quality, media_list in metadata['qualities'].items():
                 for media in media_list:
@@ -201,9 +209,7 @@ class DailymotionIE(DailymotionBaseInfoExtractor):
                 'video info', flags=re.MULTILINE),
             video_id)
 
-        if info.get('error') is not None:
-            msg = 'Couldn\'t get video, Dailymotion says: %s' % info['error']['title']
-            raise ExtractorError(msg, expected=True)
+        self._check_error(info)
 
         formats = []
         for (key, format_id) in self._FORMATS:
@@ -245,6 +251,11 @@ class DailymotionIE(DailymotionBaseInfoExtractor):
             'view_count': view_count,
             'duration': info['duration']
         }
+
+    def _check_error(self, info):
+        if info.get('error') is not None:
+            msg = 'Couldn\'t get video, Dailymotion says: %s' % info['error']['title']
+            raise ExtractorError(msg, expected=True)
 
     def _get_subtitles(self, video_id, webpage):
         try:


### PR DESCRIPTION
Fixes this:

```
$ PYTHONPATH=`pwd`  ./bin/youtube-dl --verbose --list-formats 'http://www.dailymotion.com/video/xhza0o'
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'--verbose', u'--list-formats', u'http://www.dailymotion.com/video/xhza0o']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2015.10.16
[debug] Git HEAD: 59fe482
[debug] Python version 2.7.9 - Linux-3.19.0-30-generic-x86_64-with-Ubuntu-15.04-vivid
[debug] exe versions: ffmpeg 2.5.8-0ubuntu0.15.04.1, ffprobe 2.5.8-0ubuntu0.15.04.1, rtmpdump 2.4
[debug] Proxy map: {}
[dailymotion] xhza0o: Downloading webpage
{u'duration': 68,
 u'error': {u'code': u'DM007',
            u'message': u'Search for <a target="_top" href="/relevance/search/LISBOA+:+une+minute+avant+le+film" class="highlight">LISBOA : une minute avant le film</a> or enjoy more videos from the <a target="_top" href="http://www.dailymotion.com/en/channel/shortfilms" class="highlight">Movies</a> category.',
            u'raw_message': u'Search for LISBOA : une minute avant le film or enjoy more videos from the Movies category.',
            u'refresh': 0,
            u'status_code': 403,
            u'title': u'Video geo-restricted by the owner.'},
 u'id': u'xhza0o',
 u'poster_url': u'https://s1-ssl.dmcdn.net/Gqr0.jpg',
 u'title': u'LISBOA : une minute avant le film',
 u'url': u'https://www.dailymotion.com/video/xhza0o_lisboa-une-minute-avant-le-film_shortfilms'}
ERROR: An extractor error has occured. (caused by KeyError(u'qualities',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/common.py", line 290, in extract
    return self._real_extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/dailymotion.py", line 130, in _real_extract
    for quality, media_list in metadata['qualities'].items():
KeyError: u'qualities'
Traceback (most recent call last):
  File "/home/lukas/work/youtube-dl/youtube_dl/YoutubeDL.py", line 660, in extract_info
    ie_result = ie.extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/common.py", line 296, in extract
    raise ExtractorError('An extractor error has occured.', cause=e)
ExtractorError: An extractor error has occured. (caused by KeyError(u'qualities',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```