### PR TITLE
Youku bugfix  Download the longest video in minimum parts instead of downloading  too many segments of one video

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -186,6 +186,20 @@ class VimeoIE(VimeoBaseInfoExtractor):
             },
         },
         {
+            # contains original format
+            'url': 'https://vimeo.com/33951933',
+            'md5': '53c688fa95a55bf4b7293d37a89c5c53',
+            'info_dict': {
+                'id': '33951933',
+                'ext': 'mp4',
+                'title': 'FOX CLASSICS - Forever Classic ID - A Full Minute',
+                'uploader': 'The DMCI',
+                'uploader_id': 'dmci',
+                'upload_date': '20111220',
+                'description': 'md5:ae23671e82d05415868f7ad1aec21147',
+            },
+        },
+        {
             'url': 'https://vimeo.com/109815029',
             'note': 'Video not completely processed, "failed" seed status',
             'only_matching': True,

--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -406,6 +406,7 @@ class VimeoIE(VimeoBaseInfoExtractor):
                     'height': int_or_none(source_file.get('height')),
                     'filesize': parse_filesize(source_file.get('size')),
                     'format_id': source_file.get('public_name', 'Original'),
+                    'preference': 1,
                 })
         config_files = config['video'].get('files') or config['request'].get('files', {})
         for f in config_files.get('progressive', []):
@@ -423,12 +424,12 @@ class VimeoIE(VimeoBaseInfoExtractor):
         m3u8_url = config_files.get('hls', {}).get('url')
         if m3u8_url:
             m3u8_formats = self._extract_m3u8_formats(
-                m3u8_url, video_id, 'mp4', 'm3u8_native', 0, 'hls', fatal=False)
+                m3u8_url, video_id, 'mp4', 'm3u8_native', m3u8_id='hls', fatal=False)
             if m3u8_formats:
                 formats.extend(m3u8_formats)
         # Bitrates are completely broken. Single m3u8 may contain entries in kbps and bps
         # at the same time without actual units specified. This lead to wrong sorting.
-        self._sort_formats(formats, field_preference=('height', 'width', 'fps', 'format_id'))
+        self._sort_formats(formats, field_preference=('preference', 'height', 'width', 'fps', 'format_id'))
 
         subtitles = {}
         text_tracks = config['request'].get('text_tracks')

--- a/youtube_dl/extractor/youku.py
+++ b/youtube_dl/extractor/youku.py
@@ -87,10 +87,6 @@ class YoukuIE(InfoExtractor):
         # get oip
         oip = data['security']['ip']
 
-<<<<<<< HEAD
-=======
-        # get fileid
->>>>>>> githubMaster/youku_bugfix
         fileid_dict = {}
         for stream in data['stream']:
             format = stream.get('stream_type')

--- a/youtube_dl/extractor/youku.py
+++ b/youtube_dl/extractor/youku.py
@@ -138,7 +138,6 @@ class YoukuIE(InfoExtractor):
                     compat_urllib_parse.urlencode(param)
                 video_urls.append(video_url)
             video_urls_dict[format] = video_urls
-            print(video_urls)
 
         return video_urls_dict
 

--- a/youtube_dl/extractor/youku.py
+++ b/youtube_dl/extractor/youku.py
@@ -245,17 +245,17 @@ class YoukuIE(InfoExtractor):
             'formats': [],
             # some formats are not available for all parts, we have to detect
             # which one has all
-            } for i in range(min(seq))]
+        } for i in range(min(seq))]
         stream = data['stream'][seq.index(min(seq))]
         fm = stream.get('stream_type')
         video_urls = video_urls_dict[fm]
         for video_url, seg, entry in zip(video_urls, stream['segs'], entries):
             entry['formats'].append({
-                    'url': video_url,
-                    'format_id': self.get_format_name(fm),
-                    'ext': self.parse_ext_l(fm),
-                    'filesize': int(seg['size']),
-                })
+                'url': video_url,
+                'format_id': self.get_format_name(fm),
+                'ext': self.parse_ext_l(fm),
+                'filesize': int(seg['size']),
+            })
 
         return {
             '_type': 'multi_video',


### PR DESCRIPTION
What this pr has done:
1 Download the longest video in minimum parts instead of download the too many segments of one video.

2 Change the mp4ph3 value to 0. Last time I was wrong. And rearrange their order to look nice.

3 check the code with flake8. 