### PR TITLE
Updated fix for downloading multiple formats with --download-archive argument

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1330,11 +1330,15 @@ class YoutubeDL(object):
         if download:
             if len(formats_to_download) > 1:
                 self.to_screen('[info] %s: downloading video in %s formats' % (info_dict['id'], len(formats_to_download)))
+            download_success = 0
             for format in formats_to_download:
                 new_info = dict(info_dict)
                 new_info.update(format)
-                self.process_info(new_info)
-            self.record_download_archive(info_dict)
+                success = self.process_info(new_info)
+                if success:
+                    download_success += 1
+            if download_success == len(formats_to_download):
+                self.record_download_archive(info_dict)
         # We update the info dict with the best quality format (backwards compatibility)
         info_dict.update(formats_to_download[-1])
         return info_dict
@@ -1650,6 +1654,8 @@ class YoutubeDL(object):
                 except (PostProcessingError) as err:
                     self.report_error('postprocessing: %s' % str(err))
                     return
+                
+                return success
 
     def download(self, url_list):
         """Download a given list of URLs."""

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1334,6 +1334,7 @@ class YoutubeDL(object):
                 new_info = dict(info_dict)
                 new_info.update(format)
                 self.process_info(new_info)
+            self.record_download_archive(info_dict)
         # We update the info dict with the best quality format (backwards compatibility)
         info_dict.update(formats_to_download[-1])
         return info_dict
@@ -1649,7 +1650,6 @@ class YoutubeDL(object):
                 except (PostProcessingError) as err:
                     self.report_error('postprocessing: %s' % str(err))
                     return
-                self.record_download_archive(info_dict)
 
     def download(self, url_list):
         """Download a given list of URLs."""


### PR DESCRIPTION
A updated fix for issue described in https://github.com/rg3/youtube-dl/issues/7022. This fixes the issues brought up in https://github.com/rg3/youtube-dl/pull/7467 where a record would be saved in a download archive even when a error occurs.