### PR TITLE
[YoutubeDL] Gracefully handle audio/video format reversal (Fixes #5154)

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1105,15 +1105,17 @@ class YoutubeDL(object):
             elif selector.type == MERGE:
                 def _merge(formats_info):
                     format_1, format_2 = [f['format_id'] for f in formats_info]
-                    # The first format must contain the video and the
-                    # second the audio
+                    # The first format must contain the video
+                    # If the formats are reversed, swap them
                     if formats_info[0].get('vcodec') == 'none':
-                        self.report_error('The first format must '
-                                          'contain the video, try using '
-                                          '"-f %s+%s"' % (format_2, format_1))
-                        return
-                    # Formats must be opposite (video+audio)
-                    if formats_info[0].get('acodec') == 'none' and formats_info[1].get('acodec') == 'none':
+                        if formats_info[1].get('vcodec') == 'none':
+                            self.report_error(
+                                'Both formats %s and %s are audio-only, you must specify "-f video+audio"'
+                                % (format_1, format_2))
+                            return
+                        formats_info = (formats_info[1], formats_info[0])
+                    # Second format must contain audio
+                    if formats_info[1].get('acodec') == 'none':
                         self.report_error(
                             'Both formats %s and %s are video-only, you must specify "-f video+audio"'
                             % (format_1, format_2))


### PR DESCRIPTION
Improved error handling by automatically attempting the suggested fix and swapping formats, failing with error only in the case where two audio-only formats are given. Simplified audio format handling logic and comments, for readability.