### PR TITLE
[youtube] Fallback instead of failing when title can't be determined

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1631,9 +1631,14 @@ class YoutubePlaylistIE(YoutubeBaseInfoExtractor, YoutubePlaylistBaseInfoExtract
             else:
                 self.report_warning('Youtube gives an alert message: ' + match)
 
-        playlist_title = self._html_search_regex(
-            r'(?s)<h1 class="pl-header-title[^"]*"[^>]*>\s*(.*?)\s*</h1>',
-            page, 'title')
+        playlist_title = str(playlist_id)
+
+        try:
+            playlist_title = self._html_search_regex(
+                r'(?s)<h1 class="pl-header-title[^"]*"[^>]*>\s*(.*?)\s*</h1>',
+                page, 'title')
+        except:
+            self.report_warning('Cannot extract playlist title, using playlist id instead')
 
         return self.playlist_result(self._entries(page, playlist_id), playlist_id, playlist_title)
 


### PR DESCRIPTION
**Bug:**

Sometimes, playlists on youtube can't be downloaded because the
title can't be extracted.

**Example:**

    $ youtube-dl --verbose --yes-playlist 'https://www.youtube.com/watch?v=SRFOD5P0K28&list=PLVzW5E8pn2CNJJW4U6EVN8LM9sGEguxO_&index=1'
    [debug] System config: []
    [debug] User config: []
    [debug] Command-line args: [u'--verbose', u'--yes-playlist', u'https://www.youtube.com/watch?v=SRFOD5P0K28&list=PLVzW5E8pn2CNJJW4U6EVN8LM9sGEguxO_&index=1']
    [debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
    [debug] youtube-dl version 2015.11.15
    [debug] Python version 2.7.10 - Linux-4.3.0+-x86_64-Intel-R-_Core-TM-_i5-3570K_CPU_@_3.40GHz-with-gentoo-2.2
    [debug] exe versions: ffmpeg 2.8.2, ffprobe 2.8.2, rtmpdump 2.4
    [debug] Proxy map: {}
    [youtube:playlist] Downloading playlist PLVzW5E8pn2CNJJW4U6EVN8LM9sGEguxO_ - add --no-playlist to just download video SRFOD5P0K28
    [youtube:playlist] PLVzW5E8pn2CNJJW4U6EVN8LM9sGEguxO_: Downloading webpage
    ERROR: Unable to extract title; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/site-packages/youtube_dl/YoutubeDL.py", line 661, in extract_info
        ie_result = ie.extract(url)
      File "/usr/lib64/python2.7/site-packages/youtube_dl/extractor/common.py", line 290, in extract
        return self._real_extract(url)
      File "/usr/lib64/python2.7/site-packages/youtube_dl/extractor/youtube.py", line 1644, in _real_extract
        return self._extract_playlist(playlist_id)
      File "/usr/lib64/python2.7/site-packages/youtube_dl/extractor/youtube.py", line 1619, in _extract_playlist
        page, 'title')
      File "/usr/lib64/python2.7/site-packages/youtube_dl/extractor/common.py", line 593, in _html_search_regex
        res = self._search_regex(pattern, string, name, default, fatal, flags, group)
      File "/usr/lib64/python2.7/site-packages/youtube_dl/extractor/common.py", line 584, in _search_regex
        raise RegexNotFoundError('Unable to extract %s' % _name)
    RegexNotFoundError: Unable to extract title; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
    
**Proposed solution:**

For me, in my particular use case, I don't care about the
title (I'm using mpv integration). So I'd be fine with it being
set to anything, as long as it doesn't fail.  This change seems
to work pretty well (for me, in my use case).