### PR TITLE
Add MTV81 extractor

### DIFF
--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -353,6 +353,7 @@ from .movshare import MovShareIE
 from .mtv import (
     MTVIE,
     MTVServicesEmbeddedIE,
+    MTV81IE,
     MTVIggyIE,
     MTVDEIE,
 )

--- a/youtube_dl/extractor/comedycentral.py
+++ b/youtube_dl/extractor/comedycentral.py
@@ -18,7 +18,7 @@ class ComedyCentralIE(MTVServicesInfoExtractor):
     _VALID_URL = r'''(?x)https?://(?:www\.)?cc\.com/
         (video-clips|episodes|cc-studios|video-collections|full-episodes)
         /(?P<title>.*)'''
-    _FEED_URL = 'http://comedycentral.com/feeds/mrss/'
+    _FEED_BASE_URL = 'http://comedycentral.com/feeds/mrss/'
 
     _TEST = {
         'url': 'http://www.cc.com/video-clips/kllhuv/stand-up-greg-fitzsimmons--uncensored---too-good-of-a-mother',

--- a/youtube_dl/extractor/gametrailers.py
+++ b/youtube_dl/extractor/gametrailers.py
@@ -16,4 +16,4 @@ class GametrailersIE(MTVServicesInfoExtractor):
         },
     }
 
-    _FEED_URL = 'http://www.gametrailers.com/feeds/mrss'
+    _FEED_BASE_URL = 'http://www.gametrailers.com/feeds/mrss'

--- a/youtube_dl/extractor/southpark.py
+++ b/youtube_dl/extractor/southpark.py
@@ -8,7 +8,7 @@ class SouthParkIE(MTVServicesInfoExtractor):
     IE_NAME = 'southpark.cc.com'
     _VALID_URL = r'https?://(?:www\.)?(?P<url>southpark\.cc\.com/(?:clips|full-episodes)/(?P<id>.+?)(\?|#|$))'
 
-    _FEED_URL = 'http://www.southparkstudios.com/feeds/video-player/mrss'
+    _FEED_BASE_URL = 'http://www.southparkstudios.com/feeds/video-player/mrss'
 
     _TESTS = [{
         'url': 'http://southpark.cc.com/clips/104437/bat-daded#tab=featured',
@@ -35,7 +35,7 @@ class SouthParkEsIE(SouthParkIE):
 class SouthParkDeIE(SouthParkIE):
     IE_NAME = 'southpark.de'
     _VALID_URL = r'https?://(?:www\.)?(?P<url>southpark\.de/(?:clips|alle-episoden)/(?P<id>.+?)(\?|#|$))'
-    _FEED_URL = 'http://www.southpark.de/feeds/video-player/mrss/'
+    _FEED_BASE_URL = 'http://www.southpark.de/feeds/video-player/mrss/'
 
     _TESTS = [{
         'url': 'http://www.southpark.de/clips/uygssh/the-government-wont-respect-my-privacy#tab=featured',
@@ -59,7 +59,7 @@ class SouthParkDeIE(SouthParkIE):
 class SouthParkNlIE(SouthParkIE):
     IE_NAME = 'southpark.nl'
     _VALID_URL = r'https?://(?:www\.)?(?P<url>southpark\.nl/(?:clips|full-episodes)/(?P<id>.+?)(\?|#|$))'
-    _FEED_URL = 'http://www.southpark.nl/feeds/video-player/mrss/'
+    _FEED_BASE_URL = 'http://www.southpark.nl/feeds/video-player/mrss/'
 
     _TESTS = [{
         'url': 'http://www.southpark.nl/full-episodes/s18e06-freemium-isnt-free',
@@ -70,7 +70,7 @@ class SouthParkNlIE(SouthParkIE):
 class SouthParkDkIE(SouthParkIE):
     IE_NAME = 'southparkstudios.dk'
     _VALID_URL = r'https?://(?:www\.)?(?P<url>southparkstudios\.dk/(?:clips|full-episodes)/(?P<id>.+?)(\?|#|$))'
-    _FEED_URL = 'http://www.southparkstudios.dk/feeds/video-player/mrss/'
+    _FEED_BASE_URL = 'http://www.southparkstudios.dk/feeds/video-player/mrss/'
 
     _TESTS = [{
         'url': 'http://www.southparkstudios.dk/full-episodes/s18e07-grounded-vindaloop',

--- a/youtube_dl/extractor/spike.py
+++ b/youtube_dl/extractor/spike.py
@@ -19,7 +19,7 @@ class SpikeIE(MTVServicesInfoExtractor):
         },
     }
 
-    _FEED_URL = 'http://www.spike.com/feeds/mrss/'
+    _FEED_BASE_URL = 'http://www.spike.com/feeds/mrss/'
     _MOBILE_TEMPLATE = 'http://m.spike.com/videos/video.rbml?id=%s'
 
     def _real_extract(self, url):


### PR DESCRIPTION
Support for videos from http://www.mtv81.com/ .

Composition of `MTVServicesInfoExtractor`'s feed URL is also moved `_get_feed_url` to allow its overriding.
