### PR TITLE
Remove trailing whitespaces on sanitizing filename

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -330,6 +330,10 @@ def sanitize_filename(s, restricted=False, is_id=False):
     # Handle timestamps
     s = re.sub(r'[0-9]+(?::[0-9]+)+', lambda m: m.group(0).replace(':', '_'), s)
     result = ''.join(map(replace_insane, s))
+
+    # Remove trailing spaces. os.mkdir fails to create directory ending with spaces on Windows.
+    result = result.rstrip()
+
     if not is_id:
         while '__' in result:
             result = result.replace('__', '_')


### PR DESCRIPTION
Python fails to make file or directory with the exact filename when it contains trailing spaces on Windows. When you do `os.mkdir(' foo ')` the directory " foo" will be made, which causes errors like the following.

```
> python -m youtube_dl --output "%(uploader)s/%(id)s.%(ext)s" --username hakatasiloving@gmail.com http://www.nicovideo.jp/watch/1445497631 --verbose
[debug] System config: []
[debug] User config: []
[debug] Command-line args: ['--output', '%(uploader)s/%(id)s.%(ext)s', '--username', 'PRIVATE', 'http://www.nicovideo.jp/watch/1445497631', '--verbose']
Type account password and press [Return]:
[debug] Encodings: locale cp932, fs mbcs, out cp932, pref cp932
[debug] youtube-dl version 2015.10.24
[debug] Git HEAD: 6722ebd
[debug] Python version 3.4.3 - Windows-8-6.2.9200
[debug] exe versions: ffmpeg N-50911-g9efcfbe, ffprobe 2.5.2, rtmpdump 2.3
[debug] Proxy map: {}
[niconico] Logging in
[niconico] 1445497631: Downloading webpage
[niconico] 1445497631: Downloading video info page
[niconico] 1445497631: Downloading flv info
[debug] Invoking downloader on 'http://smile-pow23.nicovideo.jp/smile?m=27423901.53970'
ERROR: unable to open for writing: [Errno 2] No such file or directory: 'Peeping Life TV シーズン1 \\1445497631.mp4.part'
Traceback (most recent call last):
  File "C:\Users\hakatashi\Documents\GitHub\youtube-dl\youtube_dl\downloader\http.py", line 174, in real_download
    (stream, tmpfilename) = sanitize_open(tmpfilename, open_mode)
  File "C:\Users\hakatashi\Documents\GitHub\youtube-dl\youtube_dl\utils.py", line 285, in sanitize_open
    stream = open(encodeFilename(filename), open_mode)
FileNotFoundError: [Errno 2] No such file or directory: 'Peeping Life TV シーズン1 \\1445497631.mp4.part'
```

I simply add a command for removing trailing whitespaces in `sanitize_filename` and it seems work.

Please review. Thanks.