### PR TITLE
[spiegeltv] Fix Accept-Encoding issue (server chokes on gzip)

### DIFF
--- a/youtube_dl/extractor/spiegeltv.py
+++ b/youtube_dl/extractor/spiegeltv.py
@@ -83,6 +83,10 @@ class SpiegeltvIE(InfoExtractor):
                     preference=1,  # Prefer hls since it allows to workaround georestriction
                     m3u8_id='hls', fatal=False)
                 if m3u8_formats is not False:
+                    for m3u8_format in m3u8_formats:
+                        m3u8_format['http_headers'] = {
+                            'Accept-Encoding': 'deflate', # gzip causes trouble on the server side
+                        }
                     formats.extend(m3u8_formats)
             else:
                 formats.append({


### PR DESCRIPTION
The content server's responses are incomplete when the Accept-Encoding header includes `gzip`, so I removed it (Accept-Encoding in std_headers is normally set to `gzip,deflate`). As an alternative, one could set it to `*`. Seems to work fine, too.

The whole issue seems to be a bug on the server side, which we need to cope with.

Example video that fails: http://www.spiegel.tv/filme/zdfe-ice-pilots-nachwuchssorgen/