### PR TITLE
Parallel nosetests

### DIFF
--- a/devscripts/run_tests.sh
+++ b/devscripts/run_tests.sh
@@ -16,4 +16,4 @@ case "$YTDL_TEST_SET" in
     ;;
 esac
 
-nosetests test --verbose $test_set
+nosetests test --verbose $test_set --processes=4 --process-timeout=540

--- a/devscripts/run_tests.sh
+++ b/devscripts/run_tests.sh
@@ -3,6 +3,7 @@
 DOWNLOAD_TESTS="age_restriction|download|subtitles|write_annotations|iqiyi_sdk_interpreter"
 
 test_set=""
+multiprocess_args=""
 
 case "$YTDL_TEST_SET" in
     core)
@@ -10,10 +11,11 @@ case "$YTDL_TEST_SET" in
     ;;
     download)
         test_set="-I test_(?!$DOWNLOAD_TESTS).+\.py"
+        multiprocess_args="--processes=4 --process-timeout=540"
     ;;
     *)
         break
     ;;
 esac
 
-nosetests test --verbose $test_set --processes=4 --process-timeout=540
+nosetests test --verbose $test_set $multiprocess_args

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -75,7 +75,7 @@ class TestDownload(unittest.TestCase):
 # Dynamically generate tests
 
 
-def generator(test_case):
+def generator(test_case, tname):
 
     def test_template(self):
         ie = youtube_dl.extractor.get_info_extractor(test_case['name'])
@@ -148,7 +148,7 @@ def generator(test_case):
                         raise
 
                     if try_num == RETRIES:
-                        report_warning('Failed due to network errors, skipping...')
+                        report_warning('%s failed due to network errors, skipping...' % tname)
                         return
 
                     print('Retrying: {0} failed tries\n\n##########\n\n'.format(try_num))
@@ -223,12 +223,12 @@ def generator(test_case):
 
 # And add them to TestDownload
 for n, test_case in enumerate(defs):
-    test_method = generator(test_case)
     tname = 'test_' + str(test_case['name'])
     i = 1
     while hasattr(TestDownload, tname):
         tname = 'test_%s_%d' % (test_case['name'], i)
         i += 1
+    test_method = generator(test_case, tname)
     test_method.__name__ = str(tname)
     setattr(TestDownload, test_method.__name__, test_method)
     del test_method

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -65,6 +65,8 @@ defs = gettestcases()
 
 
 class TestDownload(unittest.TestCase):
+    _multiprocess_shared_ = True
+
     maxDiff = None
 
     def setUp(self):

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -106,6 +106,7 @@ def generator(test_case, tname):
                 return
 
         params = get_params(test_case.get('params', {}))
+        params['outtmpl'] = tname + '_' + params['outtmpl']
         if is_playlist and 'playlist' not in test_case:
             params.setdefault('extract_flat', 'in_playlist')
             params.setdefault('skip_download', True)

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -65,6 +65,8 @@ defs = gettestcases()
 
 
 class TestDownload(unittest.TestCase):
+    # Parallel testing in nosetests. See
+    # http://nose.readthedocs.org/en/latest/doc_tests/test_multiprocess/multiprocess.html
     _multiprocess_shared_ = True
 
     maxDiff = None


### PR DESCRIPTION
With this patch, there will be no more congestion in Travis CI tests. Tries to solve #5289 and #7193.

Implementation considerations:
1. 4 processors: just my intuition. Larger values are fine.
2. 540-second timeout: Travis CI sets a 10-minute limit for output, I use 9 minutes.
3. `_multiprocess_shared_`: If I'm correct, `setUp` function of `TestDownload` is not reentrant. Is it?
4. Print test names in case of network errors. Just for easier debugging of such errors.

See https://travis-ci.org/yan12125/youtube-dl/builds/86834580 for the result.
