### PR TITLE
[downloader/fragment] Set 'total_bytes' in progress hook to None

### DIFF
--- a/youtube_dl/downloader/fragment.py
+++ b/youtube_dl/downloader/fragment.py
@@ -62,6 +62,7 @@ class FragmentFD(FileDownloader):
             'frag_count': total_frags,
             'filename': ctx['filename'],
             'tmpfilename': ctx['tmpfilename'],
+            'total_bytes': None,
         }
 
         start = time.time()


### PR DESCRIPTION
To be consistent with progress hook documentation.

Fixes #8711