### PR TITLE
screencast.com: support missing www

### DIFF
--- a/youtube_dl/extractor/screencast.py
+++ b/youtube_dl/extractor/screencast.py
@@ -12,7 +12,7 @@ from ..utils import (
 
 
 class ScreencastIE(InfoExtractor):
-    _VALID_URL = r'https?://www\.screencast\.com/t/(?P<id>[a-zA-Z0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?screencast\.com/t/(?P<id>[a-zA-Z0-9]+)'
     _TESTS = [{
         'url': 'http://www.screencast.com/t/3ZEjQXlT',
         'md5': '917df1c13798a3e96211dd1561fded83',
@@ -34,7 +34,7 @@ class ScreencastIE(InfoExtractor):
             'thumbnail': 're:^https?://.*\.(?:gif|jpg)$',
         }
     }, {
-        'url': 'http://www.screencast.com/t/aAB3iowa',
+        'url': 'http://screencast.com/t/aAB3iowa',
         'md5': 'dedb2734ed00c9755761ccaee88527cd',
         'info_dict': {
             'id': 'aAB3iowa',

--- a/youtube_dl/extractor/screencast.py
+++ b/youtube_dl/extractor/screencast.py
@@ -95,7 +95,8 @@ class ScreencastIE(InfoExtractor):
         if title is None:
             title = self._html_search_regex(
                 [r'<b>Title:</b> ([^<]*)</div>',
-                 r'class="tabSeperator">></span><span class="tabText">(.*?)<'],
+                 r'class="tabSeperator">></span><span class="tabText">(.*?)<',
+                 r'<title>([^<]*)</title>'],
                 webpage, 'title')
         thumbnail = self._og_search_thumbnail(webpage)
         description = self._og_search_description(webpage, default=None)


### PR DESCRIPTION
- The "www." part of the URL is not mandatory. Modified a test to test both URL formats
- use the `<title>` tag of the page to find filename