### PR TITLE
[ffmpeg] fix adding metadata when using m3u8_native(fixes #8350)

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -391,6 +391,10 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         for (name, value) in metadata.items():
             options.extend(['-metadata', '%s=%s' % (name, value)])
 
+        # https://github.com/rg3/youtube-dl/issues/8350
+        if info['protocol'] == 'm3u8_native':
+            options.extend(['-bsf:a', 'aac_adtstoasc'])
+
         self._downloader.to_screen('[ffmpeg] Adding metadata to \'%s\'' % filename)
         self.run_ffmpeg(filename, temp_filename, options)
         os.remove(encodeFilename(filename))


### PR DESCRIPTION
```
python2 __main__.py --add-metadata https://vimeo.com/70668043
[vimeo] 70668043: Downloading webpage
[vimeo] 70668043: Extracting information
[vimeo] 70668043: Downloading webpage
[vimeo] 70668043: Downloading JSON metadata
[vimeo] 70668043: Downloading m3u8 information
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 9
[download] Destination: Ask Ash No. 1-70668043.mp4
[download] 100% of 9.83MiB in 00:41
[ffmpeg] Adding metadata to 'Ask Ash No. 1-70668043.mp4'
```
```
ffprobe Ask\ Ash\ No.\ 1-70668043.mp4 
ffprobe version 2.8.5 Copyright (c) 2007-2016 the FFmpeg developers
  built with gcc 5.3.0 (GCC)
  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-avisynth --enable-avresample --enable-fontconfig --enable-gnutls --enable-gpl --enable-ladspa --enable-libass --enable-libbluray --enable-libdcadec --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-libschroedinger --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-shared --enable-version3 --enable-x11grab
  libavutil      54. 31.100 / 54. 31.100
  libavcodec     56. 60.100 / 56. 60.100
  libavformat    56. 40.101 / 56. 40.101
  libavdevice    56.  4.100 / 56.  4.100
  libavfilter     5. 40.101 /  5. 40.101
  libavresample   2.  1.  0 /  2.  1.  0
  libswscale      3.  1.101 /  3.  1.101
  libswresample   1.  2.101 /  1.  2.101
  libpostproc    53.  3.100 / 53.  3.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'Ask Ash No. 1-70668043.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    title           : Ask Ash No. 1
    artist          : JUNNNKTANK
    date            : 20130719
    encoder         : Lavf56.40.101
    comment         : More | junnnktank.com/thenakedissue/faq
                    : f. Ash twitter.com/ashvandeesch
                    : This is Ash. She's from Holland. She's a regular {and fucking awesome} contributor to The Naked Issue. You ask her questions, she makes a video and answers them {while looking pretty damn cute}. 
                    : Ask Ash | thenakedissue@junnnktank.com
    description     : More | junnnktank.com/thenakedissue/faq
                    : f. Ash twitter.com/ashvandeesch
                    : This is Ash. She's from Holland. She's a regular {and fucking awesome} contributor to The Naked Issue. You ask her questions, she makes a video and answers them {while looking pretty damn cute}. 
                    : Ask Ash | thenakedissue@junnnktank.com
  Duration: 00:01:05.43, start: 0.000000, bitrate: 1176 kb/s
    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1280x720, 1011 kb/s, 24 fps, 24 tbr, 90k tbn, 48 tbc (default)
    Metadata:
      handler_name    : VideoHandler
    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 157 kb/s (default)
    Metadata:
      handler_name    : SoundHandler
```