### PR TITLE
Detect file extensions of DASH formats from their codecs

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -29,6 +29,7 @@ from ..utils import (
     age_restricted,
     bug_reports_message,
     clean_html,
+    codec2ext,
     compiled_regex_type,
     determine_ext,
     error_to_compat_str,
@@ -1471,6 +1472,7 @@ class InfoExtractor(object):
                         f = {
                             'format_id': '%s-%s' % (mpd_id, representation_id) if mpd_id else representation_id,
                             'url': base_url,
+                            'ext': codec2ext(representation_attrib.get('codecs')),
                             'width': int_or_none(representation_attrib.get('width')),
                             'height': int_or_none(representation_attrib.get('height')),
                             'tbr': int_or_none(representation_attrib.get('bandwidth'), 1000),

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1893,6 +1893,19 @@ def mimetype2ext(mt):
     }.get(res, res)
 
 
+def codec2ext(codec):
+    codec_type = codec.split('.')[0]
+
+    # Leave the return value None for unknown values as codec_type
+    # is not a good fallback for file extensions
+    return {
+        'avc1': 'mp4',
+        'mp4a': 'm4a',
+        'vorbis': 'webm',
+        'vp9': 'webm',
+    }.get(codec_type)
+
+
 def urlhandle_detect_ext(url_handle):
     try:
         url_handle.headers

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1900,6 +1900,9 @@ def codec2ext(codec):
     # is not a good fallback for file extensions
     return {
         'avc1': 'mp4',
+        'avc2': 'mp4',
+        'avc3': 'mp4',
+        'avc4': 'mp4',
         'mp4a': 'm4a',
         'vorbis': 'webm',
         'vp9': 'webm',


### PR DESCRIPTION
youtube-dl reports wrong file extensions for the video mentioned in #8764:
```
$ youtube-dl -vF https://twitter.com/INJO/status/705585226186149888
[debug] System config: []
[debug] User config: []
[debug] Command-line args: ['-vF', 'https://twitter.com/INJO/status/705585226186149888']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2016.03.01
[debug] Git HEAD: 845817a
[debug] Python version 3.5.1 - Linux-4.4.3-1-ARCH-x86_64-with-arch-Arch-Linux
[debug] exe versions: avconv v12_dev0-2434-gf6ccee9, avprobe v12_dev0-2434-gf6ccee9, ffmpeg 3.0, ffprobe 3.0, rtmpdump 2.4
[debug] Proxy map: {}
[twitter] 705585226186149888: Downloading webpage
[twitter:card] 705585226186149888: Downloading webpage
[twitter:card] 705585226186149888: Downloading m3u8 information
[twitter:card] 705585226186149888: Downloading MPD manifest
[info] Available formats for 705585226186149888:
format code  extension  resolution note
hls-meta     mp4        multiple   Quality selection URL 
http-320     mp4        320x180     320k
http-832-0   webm       640x360     832k
http-832-1   mp4        640x360     832k
http-2176    mp4        1280x720   2176k
dash-5       com        audio only DASH audio   64k , mp4a.40.2 (44100Hz)
dash-4       com        audio only DASH audio  128k , mp4a.40.2 (44100Hz)
dash-1       com        320x180    DASH video  256k , avc1.42001f, video only
hls-320      mp4        320x180     320k , mp4a.40.2, avc1.42001f
dash-2       com        640x360    DASH video  768k , avc1.42001f, video only
hls-832      mp4        640x360     832k , mp4a.40.2, avc1.42001f
dash-3       com        1280x720   DASH video 2048k , avc1.4d001e, video only
hls-2176     mp4        1280x720   2176k , mp4a.40.2, avc1.4d001e (best)
```
That's because [```_parse_mpd_formats``` uses ```<BaseURL>``` as ```url``` for the format](https://github.com/rg3/youtube-dl/blob/845817aadfa5f811afe5834c0b34f50f6c3a2a67/youtube_dl/extractor/common.py#L1473), and ```<BaseURL>``` is https://video.twimg.com in this case.

I'm not sure whether or not this fix affects other sites with DASH formats, including YouTube and Facebook. More checks needed.