### PR TITLE
[common] fail only if the extractor didn't return formats

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1208,8 +1208,6 @@ class YoutubeDL(object):
             raise ExtractorError('Missing "id" field in extractor result')
         if 'title' not in info_dict:
             raise ExtractorError('Missing "title" field in extractor result')
-        if not info_dict.get('formats'):
-            raise ExtractorError('No video formats found')
 
         if 'playlist' not in info_dict:
             # It isn't part of a playlist

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1208,6 +1208,8 @@ class YoutubeDL(object):
             raise ExtractorError('Missing "id" field in extractor result')
         if 'title' not in info_dict:
             raise ExtractorError('Missing "title" field in extractor result')
+        if not info_dict.get('formats'):
+            raise ExtractorError('No video formats found')
 
         if 'playlist' not in info_dict:
             # It isn't part of a playlist

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -765,7 +765,7 @@ class InfoExtractor(object):
 
     def _sort_formats(self, formats, field_preference=None):
         if not formats:
-            raise ExtractorError('No video formats found')
+            return
 
         def _formats_key(f):
             # TODO remove the following workaround


### PR DESCRIPTION
format extraction will fail if one of _extract_*_formats methods didn't return any formats this is not desirable in extractors that has more than one type of formats.
this change make the error happen only if the extractor didn't return formats.