### PR TITLE
Extract xHamster title fix

### DIFF
--- a/youtube_dl/extractor/xhamster.py
+++ b/youtube_dl/extractor/xhamster.py
@@ -65,7 +65,7 @@ class XHamsterIE(InfoExtractor):
 
         title = self._html_search_regex(
             [r'<title>(?P<title>.+?)(?:, (?:[^,]+? )?Porn: xHamster| - xHamster\.com)</title>',
-             r'<h1>([^<]+)</h1>'], webpage, 'title')
+             r'<h1(?: itemprop="name")?>([^<]+)</h1>'], webpage, 'title')
 
         # Only a few videos have an description
         mobj = re.search(r'<span>Description: </span>([^<]+)', webpage)


### PR DESCRIPTION
After #6955, I am back with another fix.

I ran into a page with the title `(%title), Free Amateur Porn Video 92`. I have no idea why the xHamster brand was dropped there completely. As I did not want to overflow the `title` tag parser, I updated the regex targetting the `h1`. It had become outdated.

I haven’t done any long time testing to see if *all* `h1` tags have been changed, so I made the change optional.