### PR TITLE
[ESPNFC] Add new extractor

### DIFF
--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -184,6 +184,7 @@ from .eporner import EpornerIE
 from .eroprofile import EroProfileIE
 from .escapist import EscapistIE
 from .espn import ESPNIE
+from .espnfc import ESPNFCIE
 from .esri import EsriVideoIE
 from .europa import EuropaIE
 from .everyonesmixtape import EveryonesMixtapeIE

--- a/youtube_dl/extractor/espnfc.py
+++ b/youtube_dl/extractor/espnfc.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from urllib import parse
+
+class ESPNFCIE(InfoExtractor):
+    _VALID_URL = r'http?:\/\/(?:www\.)?espnfc\.us\/video\/((?:[a-z][a-z0-9_-]*))\/((?:[0-9]*))/video/(?P<id>[^/]+)/((?:[a-z][a-z0-9_-]*))'
+    _TESTS = [
+                {
+                'url': 'http://www.espnfc.us/video/mls-highlights/150/video/2743663/must-see-moments-best-of-the-mls-season',
+                'info_dict': {
+                    'id': '2743663',
+                    'ext': 'mp4',
+                    'title': 'Must-See Moments: Best of the MLS season',
+                    'description': 'Relive the best moments of the 2015 MLS season, including the arrival of new stars and the crowning of a first-time champion.</p>',
+                    'thumbnail': 'http://a.espncdn.com/combiner/i/?img=/media/motion/2015/1207/int_151206_Must_See_Moments_Best_of_MLS_2015_seaso145/int_151206_Must_See_Moments_Best_of_MLS_2015_seaso145.jpg&w=1500&h=1500&scale=crop&site=espnfc',
+                    }
+                },
+                {
+                    'url': 'http://www.espnfc.us/video/espn-fc-tv/86/video/2774391/drogba-set-to-quit-montreal-for-chelsea',
+                    'info_dict': {
+                        'id': '2774391',
+                        'ext': 'mp4',
+                        'title': 'Drogba set to quit Montreal for Chelsea?',
+                        'description': 'The ESPN FC team discuss reports that ex-Chelsea forward Didier Drogba is considering leaving Montreal to coach at Chelsea.</p>',
+                        'thumbnail': 'http://a.espncdn.com/combiner/i/?img=/media/motion/ESPNi/2015/1229/int_151229_INET_FC_DROGBA_TO_CHELSEA/int_151229_INET_FC_DROGBA_TO_CHELSEA.jpg&w=1500&h=1500&scale=crop&site=espnfc',
+                    }
+                }
+        ]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        webpage = self._download_webpage(url, video_id)
+
+        twitter_player_stream = self._html_search_meta('twitter:player:stream', webpage)
+
+        # Obtain reference to Once URL using an index on the Twitter player stream, add four to start at
+        onceurl_start = twitter_player_stream.index('url=') + 4
+
+        video_url = parse.unquote(twitter_player_stream[onceurl_start:]).replace('.once', '.mp4')
+
+        formats = [{
+             'url': video_url,
+        }]
+
+        return {
+            'id': video_id,
+            'title': self._og_search_title(webpage),
+            'description': self._og_search_description(webpage),
+            'thumbnail': self._og_search_thumbnail(webpage),
+            'formats': formats,
+        }


### PR DESCRIPTION
This is my first commit and pull request, go easy on me!

Per #7858, created a new extractor for ESPNFC. I decided to keep this separate from the ESPN extractor due how the links are formatted.  I decided to use the Once auto link since it will return an MP4/stitched for browsers that do not support native HLS.

I added some additional comments to #7858 after realizing that we can just swap the ID of the video in with "intl:<videoID>" and use the existing extractor.

Let me know what the best path would be (as well as suggestions for the next extractor with this commit). 
