### PR TITLE
different method to handle multi part videos 2(fixes #6193)

### DIFF
--- a/youtube_dl/downloader/__init__.py
+++ b/youtube_dl/downloader/__init__.py
@@ -9,6 +9,7 @@ from .http import HttpFD
 from .rtsp import RtspFD
 from .rtmp import RtmpFD
 from .dash import DashSegmentsFD
+from .multipart import MultiPartFD
 
 from ..utils import (
     determine_protocol,
@@ -22,6 +23,7 @@ PROTOCOL_MAP = {
     'rtsp': RtspFD,
     'f4m': F4mFD,
     'http_dash_segments': DashSegmentsFD,
+    'multipart': MultiPartFD,
 }
 
 

--- a/youtube_dl/downloader/multipart.py
+++ b/youtube_dl/downloader/multipart.py
@@ -1,0 +1,29 @@
+from __future__ import unicode_literals
+
+from .common import FileDownloader
+
+from ..utils import prepend_extension
+
+
+class MultiPartFD(FileDownloader):
+
+    FD_NAME = 'multipart'
+
+    def real_download(self, filename, info_dict):
+        parts = info_dict['parts']
+        self.to_screen('[%s] Total parts: %d' % (self.FD_NAME, len(parts)))
+
+        for i in range(len(parts)):
+            fd = get_suitable_downloader(parts[i], self.params)(self.ydl, self.params)
+            frag_filename = prepend_extension(filename, 'part%d' % i)
+            success = fd.download(frag_filename, parts[i])
+            if not success:
+                return False
+            # We only download the first fragment during the test
+            if self.params.get('test', False):
+                break
+
+        return True
+
+# workaround circular imports
+from .__init__ import get_suitable_downloader

--- a/youtube_dl/extractor/youku.py
+++ b/youtube_dl/extractor/youku.py
@@ -14,6 +14,8 @@ from ..compat import (
 from ..utils import (
     ExtractorError,
     sanitized_Request,
+    int_or_none,
+    float_or_none,
 )
 
 
@@ -66,7 +68,7 @@ class YoukuIE(InfoExtractor):
         },
     }]
 
-    def construct_video_urls(self, data):
+    def construct_formats(self, data):
         # get sid, token
         def yk_t(s1, s2):
             ls = list(range(256))
@@ -114,11 +116,10 @@ class YoukuIE(InfoExtractor):
             ep = base64.b64encode(ep_t).decode('ascii')
             return ep
 
-        # generate video_urls
-        video_urls_dict = {}
+        formats = []
         for stream in data['stream']:
             format = stream.get('stream_type')
-            video_urls = []
+            parts = []
             for dt in stream['segs']:
                 n = str(stream['segs'].index(dt))
                 param = {
@@ -139,10 +140,20 @@ class YoukuIE(InfoExtractor):
                     '/st/' + self.parse_ext_l(format) + \
                     '/fileid/' + get_fileid(format, n) + '?' + \
                     compat_urllib_parse.urlencode(param)
-                video_urls.append(video_url)
-            video_urls_dict[format] = video_urls
-
-        return video_urls_dict
+                parts.append({
+                    'url': video_url,
+                    'filesize': int_or_none(dt.get('size')),
+                })
+            formats.append({
+                'format_id': self.get_format_name(format),
+                'parts': parts,
+                'width': int_or_none(stream.get('width')),
+                'height': int_or_none(stream.get('height')),
+                'filesize': int_or_none(stream.get('size')),
+                'ext': self.parse_ext_l(format),
+            })
+        self._sort_formats(formats)
+        return formats
 
     @staticmethod
     def get_ysuid():
@@ -235,34 +246,13 @@ class YoukuIE(InfoExtractor):
                     msg += ': ' + error_note
                 raise ExtractorError(msg)
 
-        # get video title
-        title = data['video']['title']
-
-        # generate video_urls_dict
-        video_urls_dict = self.construct_video_urls(data)
-
-        # construct info
-        entries = [{
-            'id': '%s_part%d' % (video_id, i + 1),
-            'title': title,
-            'formats': [],
-            # some formats are not available for all parts, we have to detect
-            # which one has all
-        } for i in range(max(len(v.get('segs')) for v in data['stream']))]
-        for stream in data['stream']:
-            fm = stream.get('stream_type')
-            video_urls = video_urls_dict[fm]
-            for video_url, seg, entry in zip(video_urls, stream['segs'], entries):
-                entry['formats'].append({
-                    'url': video_url,
-                    'format_id': self.get_format_name(fm),
-                    'ext': self.parse_ext_l(fm),
-                    'filesize': int(seg['size']),
-                })
+        video_data = data['video']
 
         return {
-            '_type': 'multi_video',
             'id': video_id,
-            'title': title,
-            'entries': entries,
+            'title': video_data['title'],
+            'duration': float_or_none(video_data.get('seconds')),
+            'uploader': video_data.get('username'),
+            'uploader_id': video_data.get('userid'),
+            'formats': self.construct_formats(data),
         }

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1891,6 +1891,8 @@ def determine_protocol(info_dict):
     if protocol is not None:
         return protocol
 
+    if 'parts' in info_dict:
+        return 'multipart'
     url = info_dict['url']
     if url.startswith('rtmp'):
         return 'rtmp'


### PR DESCRIPTION
continue the work in #8223.
with this change it will possible to:
- handle videos that has multipart and non multipart formats
- handle videos that has different number of parts for different formats

the parts array can be contained directly in the info dict if it has only one format or in format dict for multi format video and every part should have at least a url.

i added a MultiPartFD based on the FragmentFD to download the parts(simular to the current behavior but it won't fail if the number of parts is different between formats)
format listing:
iqiyi:

```
python2 __main__.py -F 'http://www.iqiyi.com/v_19rrhnnclk.html'
[iqiyi] temp_id: download video page
[iqiyi] e3f585b550a280af23c98b6cb2be19fb: Downloading JSON metadata
...
[info] Available formats for e3f585b550a280af23c98b6cb2be19fb:
format code  extension  resolution note
h6           f4v        592x336    ~71.61MiB, 4 parts
h5           f4v        848x480    ~132.71MiB, 4 parts
h3           f4v        1280x720   ~237.36MiB, 8 parts (best)
```

youku:

```
python2 __main__.py -F 'http://v.youku.com/v_show/id_XMTI1OTczNDM5Mg==.html'
[youku] XMTI1OTczNDM5Mg: Downloading JSON metadata
[info] Available formats for XMTI1OTczNDM5Mg:
format code  extension  resolution note
h4-0         flv        512x288    80.95MiB, 6 parts
h5           mp4        512x288    85.07MiB
h3           mp4        672x378    155.27MiB, 6 parts
h4-1         flv        1104x622   339.07MiB, 13 parts (best)
```

sohu(the server return incrrect width and height):

```
python2 __main__.py -F 'http://my.tv.sohu.com/pl/8384802/78910339.shtml'
[Sohu] 78910339: Downloading webpage
...
[info] Available formats for 78910339:
format code  extension  resolution note
nor          mp4        0x0        ~25.22MiB, 3 parts
high         mp4        0x0        ~47.38MiB, 3 parts
super        mp4        0x0        ~82.74MiB, 3 parts
ori          mp4        0x0        ~182.80MiB, 3 parts (best)
```
