### PR TITLE
Add an info string when playlist download is finished

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -833,7 +833,7 @@ class YoutubeDL(object):
                                                       extra_info=extra)
                 playlist_results.append(entry_result)
             ie_result['entries'] = playlist_results
-            self.to_screen('[download] Playlist %s : download process finished' % playlist)
+            self.to_screen('[download] Finished downloading playlist: %s' % playlist)
             return ie_result
         elif result_type == 'compat_list':
             self.report_warning(

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -833,7 +833,7 @@ class YoutubeDL(object):
                                                       extra_info=extra)
                 playlist_results.append(entry_result)
             ie_result['entries'] = playlist_results
-            self.to_screen('[download] Playlist download process finished')
+            self.to_screen('[download] Playlist %s : download process finished' % playlist)
             return ie_result
         elif result_type == 'compat_list':
             self.report_warning(

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -833,7 +833,7 @@ class YoutubeDL(object):
                                                       extra_info=extra)
                 playlist_results.append(entry_result)
             ie_result['entries'] = playlist_results
-            self.to_screen('[info] Playlist download process finished')
+            self.to_screen('[download] Playlist download process finished')
             return ie_result
         elif result_type == 'compat_list':
             self.report_warning(

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -833,6 +833,8 @@ class YoutubeDL(object):
                                                       extra_info=extra)
                 playlist_results.append(entry_result)
             ie_result['entries'] = playlist_results
+            if result_type == 'playlist':
+                self.to_screen('[info] Playlist download process finished')
             return ie_result
         elif result_type == 'compat_list':
             self.report_warning(

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -833,8 +833,7 @@ class YoutubeDL(object):
                                                       extra_info=extra)
                 playlist_results.append(entry_result)
             ie_result['entries'] = playlist_results
-            if result_type == 'playlist':
-                self.to_screen('[info] Playlist download process finished')
+            self.to_screen('[info] Playlist download process finished')
             return ie_result
         elif result_type == 'compat_list':
             self.report_warning(


### PR DESCRIPTION
see #7517 
When the playlist is fully downloaded/converted, output an info message.
Without an indicator, it is very difficult to know when all playlist videos processing have finished  when youtube-dl is embedded in an external app. Just adding this line solves a lot of code/performance when building an app based on youtube-dl fro downloading playlists.