### PR TITLE
[MDR] Why m3u8_native instead of m3u8?

### DIFF
--- a/youtube_dl/extractor/mdr.py
+++ b/youtube_dl/extractor/mdr.py
@@ -99,7 +99,7 @@ class MDRIE(InfoExtractor):
                 ext = determine_ext(url_el.text)
                 if ext == 'm3u8':
                     url_formats = self._extract_m3u8_formats(
-                        video_url, video_id, 'mp4', entry_protocol='m3u8_native',
+                        video_url, video_id, 'mp4', entry_protocol='m3u8',
                         preference=0, m3u8_id='HLS', fatal=False)
                 elif ext == 'f4m':
                     url_formats = self._extract_f4m_formats(


### PR DESCRIPTION
I recently used youtube-dl to download a KiKa-broadcast-recording like this: `youtube-dl -f HLS-3771 "http://www.kika.de/checker-tobi/sendungen/sendung76752.html"`. The resulting file played fine in VLC but would not play in QuickTime Player. I could fix the file by doing `ffmpeg -i Der\ THW-Check-76752.mp4 -c copy -f mp4 -bsf:a aac_adtstoasc Der\ THW-Check-76752.2.mp4`.

I then realized that there are two implementations of m3u8 in [youtube_dl/downloader/hls.py](https://github.com/rg3/youtube-dl/blob/master/youtube_dl/downloader/hls.py). One difference between the two is that the step I took to fix the file is already done while downloading the file.

I locally changed [youtube_dl/extractor/mdr.py](https://github.com/rg3/youtube-dl/blob/master/youtube_dl/extractor/mdr.py#L102) to read

                if ext == 'm3u8':
                    url_formats = self._extract_m3u8_formats(
                        video_url, video_id, 'mp4', entry_protocol='m3u8_native',
                        preference=0, m3u8_id='HLS', fatal=False)

and it seems to fix my problem. Also it seems that by using the `hls_prefer_native`-setting clients without `ffmpeg` installed are still supported.

I currently don't have the time to verify this globally at hand, but to me it seems, that extractors generally should be switched from `m3u8_native` to `m3u` and let `hls_prefer_native` do the magic.