### PR TITLE
[trilulilu] extract info from webpage

### DIFF
--- a/youtube_dl/extractor/trilulilu.py
+++ b/youtube_dl/extractor/trilulilu.py
@@ -1,11 +1,14 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import re
+
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
-    int_or_none,
     parse_iso8601,
+    js_to_json,
+    parse_duration,
 )
 
 
@@ -22,10 +25,6 @@ class TriluliluIE(InfoExtractor):
             'uploader_id': 'chipy',
             'upload_date': '20120304',
             'timestamp': 1330830647,
-            'uploader': 'chipy',
-            'view_count': int,
-            'like_count': int,
-            'comment_count': int,
         },
     }, {
         'url': 'http://www.trilulilu.ro/adena-ft-morreti-inocenta',
@@ -37,57 +36,59 @@ class TriluliluIE(InfoExtractor):
             'description': 'pop music',
             'uploader_id': 'VEVOmixt',
             'upload_date': '20151204',
-            'uploader': 'VEVOmixt',
             'timestamp': 1449187937,
-            'view_count': int,
-            'like_count': int,
-            'comment_count': int,
         },
     }]
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
-        media_info = self._download_json('http://m.trilulilu.ro/%s?format=json' % display_id, display_id)
+        webpage = self._download_webpage(url, display_id)
 
-        media_class = media_info.get('class')
+        if re.search(r'Fişierul nu este disponibil pentru vizionare în ţara dumneavoastră', webpage):
+            raise ExtractorError(
+                'This video is not available in your country.', expected=True)
+        elif re.search('Fişierul poate fi accesat doar de către prietenii lui', webpage):
+            raise ExtractorError('This video is private.', expected=True)
+
+        player_vars = self._parse_json(
+            self._search_regex(r'(?s)playerVars\s*=\s*({.+?});', webpage, 'player vars'),
+            display_id, js_to_json)
+
+        uploader_id, media_id = self._search_regex(
+            r'<input type="hidden" id="identifier" value="([^"]+)"',
+            webpage, 'identifier').split('|')
+
+        media_class = player_vars.get('fileClass')
         if media_class not in ('video', 'audio'):
             raise ExtractorError('not a video or an audio')
 
-        user = media_info.get('user', {})
-
-        thumbnail = media_info.get('cover_url')
-        if thumbnail:
-            thumbnail.format(width='1600', height='1200')
-
         # TODO: get correct ext for audio files
-        stream_type = media_info.get('stream_type')
         formats = [{
-            'url': media_info['href'],
-            'ext': stream_type,
+            'url': player_vars['file'],
+            'ext': player_vars.get('streamType'),
         }]
-        if media_info.get('is_hd'):
+
+        hd_url = player_vars.get('fileUrlHD')
+        if hd_url:
             formats.append({
                 'format_id': 'hd',
-                'url': media_info['hrefhd'],
-                'ext': stream_type,
+                'url': hd_url,
+                'ext': player_vars.get('fileTypeHD'),
             })
+
         if media_class == 'audio':
             formats[0]['vcodec'] = 'none'
         else:
             formats[0]['format_id'] = 'sd'
 
         return {
-            'id': media_info['identifier'].split('|')[1],
+            'id': media_id,
             'display_id': display_id,
             'formats': formats,
-            'title': media_info['title'],
-            'description': media_info.get('description'),
-            'thumbnail': thumbnail,
-            'uploader_id': user.get('username'),
-            'uploader': user.get('fullname'),
-            'timestamp': parse_iso8601(media_info.get('published'), ' '),
-            'duration': int_or_none(media_info.get('duration')),
-            'view_count': int_or_none(media_info.get('count_views')),
-            'like_count': int_or_none(media_info.get('count_likes')),
-            'comment_count': int_or_none(media_info.get('count_comments')),
+            'title': self._og_search_title(webpage),
+            'description': self._og_search_description(webpage),
+            'thumbnail': player_vars.get('image'),
+            'uploader_id': uploader_id,
+            'timestamp': parse_iso8601(self._html_search_meta('uploadDate', webpage), ' '),
+            'duration': parse_duration(self._html_search_meta('duration', webpage)),
         }


### PR DESCRIPTION
this approch also didn't work perfectly.
for example(http://www.trilulilu.ro/video-haioase/sa-ne-amuzam-gluma-de-tampiti-in-loc-de-buna-dimin)
using this code(it download a webpage):
```
python __main__.py http://www.trilulilu.ro/video-haioase/sa-ne-amuzam-gluma-de-tampiti-in-loc-de-buna-dimin
[Trilulilu] sa-ne-amuzam-gluma-de-tampiti-in-loc-de-buna-dimin: Downloading webpage
[download] Destination: Sa ne amuzam ....Gluma de tampiti    in loc de ... buna dimineata    -6ccf17c6d75ff7.flv
[#f73040 0B/0B CN:1 DL:0B]                                                     
12/05 08:38:17 [NOTICE] Download complete: /home/amine/youtube-dl/youtube_dl/Sa ne amuzam ....Gluma de tampiti    in loc de ... buna dimineata    -6ccf17c6d75ff7.flv.part

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
f73040|OK  |   3.7KiB/s|/home/amine/youtube-dl/youtube_dl/Sa ne amuzam ....Gluma de tampiti    in loc de ... buna dimineata    -6ccf17c6d75ff7.flv.part

Status Legend:
(OK):download completed.
[aria2c] Downloaded 110464 bytes
[download] 100% of 107.88KiB
```
```
ffprobe Sa\ ne\ amuzam\ ....Gluma\ de\ tampiti\ \ \ \ in\ loc\ de\ ...\ buna\ dimineata\ \ \ \ -6ccf17c6d75ff7.flv 
ffprobe version 2.8.2 Copyright (c) 2007-2015 the FFmpeg developers
  built with gcc 5.2.0 (GCC)
  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-avisynth --enable-avresample --enable-fontconfig --enable-gnutls --enable-gpl --enable-ladspa --enable-libass --enable-libbluray --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-libschroedinger --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-shared --enable-version3 --enable-x11grab
  libavutil      54. 31.100 / 54. 31.100
  libavcodec     56. 60.100 / 56. 60.100
  libavformat    56. 40.101 / 56. 40.101
  libavdevice    56.  4.100 / 56.  4.100
  libavfilter     5. 40.101 /  5. 40.101
  libavresample   2.  1.  0 /  2.  1.  0
  libswscale      3.  1.101 /  3.  1.101
  libswresample   1.  2.101 /  1.  2.101
  libpostproc    53.  3.100 / 53.  3.100
Sa ne amuzam ....Gluma de tampiti    in loc de ... buna dimineata    -6ccf17c6d75ff7.flv: Invalid data found when processing input
```
and using the code in the current master:
```
python __main__.py http://www.trilulilu.ro/video-haioase/sa-ne-amuzam-gluma-de-tampiti-in-loc-de-buna-dimin
[Trilulilu] sa-ne-amuzam-gluma-de-tampiti-in-loc-de-buna-dimin: Downloading JSON metadata
[download] Destination: Sa ne amuzam ....Gluma de tampiti    in loc de ... buna dimineata    -6ccf17c6d75ff7.flv
[#638138 3.0MiB/3.1MiB(96%) CN:2 DL:60KiB ETA:1s]                              
12/05 09:00:12 [NOTICE] Download complete: /home/amine/youtube-dl/youtube_dl/Sa ne amuzam ....Gluma de tampiti    in loc de ... buna dimineata    -6ccf17c6d75ff7.flv.part

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
638138|OK  |    66KiB/s|/home/amine/youtube-dl/youtube_dl/Sa ne amuzam ....Gluma de tampiti    in loc de ... buna dimineata    -6ccf17c6d75ff7.flv.part

Status Legend:
(OK):download completed.
[aria2c] Downloaded 3305887 bytes
[download] 100% of 3.15MiB
```
```
ffprobe Sa\ ne\ amuzam\ ....Gluma\ de\ tampiti\ \ \ \ in\ loc\ de\ ...\ buna\ dimineata\ \ \ \ -6ccf17c6d75ff7.flv 
ffprobe version 2.8.2 Copyright (c) 2007-2015 the FFmpeg developers
  built with gcc 5.2.0 (GCC)
  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-avisynth --enable-avresample --enable-fontconfig --enable-gnutls --enable-gpl --enable-ladspa --enable-libass --enable-libbluray --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-libschroedinger --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-shared --enable-version3 --enable-x11grab
  libavutil      54. 31.100 / 54. 31.100
  libavcodec     56. 60.100 / 56. 60.100
  libavformat    56. 40.101 / 56. 40.101
  libavdevice    56.  4.100 / 56.  4.100
  libavfilter     5. 40.101 /  5. 40.101
  libavresample   2.  1.  0 /  2.  1.  0
  libswscale      3.  1.101 /  3.  1.101
  libswresample   1.  2.101 /  1.  2.101
  libpostproc    53.  3.100 / 53.  3.100
Input #0, flv, from 'Sa ne amuzam ....Gluma de tampiti    in loc de ... buna dimineata    -6ccf17c6d75ff7.flv':
  Metadata:
    starttime       : 0
    totalduration   : 45
    totaldatarate   : 583
    bytelength      : 3304847
    canseekontime   : true
    sourcedata      : B4A7DD2E4HH1301320857895906
    purl            : 
    pmsg            : 
    httphostheader  : v4.cache8.c.youtube.com
  Duration: 00:00:45.32, start: 0.000000, bitrate: 583 kb/s
    Stream #0:0: Video: h264 (Main), yuv420p, 474x360 [SAR 1:1 DAR 79:60], 457 kb/s, 25 fps, 25 tbr, 1k tbn, 50 tbc
    Stream #0:1: Audio: aac (LC), 44100 Hz, stereo, fltp, 131 kb/s
```
it also didn't work for http://www.trilulilu.ro/big-buck-bunny-1 (at least for me)