### PR TITLE
Fix language selection with Arte+7

### DIFF
--- a/youtube_dl/extractor/arte.py
+++ b/youtube_dl/extractor/arte.py
@@ -161,16 +161,20 @@ class ArteTVPlus7IE(InfoExtractor):
             'es': 'E[ESP]',
         }
 
+        langcode = LANGS.get(lang, lang)
         formats = []
         for format_id, format_dict in player_info['VSR'].items():
             f = dict(format_dict)
             versionCode = f.get('versionCode')
-            langcode = LANGS.get(lang, lang)
             lang_rexs = [r'VO?%s-' % re.escape(langcode), r'VO?.-ST%s$' % re.escape(langcode)]
             lang_pref = None
             if versionCode:
-                matched_lang_rexs = [r for r in lang_rexs if re.match(r, versionCode)]
-                lang_pref = -10 if not matched_lang_rexs else 10 * len(matched_lang_rexs)
+                if versionCode == 'VO%s' % langcode:
+                    # versionCode exactly matches langCode
+                    lang_pref = 20
+                else:
+                    matched_lang_rexs = [r for r in lang_rexs if re.match(r, versionCode)]
+                    lang_pref = -10 if not matched_lang_rexs else 10 * len(matched_lang_rexs)
             source_pref = 0
             if versionCode is not None:
                 # The original version with subtitles has lower relevance


### PR DESCRIPTION
Hi everyone,
This PR fixes a problem in the choice of the language in Arte+7 videos.

The allocation of lang_pref now gives more weight to the version that has an exact match with the wanted language.
Before this change, the script would randomly choose a version that had some kind of match with the wanted language. For example, I wanted the French version of a video, and I got one with French audio and Spanish subtitles (e.g. `youtube_dl http://www.arte.tv/guide/fr/053986-001-A/la-fin-des-ottomans-1-2`).

Thanks