### PR TITLE
return mpd_url for dash segmented formats(#8704)

### DIFF
--- a/youtube_dl/downloader/dash.py
+++ b/youtube_dl/downloader/dash.py
@@ -18,9 +18,10 @@ class DashSegmentsFD(FragmentFD):
     FD_NAME = 'dashsegments'
 
     def real_download(self, filename, info_dict):
-        base_url = info_dict['url']
-        segment_urls = [info_dict['segment_urls'][0]] if self.params.get('test', False) else info_dict['segment_urls']
-        initialization_url = info_dict.get('initialization_url')
+        params = info_dict['_downloader_params']
+        base_url = params['base_url']
+        segment_urls = [params['segment_urls'][0]] if self.params.get('test', False) else params['segment_urls']
+        initialization_url = params.get('initialization_url')
 
         ctx = {
             'filename': filename,

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -1320,7 +1320,7 @@ class GenericIE(InfoExtractor):
                 return self.playlist_result(self._parse_xspf(doc, video_id), video_id)
             elif re.match(r'(?i)^(?:{[^}]+})?MPD$', doc.tag):
                 info_dict['formats'] = self._parse_mpd_formats(
-                    doc, video_id, mpd_base_url=url.rpartition('/')[0])
+                    doc, video_id, mpd_url=url)
                 return info_dict
             elif re.match(r'^{http://ns\.adobe\.com/f4m/[12]\.0}manifest$', doc.tag):
                 info_dict['formats'] = self._parse_f4m_formats(doc, url, video_id)


### PR DESCRIPTION
mpd_url construction rules can be found in Annex C section 4 in ISO/IEC 23009-1

- separate downloader specific params from other info_dict keys
- the mpd_url can be used with external programs like MP4Box and VLC 3
- it's needed to be passed to dash downloader to support live stream download