### PR TITLE
force id to be string for download_archive

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1753,7 +1753,7 @@ class YoutubeDL(object):
                 extractor = info_dict.get('ie_key')  # key in a playlist
         if extractor is None:
             return None  # Incomplete video information
-        return extractor.lower() + ' ' + info_dict['id']
+        return extractor.lower() + ' ' + str(info_dict['id'])
 
     def in_download_archive(self, info_dict):
         fn = self.params.get('download_archive')


### PR DESCRIPTION
As far as I know, netease uses numbers, which are no strings and need to get converted.