### PR TITLE
[common] simplify the use of _extract_m3u8_formats and _extract_f4m_formats

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -885,7 +885,7 @@ class InfoExtractor(object):
             fatal=fatal)
 
         if manifest is False:
-            return manifest
+            return []
 
         formats = []
         manifest_version = '1.0'
@@ -956,7 +956,7 @@ class InfoExtractor(object):
             errnote=errnote or 'Failed to download m3u8 information',
             fatal=fatal)
         if res is False:
-            return res
+            return []
         m3u8_doc, urlh = res
         m3u8_url = urlh.geturl()
         last_info = None


### PR DESCRIPTION
instead of:
```
m3u8_formats = self._extract_m3u8_formats(m3u8_url, video_id, 'mp4', m3u8_id='hls', fatal=False)
if m3u8_formats:
    formats.extend(m3u8_formats)
f4m_formats = self._extract_f4m_formats(f4m_url, video_id, f4m_id='hds', fatal=False)
if f4m_formats:
    formats.extend(f4m_formats)
```
just use:
```
formats.extend(self._extract_m3u8_formats(m3u8_url, video_id, 'mp4', m3u8_id='hls', fatal=False))
formats.extend(self._extract_f4m_formats(f4m_url, video_id, f4m_id='hds', fatal=False))
```
and may be even making mp4 as the default ext and hls as the default id for m3u8_formats
and hds as the default id for f4m_formats
if this acceptable i will change all the parts that use this two methods in the other extractors.