### PR TITLE
[youtube] Ignore yt:stretch with zero width/height

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -714,6 +714,22 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'url': 'https://www.youtube.com/watch?v=Ms7iBXnlUO8',
             'only_matching': True,
         },
+        {
+            # Video with yt:stretch=17:0
+            'url': 'https://www.youtube.com/watch?v=Q39EVAstoRM',
+            'info_dict': {
+                'id': 'Q39EVAstoRM',
+                'ext': 'mp4',
+                'title': 'Clash Of Clans#14 Dicas De Ataque Para CV 4',
+                'description': 'md5:ee18a25c350637c8faff806845bddee9',
+                'upload_date': '20151107',
+                'uploader_id': 'UCCr7TALkRbo3EtFzETQF1LA',
+                'uploader': 'CH GAMER DROID',
+            },
+            'params': {
+                'skip_download': True,
+            },
+        },
     ]
 
     def __init__(self, *args, **kwargs):
@@ -1496,10 +1512,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             r'<meta\s+property="og:video:tag".*?content="yt:stretch=(?P<w>[0-9]+):(?P<h>[0-9]+)">',
             video_webpage)
         if stretched_m:
-            ratio = float(stretched_m.group('w')) / float(stretched_m.group('h'))
-            for f in formats:
-                if f.get('vcodec') != 'none':
-                    f['stretched_ratio'] = ratio
+            w = float(stretched_m.group('w'))
+            h = float(stretched_m.group('h'))
+            if w > 0 and h > 0:
+                ratio = float(stretched_m.group('w')) / float(stretched_m.group('h'))
+                for f in formats:
+                    if f.get('vcodec') != 'none':
+                        f['stretched_ratio'] = ratio
 
         self._sort_formats(formats)
 

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1515,7 +1515,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             w = float(stretched_m.group('w'))
             h = float(stretched_m.group('h'))
             if w > 0 and h > 0:
-                ratio = float(stretched_m.group('w')) / float(stretched_m.group('h'))
+                ratio = w / h
                 for f in formats:
                     if f.get('vcodec') != 'none':
                         f['stretched_ratio'] = ratio


### PR DESCRIPTION
YouTube video Q39EVAstoRM can't be downloaded because it contains the `yt:stretch` attribute with zero height:

```
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'--verbose', u'--list-formats', u'https://www.youtube.com/watch?v=Q39EVAstoRM']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2015.11.27.1
[debug] Git HEAD: 78a55d7
[debug] Python version 2.7.10 - Linux-4.2.0-18-generic-x86_64-with-Ubuntu-15.10-wily
[debug] exe versions: ffmpeg 2.7.3-0ubuntu0.15.10.1, ffprobe 2.7.3-0ubuntu0.15.10.1, rtmpdump 2.4
[debug] Proxy map: {}
[youtube] Q39EVAstoRM: Downloading webpage
[youtube] Q39EVAstoRM: Downloading video info webpage
[youtube] Q39EVAstoRM: Extracting video information
[youtube] Q39EVAstoRM: Downloading DASH manifest 
[youtube] Q39EVAstoRM: Downloading DASH manifest
Traceback (most recent call last):
  File "./bin/youtube-dl", line 6, in <module>
    youtube_dl.main()
  File "/home/lukas/work/youtube-dl/youtube_dl/__init__.py", line 410, in main
    _real_main(argv)
  File "/home/lukas/work/youtube-dl/youtube_dl/__init__.py", line 400, in _real_main
    retcode = ydl.download(all_urls)
  File "/home/lukas/work/youtube-dl/youtube_dl/YoutubeDL.py", line 1669, in download
    url, force_generic_extractor=self.params.get('force_generic_extractor', False))
  File "/home/lukas/work/youtube-dl/youtube_dl/YoutubeDL.py", line 663, in extract_info
    ie_result = ie.extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/common.py", line 290, in extract
    return self._real_extract(url)
  File "/home/lukas/work/youtube-dl/youtube_dl/extractor/youtube.py", line 1499, in _real_extract
    ratio = float(stretched_m.group('w')) / float(stretched_m.group('h'))
ZeroDivisionError: float division by zero
```