### PR TITLE
[WIP] Introduce CSS3 like string operators

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -898,6 +898,9 @@ class YoutubeDL(object):
             STR_OPERATORS = {
                 '=': operator.eq,
                 '!=': operator.ne,
+                '^=': lambda attr, value: attr.startswith(value),
+                '$=': lambda attr, value: attr.endswith(value),
+                '*=': lambda attr, value: value in attr,
             }
             str_operator_rex = re.compile(r'''(?x)
                 \s*(?P<key>ext|acodec|vcodec|container|protocol)


### PR DESCRIPTION
As pointed out by #8130, codec names like ```avc1.640028``` is difficult for format selection. I borrow some ideas from [CSS3 selectors](http://www.w3.org/TR/css3-selectors/#selectors). Here's an usage example:

```
$ youtube-dl -j -f 'worstvideo[vcodec^=avc1]' test:youtube | jq .format
"160 - 256x144 (DASH video)"
```

Currently there are no tests. I'll fill them up if this idea is acceptable.