### PR TITLE
[dailymotion] Don't try to get subtitles if enable=false

### DIFF
--- a/youtube_dl/extractor/dailymotion.py
+++ b/youtube_dl/extractor/dailymotion.py
@@ -172,11 +172,13 @@ class DailymotionIE(DailymotionBaseInfoExtractor):
             uploader_id = metadata.get('owner', {}).get('id')
 
             subtitles = {}
-            for subtitle_lang, subtitle in metadata.get('subtitles', {}).get('data', {}).items():
-                subtitles[subtitle_lang] = [{
-                    'ext': determine_ext(subtitle_url),
-                    'url': subtitle_url,
-                } for subtitle_url in subtitle.get('urls', [])]
+            subtitles_data = metadata.get('subtitles', {})
+            if subtitles_data.get('enable'):
+                for subtitle_lang, subtitle in subtitles_data['data'].items():
+                    subtitles[subtitle_lang] = [{
+                        'ext': determine_ext(subtitle_url),
+                        'url': subtitle_url,
+                    } for subtitle_url in subtitle.get('urls', [])]
 
             return {
                 'id': video_id,


### PR DESCRIPTION
Pretty much all dailymotion videos now fail to download, because of `"subtitles":{"enable":false,"data":[]}`. The current code expects `subtitles.data` to be either not there, or be a dictionary. I can't find any video with subtitles, so I can't validate if the format has changed, but this change at least avoids the problem for disabled subtitles.