### PR TITLE
fix warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ youtube-dl: youtube_dl/*.py youtube_dl/*/*.py
 	zip --quiet --junk-paths youtube-dl youtube_dl/__main__.py
 	echo '#!$(PYTHON)' > youtube-dl
 	cat youtube-dl.zip >> youtube-dl
+	zip --adjust-sfx youtube-dl
 	rm youtube-dl.zip
 	chmod a+x youtube-dl
 


### PR DESCRIPTION
```
$ unzip -t youtube-dl
Archive:  youtube-dl
warning [youtube-dl]:  22 extra bytes at beginning or within zipfile
  (attempting to process anyway)
    testing: youtube_dl/YoutubeDL.py   OK
    testing: youtube_dl/__init__.py   OK
    testing: youtube_dl/__main__.py   OK
...
```