### PR TITLE
[WIP] Use YoutubeIE._formats as fallback

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -1021,9 +1021,9 @@ class InfoExtractor(object):
                     # TODO: looks like video codec is not always necessarily goes first
                     va_codecs = codecs.split(',')
                     if va_codecs[0]:
-                        f['vcodec'] = va_codecs[0].partition('.')[0]
+                        f['vcodec'] = va_codecs[0]
                     if len(va_codecs) > 1 and va_codecs[1]:
-                        f['acodec'] = va_codecs[1].partition('.')[0]
+                        f['acodec'] = va_codecs[1]
                 resolution = last_info.get('RESOLUTION')
                 if resolution:
                     width_str, height_str = resolution.split('x')

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1831,6 +1831,8 @@ def mimetype2ext(mt):
         'x-ms-wmv': 'wmv',
         'x-mp4-fragmented': 'mp4',
         'ttml+xml': 'ttml',
+        '3gpp': '3gp',
+        'x-flv': 'flv',
     }.get(res, res)
 
 


### PR DESCRIPTION
Regarding #8130. See the discussion there.

The following zip archive is the output of ```youtube-dl -F test:youtube_N```. ```N_old.log``` is the output before this patch. ```N_new.log``` is the output with this patch. ```N_new_8130.log``` is the output with both this patch and #8130.

[youtube-formats-logs.zip](https://github.com/rg3/youtube-dl/files/99456/youtube-formats-logs.zip)

The script to generate these files is straightforward:
```Bash
#!/bin/bash
set -x
for i in $(seq 1 22) ; do
    youtube-dl -F test:youtube_$i > ${i}_old.log
done
```

Changes to ```common.py``` concerns acodec/vcodec of HLS formats. For example the output of ```youtube-dl -F test:twitch:vod``` before and after this patch:
```
$ youtube-dl -F test:twitch:vod                                 
[TestURL] Test URL: http://www.twitch.tv/riotgames/v/6528877?t=5m10s
[twitch:vod] 6528877: Downloading vod info JSON
[twitch:vod] 6528877: Downloading vod access token
[twitch:vod] 6528877: Downloading m3u8 information
[info] Available formats for v6528877:
format code  extension  resolution note
meta         mp4        multiple   Quality selection URL 
Mobile       mp4        400x226     280k , avc1, mp4a 
Low          mp4        640x360     628k , avc1, mp4a 
Medium       mp4        852x480     893k , avc1, mp4a 
High         mp4        1280x720   1603k , avc1, mp4a 
Source       mp4        1280x720   3214k , avc1, mp4a  (best)
```
```
$ youtube-dl -F test:twitch:vod
[TestURL] Test URL: http://www.twitch.tv/riotgames/v/6528877?t=5m10s
[twitch:vod] 6528877: Downloading vod info JSON
[twitch:vod] 6528877: Downloading vod access token
[twitch:vod] 6528877: Downloading m3u8 information
[info] Available formats for v6528877:
format code  extension  resolution note
meta         mp4        multiple   Quality selection URL 
Mobile       mp4        400x226     280k , avc1.42C00D, mp4a.40.2
Low          mp4        640x360     628k , avc1.42C01E, mp4a.40.2
Medium       mp4        852x480     893k , avc1.42C01E, mp4a.40.2
High         mp4        1280x720   1603k , avc1.42C01F, mp4a.40.2
Source       mp4        1280x720   3214k , avc1.100.31, mp4a.40.2 (best)
```
This part is independent from #8130, just for consistency between codec names in results from YouTube and HLS streams.