### PR TITLE
Remove extra spaces & trim title

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1423,6 +1423,7 @@ class YoutubeDL(object):
                 raise MaxDownloadsReached()
 
         info_dict['fulltitle'] = info_dict['title']
+        info_dict['title'] = " ".join(info_dict['title'].split())
         if len(info_dict['title']) > 200:
             info_dict['title'] = info_dict['title'][:197] + '...'
 


### PR DESCRIPTION
This removes extra spaces in title, also removes any leading and trailing whitespace, before title size check and after title is copied to 'fulltitle'. Repeated spaces can waste space in a filename, leading spaces can mess up sorting, and make file handling more difficult.