### PR TITLE
[extractor/common] detect media playlist in _extract_m3u8_formats

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -1014,6 +1014,18 @@ class InfoExtractor(object):
             return []
         m3u8_doc, urlh = res
         m3u8_url = urlh.geturl()
+        # A Media Playlist Tag MUST NOT appear in a Master Playlist
+        # https://tools.ietf.org/html/draft-pantos-http-live-streaming-17#section-4.3.3
+        # The EXT-X-TARGETDURATION tag is REQUIRED for every M3U8 Media Playlists
+        # https://tools.ietf.org/html/draft-pantos-http-live-streaming-17#section-4.3.3.1
+        if '#EXT-X-TARGETDURATION' in m3u8_doc:
+            return [{
+                'url': m3u8_url,
+                'format_id': m3u8_id,
+                'ext': ext,
+                'protocol': entry_protocol,
+                'preference': preference,
+            }]
         last_info = None
         last_media = None
         kv_rex = re.compile(
@@ -1164,6 +1176,7 @@ class InfoExtractor(object):
         formats = []
         rtmp_count = 0
         http_count = 0
+        m3u8_count = 0
 
         videos = smil.findall(self._xpath_ns('.//video', namespace))
         for video in videos:
@@ -1203,8 +1216,17 @@ class InfoExtractor(object):
             src_url = src if src.startswith('http') else compat_urlparse.urljoin(base, src)
 
             if proto == 'm3u8' or src_ext == 'm3u8':
-                formats.extend(self._extract_m3u8_formats(
-                    src_url, video_id, ext or 'mp4', m3u8_id='hls', fatal=False))
+                m3u8_formats = self._extract_m3u8_formats(
+                    src_url, video_id, ext or 'mp4', m3u8_id='hls', fatal=False)
+                if len(m3u8_formats) == 1:
+                    m3u8_count += 1
+                    m3u8_formats[0].update({
+                        'format_id': 'hls-%d' % (m3u8_count if bitrate is None else bitrate),
+                        'tbr': bitrate,
+                        'width': width,
+                        'height': height,
+                    })
+                formats.extend(m3u8_formats)
                 continue
 
             if src_ext == 'f4m':


### PR DESCRIPTION
fixes the broblem with smil manifests that contain m3u8 media playlists:
```
python2 __main__.py -F 'http://link.theplatform.com/s/dJ5BDC/eSDhwOPqdCjD?format=SMIL&mbr=true'
[ThePlatform] eSDhwOPqdCjD: Downloading SMIL data
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading JSON metadata
[info] Available formats for eSDhwOPqdCjD:
format code  extension  resolution note
hls-meta-0   mp4        multiple   Quality selection URL 
hls-meta-1   mp4        multiple   Quality selection URL 
hls-meta-2   mp4        multiple   Quality selection URL 
hls-meta-3   mp4        multiple   Quality selection URL 
hls-meta-4   mp4        multiple   Quality selection URL 
hls-meta-5   mp4        multiple   Quality selection URL 
hls-meta-6   mp4        multiple   Quality selection URL 
7            ts         unknown    
8            ts         unknown    
9            ts         unknown    
10           ts         unknown    
...
550          aac        unknown    
551          aac        unknown    
552          aac        unknown    
553          aac        unknown    
554          aac        unknown    
555          aac        unknown    
556          aac        unknown    
557          aac        unknown    
558          aac        unknown    
559          aac        unknown    (best)
```
with the change:
```
python2 __main__.py -F 'http://link.theplatform.com/s/dJ5BDC/eSDhwOPqdCjD?format=SMIL&mbr=true'
[ThePlatform] eSDhwOPqdCjD: Downloading SMIL data
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading m3u8 information
[ThePlatform] eSDhwOPqdCjD: Downloading JSON metadata
[info] Available formats for eSDhwOPqdCjD:
format code  extension  resolution note
hls-1        m3u8       400x224       1k 
hls-110      m3u8       400x224     110k 
hls-250      m3u8       400x224     250k 
hls-500      m3u8       512x288     500k 
hls-800      m3u8       640x360     800k 
hls-1200     m3u8       768x432    1200k 
hls-1800     m3u8       960x540    1800k  (best)
```