### PR TITLE
[soundcloud] Add Soundcloud search extractor

### DIFF
--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -567,7 +567,8 @@ from .soundcloud import (
     SoundcloudIE,
     SoundcloudSetIE,
     SoundcloudUserIE,
-    SoundcloudPlaylistIE
+    SoundcloudPlaylistIE,
+    SoundcloudSearchIE
 )
 from .soundgasm import (
     SoundgasmIE,

--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -532,11 +532,7 @@ class SoundcloudSearchIE(SearchInfoExtractor, SoundcloudIE):
             collection_id='Query "{0}"'.format(query),
             q=query.encode('utf-8'))
 
-        for _ in range(n):
-            try:
-                track = next(tracks)
-            except StopIteration:
-                break
+        for track in itertools.islice(tracks, n):
             uri = track['uri']
             title = track['title']
             results.append(self.url_result(url=uri))

--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -535,7 +535,7 @@ class SoundcloudSearchIE(SearchInfoExtractor, SoundcloudIE):
 
         if not results:
             raise ExtractorError(
-                '[soundcloud] No track results', expected=True)
+                'Soundcloud said: No track results', expected=True)
         
-        return self.playlist_result(results[:n], playlist_title=query)
+        return self.playlist_result(results, playlist_title=query)
 

--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -526,16 +526,12 @@ class SoundcloudSearchIE(SearchInfoExtractor, SoundcloudIE):
             next_url = response.get('next_href', None)
 
     def _get_n_results(self, query, n):
-        results = []
-
         tracks = self._get_collection('/search/tracks',
             collection_id='Query "{0}"'.format(query),
             q=query.encode('utf-8'))
 
-        for track in itertools.islice(tracks, n):
-            uri = track['uri']
-            title = track['title']
-            results.append(self.url_result(url=uri))
+        results = [self.url_result(url=track['uri'])
+            for track in itertools.islice(tracks, n)]
 
         if not results:
             raise ExtractorError(


### PR DESCRIPTION
It would be nice to be able to search for tracks on Soundcloud directly from youtube-dl.

I've added a `SoundcloudSearchIE` extractor that is invoked with `scsearch:"query"`. It uses the Soundcloud API v2.

Thanks.