### PR TITLE
[downloader/external] pass external downloader args to FFmpegFD only if it's specified explicitly

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -181,7 +181,8 @@ class FFmpegFD(ExternalFD):
 
         args = [ffpp.executable, '-y']
 
-        args += self._configuration_args()
+        if self.exe == self.get_basename():
+            args += self._configuration_args()
 
         # start_time = info_dict.get('start_time') or 0
         # if start_time:


### PR DESCRIPTION
currently when you use `--external-downloader` and `--external-downloader-args` with external downloader other than ffmpeg and you try to download an m3u8 video it will fail because it try to pass the `--external-downloader-args` to ffmpeg.
example(in my config file i pass this argment: `--external-downloader aria2c --external-downloader-args '-x 16'`)

```
youtube-dl -v -f hls-840 http://www.aljazeera.com/programmes/the-slum/2014/08/deliverance-201482883754237240.html
[debug] System config: []
[debug] User config: ['--external-downloader', 'aria2c', '--external-downloader-args', '-x 16', '-f', 'best[protocol=http][height<=?720]/best[protocol!=m3u8][height<=?720]/best[height<=?720]/bestvideo[height<=?720]+bestaudio', '--sub-format', 'srt/vtt/best', '--convert-subs', 'srt', '--sub-lang', 'en,enUS,en-US,English', '--write-sub', '--no-check-certificate']
[debug] Command-line args: ['-v', '-f', 'hls-840', 'http://www.aljazeera.com/programmes/the-slum/2014/08/deliverance-201482883754237240.html']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2016.04.19
[debug] Lazy loading extractors enabled
[debug] Python version 3.5.1 - Linux-4.5.0-1-ARCH-x86_64-with-arch
[debug] exe versions: ffmpeg 3.0.1, ffprobe 3.0.1, rtmpdump 2.4
[debug] Proxy map: {}
[AlJazeera] deliverance-201482883754237240: Downloading webpage
[brightcove:new] 3792260579001: Downloading webpage
[brightcove:new] 3792260579001: Downloading JSON metadata
[brightcove:new] 3792260579001: Downloading m3u8 information
[debug] Invoking downloader on 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=3792801806001&videoId=3792260579001'
[download] Destination: The Slum - Episode 1 - Deliverance-3792260579001.mp4
[debug] ffmpeg command line: ffmpeg -y -x 16 -headers 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20150101 Firefox/44.0 (Chrome)
Accept-Encoding: gzip, deflate
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
' -i 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=3792801806001&videoId=3792260579001' -c copy -f mp4 -bsf:a aac_adtstoasc 'file:The Slum - Episode 1 - Deliverance-3792260579001.mp4.part'
ffmpeg version 3.0.1 Copyright (c) 2000-2016 the FFmpeg developers
  built with gcc 5.3.0 (GCC)
  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-avisynth --enable-avresample --enable-fontconfig --enable-gnutls --enable-gpl --enable-ladspa --enable-libass --enable-libbluray --enable-libdcadec --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libiec61883 --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-libschroedinger --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-shared --enable-version3 --enable-x11grab
  libavutil      55. 17.103 / 55. 17.103
  libavcodec     57. 24.102 / 57. 24.102
  libavformat    57. 25.100 / 57. 25.100
  libavdevice    57.  0.101 / 57.  0.101
  libavfilter     6. 31.100 /  6. 31.100
  libavresample   3.  0.  0 /  3.  0.  0
  libswscale      4.  0.100 /  4.  0.100
  libswresample   2.  0.101 /  2.  0.101
  libpostproc    54.  0.100 / 54.  0.100
Option x not found.


ERROR: ffmpeg exited with code 1
  File "/usr/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/bin/youtube-dl/__main__.py", line 19, in <module>
    youtube_dl.main()
  File "/usr/local/bin/youtube-dl/youtube_dl/__init__.py", line 419, in main
    _real_main(argv)
  File "/usr/local/bin/youtube-dl/youtube_dl/__init__.py", line 409, in _real_main
    retcode = ydl.download(all_urls)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 1730, in download
    url, force_generic_extractor=self.params.get('force_generic_extractor', False))
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 682, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 734, in process_ie_result
    extra_info=extra_info)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 682, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 727, in process_ie_result
    return self.process_video_result(ie_result, download=download)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 1376, in process_video_result
    self.process_info(new_info)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 1638, in process_info
    success = dl(filename, info_dict)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 1580, in dl
    return fd.download(name, info)
  File "/usr/local/bin/youtube-dl/youtube_dl/downloader/common.py", line 350, in download
    return self.real_download(filename, info_dict)
  File "/usr/local/bin/youtube-dl/youtube_dl/downloader/external.py", line 42, in real_download
    self.get_basename(), retval))
  File "/usr/local/bin/youtube-dl/youtube_dl/downloader/common.py", line 161, in report_error
    self.ydl.report_error(*args, **kargs)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 545, in report_error
    self.trouble(error_message, tb)
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 507, in trouble
    tb_data = traceback.format_list(traceback.extract_stack())
```
