### PR TITLE
fix regex in utils to avoid breaking json structure

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -260,7 +260,7 @@ def clean_html(html):
     html = re.sub(r'\s*<\s*br\s*/?\s*>\s*', '\n', html)
     html = re.sub(r'<\s*/\s*p\s*>\s*<\s*p[^>]*>', '\n', html)
     # Strip html tags
-    html = re.sub('<.*?>', '', html)
+    html = re.sub('<[^"]*>', '', html)
     # Replace html entities
     html = unescapeHTML(html)
     return html.strip()


### PR DESCRIPTION
Stripping out html tags not done correctly. It looks for longest regex, which can span multiple tags for even multiple json fields, which in some cases can break the whole json structure and make it unparsable.

For example in https://github.com/rg3/youtube-dl/issues/7254