### PR TITLE
Fix issue #8109 (error when downloading automatic captions)

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -964,6 +964,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         try:
             args = player_config['args']
             caption_url = args['ttsurl']
+            if caption_url is None or caption_url == "" or caption_url.isspace():
+                self._downloader.report_warning("No automatic captions")
+                return {}
             timestamp = args['timestamp']
             # We get the available subtitles
             list_params = compat_urllib_parse.urlencode({


### PR DESCRIPTION
In _get_automatic_captions, when ttsurl is blank, it leads to an error (see issue #8109).
This pull request fixes it.