### PR TITLE
Add support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM gliderlabs/alpine:3.2
+
+RUN apk --update add ca-certificates python
+
+ADD https://yt-dl.org/latest/youtube-dl /usr/local/bin/youtube-dl
+
+RUN chmod a+rx /usr/local/bin/youtube-dl


### PR DESCRIPTION
Add support for docker.

An example:

`docker run -it --rm huming/youtube-dl youtube-dl -v http://www.youtube.com/watch?v=BaW_jenozKcj`

To save your file on your machine, an example like this would work:

`docker run -it --rm -v YOUR_LOCAL_DIRECOTRY_FOR_DOWNLOAD:/download huming/youtube-dl youtube-dl -v http://www.youtube.com/watch\?v\=BaW_jenozKcj -o download/test.mp4`