### PR TITLE
Added format_id to the filers on -f.

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -905,7 +905,7 @@ class YoutubeDL(object):
                 '*=': lambda attr, value: value in attr,
             }
             str_operator_rex = re.compile(r'''(?x)
-                \s*(?P<key>ext|acodec|vcodec|container|protocol)
+                \s*(?P<key>ext|acodec|vcodec|container|protocol|format_id)
                 \s*(?P<op>%s)(?P<none_inclusive>\s*\?)?
                 \s*(?P<value>[a-zA-Z0-9._-]+)
                 \s*$


### PR DESCRIPTION
Useful for certain websites (e.g. Funimation) where the formats are episode specific but all have something in common.

I wanted to be able to specify only the japanese formats, and this allows it.

Example
`youtube-dl -f best[format_id*=JPN] "url"`