### PR TITLE
[KonserthusetPlay] Add new extractor (partial support)

### DIFF
--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -323,6 +323,7 @@ from .keezmovies import KeezMoviesIE
 from .khanacademy import KhanAcademyIE
 from .kickstarter import KickStarterIE
 from .keek import KeekIE
+from .konserthusetplay import KonserthusetPlayIE
 from .kontrtube import KontrTubeIE
 from .krasview import KrasViewIE
 from .ku6 import Ku6IE

--- a/youtube_dl/extractor/konserthusetplay.py
+++ b/youtube_dl/extractor/konserthusetplay.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class KonserthusetPlayIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?konserthusetplay\.se/\?m=(?P<id>[0-9A-Za-z_-]+)'
+
+    _TESTS = [{
+        'url': 'http://www.konserthusetplay.se/?m=CKDDnlCY-dhWAAqiMERd-A',
+        'md5': 'e272a765e0d12a0226199e5f32d76116',
+        'info_dict': {
+            'id': 'CKDDnlCY-dhWAAqiMERd-A',
+            'ext': 'mp4',
+            'title': 'Orkesterns instrument: Valthornen',
+            'description': 'md5:f10e1f0030202020396a4d712d2fa827',
+            'thumbnail': 'http://csp.picsearch.com/img/C/K/D/D/title_CKDDnlCY-dhWAAqiMERd-A'
+        }
+    }, {
+        'url': 'http://www.konserthusetplay.se/?m=IyQcMOEpmKqT91SVT5OP8Q',
+        'md5': 'c4adb8ca76fdd33d4cbdcc7c3d181f22',
+        'info_dict': {
+            'id': 'IyQcMOEpmKqT91SVT5OP8Q',
+            'ext': 'mp4',
+            'title': 'Eliasson Einsame Fahrt, violinkonsert',
+            'description': 'md5:a8dcc8dfd9473d52433b2c5f588ba191',
+            'thumbnail': 'http://csp.picsearch.com/img/I/y/Q/c/title_IyQcMOEpmKqT91SVT5OP8Q'
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        description = self._og_search_description(webpage)
+        title = self._og_search_title(webpage)
+        main_video = self._html_search_regex(r'<link rel="video_src" href="(.+?)" />', webpage, 'url')
+        thumbnail = self._og_search_thumbnail(webpage)
+        return {
+            'id': video_id,
+            'title': title,
+            'description': description,
+            'url': main_video,
+            'thumbnail': thumbnail
+        }


### PR DESCRIPTION
Will be able to download the medium quality videos from konserthuset.se #8370 
These are fallbacks for the player.
Other qualities are available within the embeded player.

For the player itself, it's generated through the script after `id="mediaplayer"` in the html.
Ex. http://csp.picsearch.com/rest?e=A9ODGLWH1tTwF-JORean95Q5B1h1VLHYXXQWoeWjE7Qn0rautuiVnbxqHkx-es0QC0nDdbJMAI1KxJSb7lbO_RKqJxUeiXZ2

Search for "bitrate", and you'll have the different qualities.
Each video is on the form `<video_id>?token=<token_id>`
None of the other qualities are directly accessable, and I'm also missing a good way to load everything from the json format into this extractor. 
Any pointers getting this done would be helpful!