### PR TITLE
Add --fragment-retries option (Fixes #8466)

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -144,14 +144,20 @@ def _real_main(argv=None):
         if numeric_limit is None:
             parser.error('invalid max_filesize specified')
         opts.max_filesize = numeric_limit
-    if opts.retries is not None:
-        if opts.retries in ('inf', 'infinite'):
-            opts_retries = float('inf')
+
+    def parse_retries(retries):
+        if retries in ('inf', 'infinite'):
+            parsed_retries = float('inf')
         else:
             try:
-                opts_retries = int(opts.retries)
+                parsed_retries = int(retries)
             except (TypeError, ValueError):
                 parser.error('invalid retry count specified')
+        return parsed_retries
+    if opts.retries is not None:
+        opts.retries = parse_retries(opts.retries)
+    if opts.fragment_retries is not None:
+        opts.fragment_retries = parse_retries(opts.fragment_retries)
     if opts.buffersize is not None:
         numeric_buffersize = FileDownloader.parse_bytes(opts.buffersize)
         if numeric_buffersize is None:
@@ -299,7 +305,8 @@ def _real_main(argv=None):
         'force_generic_extractor': opts.force_generic_extractor,
         'ratelimit': opts.ratelimit,
         'nooverwrites': opts.nooverwrites,
-        'retries': opts_retries,
+        'retries': opts.retries,
+        'fragment_retries': opts.fragment_retries,
         'buffersize': opts.buffersize,
         'noresizebuffer': opts.noresizebuffer,
         'continuedl': opts.continue_dl,

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -116,6 +116,10 @@ class FileDownloader(object):
         return '%10s' % ('%s/s' % format_bytes(speed))
 
     @staticmethod
+    def format_retries(retries):
+        return 'inf' if retries == float('inf') else '%.0f' % retries
+
+    @staticmethod
     def best_block_size(elapsed_time, bytes):
         new_min = max(bytes / 2.0, 1.0)
         new_max = min(max(bytes * 2.0, 1.0), 4194304)  # Do not surpass 4 MB
@@ -297,7 +301,9 @@ class FileDownloader(object):
 
     def report_retry(self, count, retries):
         """Report retry in case of HTTP error 5xx"""
-        self.to_screen('[download] Got server HTTP error. Retrying (attempt %d of %.0f)...' % (count, retries))
+        self.to_screen(
+            '[download] Got server HTTP error. Retrying (attempt %d of %s)...'
+            % (count, self.format_retries(retries)))
 
     def report_file_already_downloaded(self, file_name):
         """Report file has already been fully downloaded."""

--- a/youtube_dl/downloader/fragment.py
+++ b/youtube_dl/downloader/fragment.py
@@ -19,6 +19,10 @@ class HttpQuietDownloader(HttpFD):
 class FragmentFD(FileDownloader):
     """
     A base file downloader class for fragmented media (e.g. f4m/m3u8 manifests).
+
+    Available options:
+
+    fragment_retries:   Number of times to retry a fragment for HTTP error (DASH only)
     """
 
     def report_retry_fragment(self, fragment_name, count, retries):

--- a/youtube_dl/downloader/fragment.py
+++ b/youtube_dl/downloader/fragment.py
@@ -21,6 +21,11 @@ class FragmentFD(FileDownloader):
     A base file downloader class for fragmented media (e.g. f4m/m3u8 manifests).
     """
 
+    def report_retry_fragment(self, fragment_name, count, retries):
+        self.to_screen(
+            '[download] Got server HTTP error. Retrying fragment %s (attempt %d of %.0f)...'
+            % (fragment_name, count, retries))
+
     def _prepare_and_start_frag_download(self, ctx):
         self._prepare_frag_download(ctx)
         self._start_frag_download(ctx)

--- a/youtube_dl/downloader/fragment.py
+++ b/youtube_dl/downloader/fragment.py
@@ -23,8 +23,8 @@ class FragmentFD(FileDownloader):
 
     def report_retry_fragment(self, fragment_name, count, retries):
         self.to_screen(
-            '[download] Got server HTTP error. Retrying fragment %s (attempt %d of %.0f)...'
-            % (fragment_name, count, retries))
+            '[download] Got server HTTP error. Retrying fragment %s (attempt %d of %s)...'
+            % (fragment_name, count, self.format_retries(retries)))
 
     def _prepare_and_start_frag_download(self, ctx):
         self._prepare_frag_download(ctx)

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -400,6 +400,10 @@ def parseOpts(overrideArguments=None):
         dest='retries', metavar='RETRIES', default=10,
         help='Number of retries (default is %default), or "infinite".')
     downloader.add_option(
+        '--fragment-retries',
+        dest='fragment_retries', metavar='RETRIES', default=10,
+        help='Number of retries for a fragment (default is %default), or "infinite" (DASH only)')
+    downloader.add_option(
         '--buffer-size',
         dest='buffersize', metavar='SIZE', default='1024',
         help='Size of download buffer (e.g. 1024 or 16K) (default is %default)')


### PR DESCRIPTION
**Abstract**
Introduces a new option `--fragment-retries` for retrying fragments in fragment based downloaders (yet DASH segments only) with default value of 10 retry attemps.

**Rationale**
YouTube may often return 404 HTTP error for a fragment in DASH segments downloader causing the whole download to fail. However if the same fragment is immediately retried with the same request data this usually succeeds (1-2 attemps is usually enough for success) thus allowing to download the whole file successfully. So, we will retry all fragments that fail with 404 HTTP error for now.

**Example URLs**
Example videos I've been able to reproduce failing fragments with: RTwddp2uIu0 ImiqwgpbQuQ. Videos uploaded to YouTube in a last hour are also very likely to be DASH segments with failing fragments.

**Demo**
Here is how it looks in action:
```
> py26yt -v https://www.youtube.com/watch?v=ImiqwgpbQuQ
[debug] System config: []
[debug] User config: [u'--cookies', u'C:\\Documents and Settings\\Administrator\\My Documents\\Downloads\\cookies (7).txt']
[debug] Command-line args: [u'-v', u'https://www.youtube.com/watch?v=ImiqwgpbQuQ']
[debug] Encodings: locale cp1251, fs mbcs, out cp866, pref cp1251
[debug] youtube-dl version 2016.03.18
[debug] Git HEAD: 0d769bc
[debug] Python version 2.6.6 - Windows-2003Server-5.2.3790-SP2
[debug] exe versions: ffmpeg 3.0, ffprobe N-77883-gd7c75a5, rtmpdump 2.4
[debug] Proxy map: {}
[youtube] ImiqwgpbQuQ: Downloading webpage
[youtube] ImiqwgpbQuQ: Downloading video info webpage
[youtube] ImiqwgpbQuQ: Extracting video information
[youtube] ImiqwgpbQuQ: Downloading MPD manifest
[youtube] ImiqwgpbQuQ: Downloading MPD manifest
[debug] Invoking downloader on u'https://r2---sn-ug5onuxaxjvh-v8cl.googlevideo.com/videoplayback/id/2268aac20a5b42e4/itag/160/source/yt_otf/requiressl/yes/pl/20/mv/m/ms/au/pcm2cms/yes/mn/sn-ug5onuxaxjvh-v8cl/mm/31/ratebypass/yes/mime/video%2Fmp4/otfp/1/otf/1/lmt/1458363344473186/sver/3/upn/_naZCjFF770/signature/4AA369077A0E75BA98E0B30BECE7B4A04F678D2B.01A8878203A97106568518CA6F747D7EE56E8F20/mt/1458395955/key/dg_yt0/fexp/9416126,9420452,9422596,9423661,9423662,9427902,9429362,9431012/ip/<snip>/ipbits/0/expire/1458417723/sparams/ip,ipbits,expire,id,itag,source,requiressl,pl,mv,ms,pcm2cms,mn,mm,ratebypass,mime,otfp,otf,lmt/'
[dashsegments] Total fragments: 153
[download] Destination: Test Online game. BigDaimon vs _Shepherd-ImiqwgpbQuQ.f160.mp4
[download]  33.3% of ~9.45MiB at  2.01MiB/s ETA 01:04     [download] Got server HTTP error. Retrying Seg50 (attempt 1 of 10)...
[download]  43.8% of ~9.52MiB at  4.07MiB/s ETA 00:55     [download] Got server HTTP error. Retrying Seg66 (attempt 1 of 10)...
[download]  59.5% of ~9.36MiB at  2.02MiB/s ETA 00:40     [download] Got server HTTP error. Retrying Seg90 (attempt 1 of 10)...
[download]  69.3% of ~9.43MiB at  4.45MiB/s ETA 00:30     [download] Got server HTTP error. Retrying Seg105 (attempt 1 of 10)...
[download]  75.8% of ~9.48MiB at  2.09MiB/s ETA 00:24     [download] Got server HTTP error. Retrying Seg115 (attempt 1 of 10)...
[download] 100% of 9.31MiB in 01:43
[debug] Invoking downloader on u'https://r2---sn-ug5onuxaxjvh-v8cl.googlevideo.com/videoplayback/id/2268aac20a5b42e4/itag/140/source/youtube/requiressl/yes/pl/20/mv/m/ms/au/pcm2cms/yes/mn/sn-ug5onuxaxjvh-v8cl/mm/31/ratebypass/yes/mime/audio%2Fmp4/otfp/1/gir/yes/clen/12828777/lmt/1458363330509055/dur/807.102/sver/3/upn/_naZCjFF770/signature/583449DC8EEF61E4B9F15549DF840416658F032F.80EDCA73B263405C620121A3968B36884E540078/mt/1458395955/key/dg_yt0/fexp/9416126,9420452,9422596,9423661,9423662,9427902,9429362,9431012/ip/<snip>/ipbits/0/expire/1458417723/sparams/ip,ipbits,expire,id,itag,source,requiressl,pl,mv,ms,pcm2cms,mn,mm,ratebypass,mime,otfp,gir,clen,lmt,dur/'
[dashsegments] Total fragments: 163
[download] Destination: Test Online game. BigDaimon vs _Shepherd-ImiqwgpbQuQ.f140.m4a
[download] 100% of 12.23MiB in 01:10
[ffmpeg] Merging formats into "Test Online game. BigDaimon vs _Shepherd-ImiqwgpbQuQ.mp4"
[debug] ffmpeg command line: ffmpeg -y -i 'file:Test Online game. BigDaimon vs _Shepherd-ImiqwgpbQuQ.f160.mp4' -i 'file:Test Online game. BigDaimon vs _Shepherd-ImiqwgpbQuQ.f140.m4a' -c copy -map 0:v:0 -map 1:a:0 'file:Test Online game. BigDaimon vs _Shepherd-ImiqwgpbQuQ.temp.mp4'
Deleting original file Test Online game. BigDaimon vs _Shepherd-ImiqwgpbQuQ.f160.mp4 (pass -k to keep)
Deleting original file Test Online game. BigDaimon vs _Shepherd-ImiqwgpbQuQ.f140.m4a (pass -k to keep)
```

**Further improvements**
This can be adopted for other fragment based downloaders if necessary.