### PR TITLE
fix netzkino extractor for subcategory urls

### DIFF
--- a/youtube_dl/extractor/netzkino.py
+++ b/youtube_dl/extractor/netzkino.py
@@ -36,7 +36,7 @@ class NetzkinoIE(InfoExtractor):
 
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)
-        category_id = mobj.group('category').split('-')[-1]
+        category_id = mobj.group('category').split('-')[0]
         video_id = mobj.group('id')
 
         api_url = 'http://api.netzkino.de.simplecache.net/capi-2.0a/categories/%s.json?d=www' % category_id

--- a/youtube_dl/extractor/netzkino.py
+++ b/youtube_dl/extractor/netzkino.py
@@ -36,7 +36,7 @@ class NetzkinoIE(InfoExtractor):
 
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)
-        category_id = mobj.group('category')
+        category_id = mobj.group('category').split('-')[-1]
         video_id = mobj.group('id')
 
         api_url = 'http://api.netzkino.de.simplecache.net/capi-2.0a/categories/%s.json?d=www' % category_id


### PR DESCRIPTION
Some movies on netzkino are in subcategories, but the api url is only for main category. E.g. http://www.netzkino.de/#!/science-fiction-kinoab18/downstream will not load with current extractor. This PR fixes this by splitting the category and taking only the last part.