### PR TITLE
[Udemy] Fix issue 8753

### DIFF
--- a/youtube_dl/extractor/udemy.py
+++ b/youtube_dl/extractor/udemy.py
@@ -142,9 +142,12 @@ class UdemyIE(InfoExtractor):
         lecture_id = self._match_id(url)
 
         webpage = self._download_webpage(url, lecture_id)
-
-        course_id = self._search_regex(
+        try:
+            course_id = self._search_regex(
             r'data-course-id=["\'](\d+)', webpage, 'course id')
+        except ExtractorError as e:
+            course_id = self._search_regex(
+               r'&quot;id&quot;: (\d+)', webpage, 'course id')
 
         try:
             lecture = self._download_lecture(course_id, lecture_id)

--- a/youtube_dl/extractor/udemy.py
+++ b/youtube_dl/extractor/udemy.py
@@ -142,12 +142,10 @@ class UdemyIE(InfoExtractor):
         lecture_id = self._match_id(url)
 
         webpage = self._download_webpage(url, lecture_id)
-        try:
-            course_id = self._search_regex(
-            r'data-course-id=["\'](\d+)', webpage, 'course id')
-        except ExtractorError as e:
-            course_id = self._search_regex(
-               r'&quot;id&quot;: (\d+)', webpage, 'course id')
+        
+        course_id = self._search_regex(
+            (r'data-course-id=["\'](\d+)', r'&quot;id&quot;: (\d+)'),
+            webpage, 'course id')
 
         try:
             lecture = self._download_lecture(course_id, lecture_id)


### PR DESCRIPTION
Fix issue in https://github.com/rg3/youtube-dl/issues/8753
The web page changes the HTML in new version of video player so it causes the error of "Unable to extract course id". I change the regex and everything works now.