### PR TITLE
different method to handle multi part videos(fixes #6193)

### DIFF
--- a/youtube_dl/downloader/__init__.py
+++ b/youtube_dl/downloader/__init__.py
@@ -9,6 +9,7 @@ from .http import HttpFD
 from .rtsp import RtspFD
 from .rtmp import RtmpFD
 from .dash import DashSegmentsFD
+from .multipart import MultiPartFD
 
 from ..utils import (
     determine_protocol,
@@ -22,11 +23,16 @@ PROTOCOL_MAP = {
     'rtsp': RtspFD,
     'f4m': F4mFD,
     'http_dash_segments': DashSegmentsFD,
+    'multipart': MultiPartFD,
 }
 
 
 def get_suitable_downloader(info_dict, params={}):
     """Get the downloader class that can handle the info dict."""
+
+    if 'parts' in info_dict:
+        return MultiPartFD
+
     protocol = determine_protocol(info_dict)
     info_dict['protocol'] = protocol
 

--- a/youtube_dl/downloader/multipart.py
+++ b/youtube_dl/downloader/multipart.py
@@ -1,0 +1,46 @@
+from __future__ import unicode_literals
+
+import os
+
+from .fragment import FragmentFD
+
+from ..utils import (
+    encodeFilename,
+    sanitize_open,
+)
+
+
+class MultiPartFD(FragmentFD):
+    """ A more limited implementation that does not require ffmpeg """
+
+    FD_NAME = 'multipart'
+
+    def real_download(self, filename, info_dict):
+        parts = info_dict['parts']
+        ctx = {
+            'filename': filename,
+            'total_frags': len(parts),
+        }
+
+        self._prepare_and_start_frag_download(ctx)
+
+        frags_filenames = []
+        for i in range(len(parts)):
+            frag_filename = '%s%d' % (ctx['tmpfilename'], i)
+            success = ctx['dl'].download(frag_filename, {'url': parts[i]['url']})
+            if not success:
+                return False
+            down, frag_sanitized = sanitize_open(frag_filename, 'rb')
+            ctx['dest_stream'].write(down.read())
+            down.close()
+            frags_filenames.append(frag_sanitized)
+            # We only download the first fragment during the test
+            if self.params.get('test', False):
+                break
+
+        self._finish_frag_download(ctx)
+
+        for frag_file in frags_filenames:
+            os.remove(encodeFilename(frag_file))
+
+        return True


### PR DESCRIPTION
with this change it will possible to:
- handle videos that has multipart and non multipart formats
- handle videos that has different number of parts for different formats
- merge multipart videos

the parts array can be contained dirrectly in the info dict if it has only one format or in format dict for multi format video and every part should have at least a url.

i added a MultiPartFD based on the FragmentFD i used a simular method to hlsnative for merge formats(i it doesn't always work that i will change to use ffmpeg to merge parts)

i changed the youku extractor to use this method as a way to test if it woking.

this is how formats are shown now:
```
python2 __main__.py -F http://v.youku.com/v_show/id_XODgxNjg1Mzk2_ev_1.html
[youku] XODgxNjg1Mzk2: Downloading JSON metadata
[info] Available formats for XODgxNjg1Mzk2:
format code  extension  resolution note
h5           mp4        512x288    71.96MiB
h4-0         flv        512x288    68.48MiB, multipart
h3           mp4        672x378    131.32MiB, multipart
h4-1         flv        1104x622   286.96MiB, multipart (best)
```
and this is when downloading using the MultiPartFD:
```
python2 __main__.py -f h4-0 http://v.youku.com/v_show/id_XODgxNjg1Mzk2_ev_1.html
[youku] XODgxNjg1Mzk2: Downloading JSON metadata
[multipart] Total fragments: 6
[download] Destination: 武媚娘传奇 85-XODgxNjg1Mzk2.flv
[download]  49.1% of ~73.86MiB at 60.41KiB/s ETA 00:11
```
if this solution is acceptable i will continue to improve it and fix errors and use it for other extractors.