### PR TITLE
Introduce chapter and series fields

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -200,6 +200,26 @@ class InfoExtractor(object):
     end_time:       Time in seconds where the reproduction should end, as
                     specified in the URL.
 
+    The following fields should only be used when the video belongs to some logical
+    chapter or section:
+
+    chapter:        Name or title of the chapter the video belongs to.
+    chapter_id:     Number or id of the chapter the video belongs to, as an integer
+                    or unicode string.
+
+    The following fields should only be used when the video is an episode of some
+    series or programme:
+
+    series:         Title of the series or programme the video episode belongs to.
+    season:         Title of the season the video episode belongs to.
+    season_id:      Number or id of the season the video episode belongs to, as an
+                    integer or unicode string.
+    episode:        Title of the video episode. Unlike mandatory video title field,
+                    this field should denote the exact title of the video episode
+                    without any kind of decoration.
+    episode_id:     Number or id of the video episode within a season, as an integer
+                    or unicode string.
+
     Unless mentioned otherwise, the fields should be Unicode strings.
 
     Unless mentioned otherwise, None is equivalent to absence of information.

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -204,21 +204,21 @@ class InfoExtractor(object):
     chapter or section:
 
     chapter:        Name or title of the chapter the video belongs to.
-    chapter_id:     Number or id of the chapter the video belongs to, as an integer
-                    or unicode string.
+    chapter_number: Number of the chapter the video belongs to, as an integer.
+    chapter_id:     Id of the chapter the video belongs to, as a unicode string.
 
     The following fields should only be used when the video is an episode of some
     series or programme:
 
     series:         Title of the series or programme the video episode belongs to.
     season:         Title of the season the video episode belongs to.
-    season_id:      Number or id of the season the video episode belongs to, as an
-                    integer or unicode string.
+    season_number:  Number of the season the video episode belongs to, as an integer.
+    season_id:      Id of the season the video episode belongs to, as a unicode string.
     episode:        Title of the video episode. Unlike mandatory video title field,
                     this field should denote the exact title of the video episode
                     without any kind of decoration.
-    episode_id:     Number or id of the video episode within a season, as an integer
-                    or unicode string.
+    episode_number: Number of the video episode within a season, as an integer.
+    episode_id:     Id of the video episode, as a unicode string.
 
     Unless mentioned otherwise, the fields should be Unicode strings.
 

--- a/youtube_dl/extractor/udemy.py
+++ b/youtube_dl/extractor/udemy.py
@@ -244,10 +244,25 @@ class UdemyCourseIE(UdemyIE):
             'https://www.udemy.com/api-1.1/courses/%s/curriculum' % course_id,
             course_id, 'Downloading course curriculum')
 
-        entries = [
-            self.url_result(
-                'https://www.udemy.com/%s/#/lecture/%s' % (course_path, asset['id']), 'Udemy')
-            for asset in response if asset.get('assetType') or asset.get('asset_type') == 'Video'
-        ]
+        entries = []
+        chapter, chapter_id = None, None
+        for asset in response:
+            asset_type = asset.get('assetType') or asset.get('asset_type')
+            if asset_type == 'Video':
+                asset_id = asset.get('id')
+                if asset_id:
+                    entry = {
+                        '_type': 'url_transparent',
+                        'url': 'https://www.udemy.com/%s/#/lecture/%s' % (course_path, asset['id']),
+                        'ie_key': UdemyIE.ie_key(),
+                    }
+                    if chapter_id:
+                        entry['chapter_id'] = chapter_id
+                    if chapter:
+                        entry['chapter'] = chapter
+                    entries.append(entry)
+            elif asset.get('type') == 'chapter':
+                chapter_id = asset.get('index') or asset.get('object_index')
+                chapter = asset.get('title')
 
         return self.playlist_result(entries, course_id, course_title)

--- a/youtube_dl/extractor/udemy.py
+++ b/youtube_dl/extractor/udemy.py
@@ -245,7 +245,7 @@ class UdemyCourseIE(UdemyIE):
             course_id, 'Downloading course curriculum')
 
         entries = []
-        chapter, chapter_id = None, None
+        chapter, chapter_number = None, None
         for asset in response:
             asset_type = asset.get('assetType') or asset.get('asset_type')
             if asset_type == 'Video':
@@ -256,13 +256,13 @@ class UdemyCourseIE(UdemyIE):
                         'url': 'https://www.udemy.com/%s/#/lecture/%s' % (course_path, asset['id']),
                         'ie_key': UdemyIE.ie_key(),
                     }
-                    if chapter_id:
-                        entry['chapter_id'] = chapter_id
+                    if chapter_number:
+                        entry['chapter_number'] = chapter_number
                     if chapter:
                         entry['chapter'] = chapter
                     entries.append(entry)
             elif asset.get('type') == 'chapter':
-                chapter_id = asset.get('index') or asset.get('object_index')
+                chapter_number = asset.get('index') or asset.get('object_index')
                 chapter = asset.get('title')
 
         return self.playlist_result(entries, course_id, course_title)

--- a/youtube_dl/extractor/videomore.py
+++ b/youtube_dl/extractor/videomore.py
@@ -23,10 +23,55 @@ class VideomoreIE(InfoExtractor):
             'ext': 'flv',
             'title': 'В гостях Алексей Чумаков и Юлия Ковальчук',
             'description': 'В гостях – лучшие романтические комедии года, «Выживший» Иньярриту и «Стив Джобс» Дэнни Бойла.',
+            'series': 'Кино в деталях',
+            'episode': 'В гостях Алексей Чумаков и Юлия Ковальчук',
+            'episode_id': None,
+            'season': 'Сезон 2015',
+            'season_id': 5,
             'thumbnail': 're:^https?://.*\.jpg',
             'duration': 2910,
             'age_limit': 16,
             'view_count': int,
+        },
+    }, {
+        'url': 'http://videomore.ru/embed/259974',
+        'info_dict': {
+            'id': '259974',
+            'ext': 'flv',
+            'title': '80 серия',
+            'description': '«Медведей» ждет решающий матч. Макеев выясняет отношения со Стрельцовым. Парни узнают подробности прошлого Макеева.',
+            'series': 'Молодежка',
+            'episode': '80 серия',
+            'episode_id': 40,
+            'season': '2 сезон',
+            'season_id': 2,
+            'thumbnail': 're:^https?://.*\.jpg',
+            'duration': 2809,
+            'age_limit': 16,
+            'view_count': int,
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        'url': 'http://videomore.ru/molodezhka/sezon_promo/341073',
+        'info_dict': {
+            'id': '341073',
+            'ext': 'flv',
+            'title': 'Команда проиграла из-за Бакина?',
+            'description': 'Молодежка 3 сезон скоро',
+            'series': 'Молодежка',
+            'episode': 'Команда проиграла из-за Бакина?',
+            'episode_id': None,
+            'season': 'Промо',
+            'season_id': 99,
+            'thumbnail': 're:^https?://.*\.jpg',
+            'duration': 29,
+            'age_limit': 16,
+            'view_count': int,
+        },
+        'params': {
+            'skip_download': True,
         },
     }, {
         'url': 'http://videomore.ru/elki_3?track_id=364623',
@@ -81,10 +126,21 @@ class VideomoreIE(InfoExtractor):
             'url': thumbnail,
         } for thumbnail in data.get('big_thumbnail_urls', [])]
 
+        series = data.get('project_title')
+        episode = data.get('title')
+        episode_id = data.get('episode_of_season') or None
+        season = data.get('season_title')
+        season_id = data.get('season_pos') or None
+
         return {
             'id': video_id,
             'title': title,
             'description': description,
+            'series': series,
+            'episode': episode,
+            'episode_id': episode_id,
+            'season': season,
+            'season_id': season_id,
             'thumbnails': thumbnails,
             'timestamp': timestamp,
             'duration': duration,

--- a/youtube_dl/extractor/videomore.py
+++ b/youtube_dl/extractor/videomore.py
@@ -25,9 +25,9 @@ class VideomoreIE(InfoExtractor):
             'description': 'В гостях – лучшие романтические комедии года, «Выживший» Иньярриту и «Стив Джобс» Дэнни Бойла.',
             'series': 'Кино в деталях',
             'episode': 'В гостях Алексей Чумаков и Юлия Ковальчук',
-            'episode_id': None,
+            'episode_number': None,
             'season': 'Сезон 2015',
-            'season_id': 5,
+            'season_number': 5,
             'thumbnail': 're:^https?://.*\.jpg',
             'duration': 2910,
             'age_limit': 16,
@@ -42,9 +42,9 @@ class VideomoreIE(InfoExtractor):
             'description': '«Медведей» ждет решающий матч. Макеев выясняет отношения со Стрельцовым. Парни узнают подробности прошлого Макеева.',
             'series': 'Молодежка',
             'episode': '80 серия',
-            'episode_id': 40,
+            'episode_number': 40,
             'season': '2 сезон',
-            'season_id': 2,
+            'season_number': 2,
             'thumbnail': 're:^https?://.*\.jpg',
             'duration': 2809,
             'age_limit': 16,
@@ -62,9 +62,9 @@ class VideomoreIE(InfoExtractor):
             'description': 'Молодежка 3 сезон скоро',
             'series': 'Молодежка',
             'episode': 'Команда проиграла из-за Бакина?',
-            'episode_id': None,
+            'episode_number': None,
             'season': 'Промо',
-            'season_id': 99,
+            'season_number': 99,
             'thumbnail': 're:^https?://.*\.jpg',
             'duration': 29,
             'age_limit': 16,
@@ -128,9 +128,9 @@ class VideomoreIE(InfoExtractor):
 
         series = data.get('project_title')
         episode = data.get('title')
-        episode_id = data.get('episode_of_season') or None
+        episode_number = int_or_none(data.get('episode_of_season') or None)
         season = data.get('season_title')
-        season_id = data.get('season_pos') or None
+        season_number = int_or_none(data.get('season_pos') or None)
 
         return {
             'id': video_id,
@@ -138,9 +138,9 @@ class VideomoreIE(InfoExtractor):
             'description': description,
             'series': series,
             'episode': episode,
-            'episode_id': episode_id,
+            'episode_number': episode_number,
             'season': season,
-            'season_id': season_id,
+            'season_number': season_number,
             'thumbnails': thumbnails,
             'timestamp': timestamp,
             'duration': duration,


### PR DESCRIPTION
This PR proposes some new optional fields to video info dictionary in order to cover the gap for videos organized to logical chapters and video episodes belonging to season of a series or a programme.

Field | Usage | Description
------------ | ------------- | -------------
`chapter` | chapter-only | Name or title of the chapter the video belongs to.
`chapter_number` | chapter-only | Number of the chapter the video belongs to, as an integer.
`chapter_id` | chapter-only | Id of the chapter the video belongs to, as a unicode string.
`series` | series-only | Title of the series or programme the video episode belongs to.
`season` | series-only | Title of the season the video episode belongs to.
`season_number` | series-only | Number of the season the video episode belongs to, as an integer.
`season_id` | series-only | Id of the season the video episode belongs to, as a unicode string.
`episode` | series-only | Title of the video episode. Unlike mandatory video `title` field, this field should denote the exact title of the video episode without any kind of decoration.
`episode_number` | series-only | Number of the video episode within a season, as an integer.
`episode_id` | series-only | Id of the video episode, as a unicode string.

Notes:
* `*_id` fields are not `*_index` (i.e. numeric) in order to tolerate some potential exotic naming schemas apart from autoincremented numbering.
* `episode` is supposed to be potentially different from `title` and should denote the exact name of the video episode while `title` is allowed to be decorated and imposes less strictness (e.g. can contain the title displayed on a website that is not necessarily should match episode name).

Pros:
* Collecting and providing this potentially useful information.
* An elegant way to solve issues like #4793 with help of output templates.

Cons:
* Duplicated fields for videos.