### PR TITLE
Trim and collapse whitespace from filename

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -359,6 +359,7 @@ def sanitize_filename(s, restricted=False, is_id=False):
         while '__' in result:
             result = result.replace('__', '_')
         result = result.strip('_')
+        result = " ".join(result.split())
         # Common case of "Foreign band name - English song title"
         if restricted and result.startswith('-_'):
             result = result[2:]


### PR DESCRIPTION
Removes leading, trailing and repeated spaces/whitespace.
