### PR TITLE
[WDR] complete overhaul after relaunch of the site (also fixes #8562)

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -923,7 +923,6 @@ from .wat import WatIE
 from .wdr import (
     WDRIE,
     WDRMobileIE,
-    WDRMausIE,
 )
 from .webofstories import (
     WebOfStoriesIE,

--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -17,7 +17,7 @@ from ..utils import (
 class WDRIE(InfoExtractor):
     _CURRENT_MAUS_URL = r'https?://www.wdrmaus.de/aktuelle-sendung/(wdr|index).php5'
     _PAGE_REGEX = r'/mediathek/(?P<media_type>[^/]+)/(?P<type>[^/]+)/(?P<display_id>.+)\.html'
-    _VALID_URL = r'(?P<page_url>https?://(?:www\d\.)?wdr\d?\.de)' + _PAGE_REGEX + "|" + _CURRENT_MAUS_URL
+    _VALID_URL = r'(?P<page_url>https?://(?:www\d\.)?wdr\d?\.de)' + _PAGE_REGEX + '|' + _CURRENT_MAUS_URL
 
     _JS_URL_REGEX = r'(https?://deviceids-medp.wdr.de/ondemand/\d+/\d+\.js)'
 
@@ -116,23 +116,23 @@ class WDRIE(InfoExtractor):
         json_data = self._search_regex(r'\(({.*})\)', js_data, 'json')
         metadata = self._parse_json(json_data, display_id)
 
-        metadata_tracker_data = metadata["trackerData"]
-        metadata_media_resource = metadata["mediaResource"]
+        metadata_tracker_data = metadata['trackerData']
+        metadata_media_resource = metadata['mediaResource']
 
         formats = []
 
         # check if the metadata contains a direct URL to a file
-        metadata_media_alt = metadata_media_resource.get("alt")
+        metadata_media_alt = metadata_media_resource.get('alt')
         if metadata_media_alt:
-            for tag_name in ["videoURL", 'audioURL']:
+            for tag_name in ['videoURL', 'audioURL']:
                 if tag_name in metadata_media_alt:
                     formats.append({
                         'url': metadata_media_alt[tag_name]
                     })
 
         # check if there are flash-streams for this video
-        if "dflt" in metadata_media_resource and "videoURL" in metadata_media_resource["dflt"]:
-            video_url = metadata_media_resource["dflt"]["videoURL"]
+        if 'dflt' in metadata_media_resource and 'videoURL' in metadata_media_resource['dflt']:
+            video_url = metadata_media_resource['dflt']['videoURL']
             if video_url.endswith('.f4m'):
                 full_video_url = video_url + '?hdcore=3.2.0&plugin=aasp-3.2.0.77.18'
                 formats.extend(self._extract_f4m_formats(full_video_url, display_id, f4m_id='hds', fatal=False))
@@ -140,13 +140,13 @@ class WDRIE(InfoExtractor):
                 formats.extend(self._extract_smil_formats(video_url, 'stream', fatal=False))
 
         subtitles = {}
-        caption_url = metadata_media_resource.get("captionURL")
+        caption_url = metadata_media_resource.get('captionURL')
         if caption_url:
             subtitles['de'] = [{
                 'url': caption_url
             }]
 
-        title = metadata_tracker_data.get("trackerClipTitle")
+        title = metadata_tracker_data.get('trackerClipTitle')
         is_live = url_type == 'live'
 
         if is_live:
@@ -163,13 +163,13 @@ class WDRIE(InfoExtractor):
         self._sort_formats(formats)
 
         return {
-            'id': metadata_tracker_data.get("trackerClipId", display_id),
+            'id': metadata_tracker_data.get('trackerClipId', display_id),
             'display_id': display_id,
             'title': title,
-            'alt_title': metadata_tracker_data.get("trackerClipSubcategory"),
+            'alt_title': metadata_tracker_data.get('trackerClipSubcategory'),
             'formats': formats,
             'upload_date': upload_date,
-            'description': self._html_search_meta("Description", webpage),
+            'description': self._html_search_meta('Description', webpage),
             'is_live': is_live,
             'subtitles': subtitles,
         }

--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -72,7 +72,7 @@ class WDRIE(InfoExtractor):
         },
         {
             'url': 'http://www1.wdr.de/mediathek/video/sendungen/aktuelle-stunde/aktuelle-stunde-120.html',
-            'playlist_mincount': 10,
+            'playlist_mincount': 8,
             'info_dict': {
                 'id': 'aktuelle-stunde/aktuelle-stunde-120',
             },
@@ -121,7 +121,7 @@ class WDRIE(InfoExtractor):
             entries = [
                 self.url_result(page_url + href[0], 'WDR')
                 for href in re.findall(
-                    r'<a href="(%s)"' % self._PAGE_REGEX,
+                    r'<a href="(%s)"[^>]+data-extension=' % self._PAGE_REGEX,
                     webpage)
             ]
 

--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -9,6 +9,7 @@ from ..compat import (
     compat_urlparse,
 )
 from ..utils import (
+    strip_jsonp,
     unified_strdate,
     ExtractorError,
 )
@@ -112,9 +113,8 @@ class WDRIE(InfoExtractor):
 
             raise ExtractorError('No downloadable streams found', expected=True)
 
-        js_data = self._download_webpage(js_url, 'metadata')
-        json_data = self._search_regex(r'\(({.*})\)', js_data, 'json')
-        metadata = self._parse_json(json_data, display_id)
+        metadata = self._download_json(
+            js_url, 'metadata', transform_source=strip_jsonp)
 
         metadata_tracker_data = metadata['trackerData']
         metadata_media_resource = metadata['mediaResource']

--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -15,8 +15,9 @@ from ..utils import (
 
 
 class WDRIE(InfoExtractor):
+    _CURRENT_MAUS_URL = r'https?://www.wdrmaus.de/aktuelle-sendung/(wdr|index).php5'
     _PAGE_REGEX = r'/mediathek/(?P<media_type>[^/]+)/(?P<type>[^/]+)/(?P<display_id>.+)\.html'
-    _VALID_URL = r'(?P<page_url>https?://(?:www\d\.)?wdr\d?\.de)' + _PAGE_REGEX
+    _VALID_URL = r'(?P<page_url>https?://(?:www\d\.)?wdr\d?\.de)' + _PAGE_REGEX + "|" + _CURRENT_MAUS_URL
 
     _JS_URL_REGEX = r'(https?://deviceids-medp.wdr.de/ondemand/\d+/\d+\.js)'
 
@@ -75,7 +76,18 @@ class WDRIE(InfoExtractor):
             'info_dict': {
                 'id': 'aktuelle-stunde/aktuelle-stunde-120',
             },
-        }
+        },
+        {
+            'url': 'http://www.wdrmaus.de/aktuelle-sendung/index.php5',
+            'info_dict': {
+                'id': 'mdb-1096487',
+                'ext': 'flv',
+                'upload_date': 're:^[0-9]{8}$',
+                'title': 're:^Die Sendung mit der Maus vom [0-9.]{10}$',
+                'description': '- Die Sendung mit der Maus -',
+            },
+            'skip': 'The id changes from week to week because of the new episode'
+        },
     ]
 
     def _real_extract(self, url):
@@ -195,26 +207,17 @@ class WDRMobileIE(InfoExtractor):
 
 
 class WDRMausIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?wdrmaus\.de/(?:[^/]+/){,2}(?P<id>[^/?#]+)(?:/index\.php5|(?<!index)\.php5|/(?:$|[?#]))'
+    _VALID_URL = 'https?://(?:www\.)?wdrmaus\.de/(?:[^/]+/){,2}(?P<id>[^/?#]+)((?<!index)\.php5|/(?:$|[?#]))'
     IE_DESC = 'Sendung mit der Maus'
     _TESTS = [{
-        'url': 'http://www.wdrmaus.de/aktuelle-sendung/index.php5',
+        'url': 'http://www.wdrmaus.de/sachgeschichten/sachgeschichten/achterbahn.php5',
+        'md5': '178b432d002162a14ccb3e0876741095',
         'info_dict': {
-            'id': 'aktuelle-sendung',
+            'id': 'achterbahn',
             'ext': 'mp4',
             'thumbnail': 're:^http://.+\.jpg',
-            'upload_date': 're:^[0-9]{8}$',
-            'title': 're:^[0-9.]{10} - Aktuelle Sendung$',
-        }
-    }, {
-        'url': 'http://www.wdrmaus.de/sachgeschichten/sachgeschichten/40_jahre_maus.php5',
-        'md5': '3b1227ca3ed28d73ec5737c65743b2a3',
-        'info_dict': {
-            'id': '40_jahre_maus',
-            'ext': 'mp4',
-            'thumbnail': 're:^http://.+\.jpg',
-            'upload_date': '20131007',
-            'title': '12.03.2011 - 40 Jahre Maus',
+            'upload_date': '20131001',
+            'title': '19.09.2013 - Achterbahn',
         }
     }]
 


### PR DESCRIPTION
The WDR relaunched their site on 2016-02-23 which not only changed the
URL-schema completely but also the layout of their pages.

Apparently the whole "mediathek" now runs on the wdr-domain, so no
separate URL for funkhauseuropa anymore.
There seems to be no explicit handling of video-sizes on the page or in
the URLs anymore. There seems to be only one size for HTML5, but still
several sizes for flash. The new extractor adds all to the list of formats.

There is no metadata for the HTML5-stream, so that the best flash-stream
will always be considered as the "best" format. At least in my tests
this seemed to be true anyway.

As this is my first extractor please let my know if I did anything wrong or
missed something.
I was not sure about the tests, currently they are of course working, but
because of the weird laws in Germany I know that they will be deleted
soonish, so I already added the skips to avoid that they'll break the build
at the time that happens.

This also fixes #8562 by just adding the current show URL to the
WDR-extractor, which works fine.

EDIT (2016-03-19): as #8842 was closed as a duplicate of this PR, I added
the text from there, so that there is a complete description on this changes
without having to look into the commit messages.