### PR TITLE
[rtlnl] Update 720p PG_URL_TEMPLATE

### DIFF
--- a/youtube_dl/extractor/rtlnl.py
+++ b/youtube_dl/extractor/rtlnl.py
@@ -94,19 +94,30 @@ class RtlNlIE(InfoExtractor):
         videopath = material['videopath']
         m3u8_url = meta.get('videohost', 'http://manifest.us.rtl.nl') + videopath
 
-        formats = self._extract_m3u8_formats(m3u8_url, uuid, ext='mp4')
+        formats = self._extract_m3u8_formats(m3u8_url, uuid)
 
         video_urlpart = videopath.split('/adaptive/')[1][:-5]
         PG_URL_TEMPLATE = 'http://pg.us.rtl.nl/rtlxl/network/%s/progressive/%s.mp4'
 
         formats.extend([
             {
-                'url': PG_URL_TEMPLATE % ('a2m', video_urlpart),
-                'format_id': 'pg-sd',
+                'url': PG_URL_TEMPLATE % ('a2t', video_urlpart),
+                'format_id': 'a2t',
+                'width': 512,
+                'height': 288,
             },
             {
-                'url': PG_URL_TEMPLATE % ('a3m', video_urlpart),
-                'format_id': 'pg-hd',
+                'url': PG_URL_TEMPLATE % ('a3t', video_urlpart),
+                'format_id': 'a3t',
+                'width': 704,
+                'height': 400,
+                'quality': 0,
+            },
+            {
+                'url': PG_URL_TEMPLATE % ('nettv', video_urlpart),
+                'format_id': 'nettv',
+                'width': 1280,
+                'height': 720,
                 'quality': 0,
             }
         ])


### PR DESCRIPTION
- Fixed the format_id for the 720p progressive videostream and added the video's resolution.
- The adaptive videostreams have the m3u8-extension, so I removed the confusing mp4-extension in order to make a better distinction between these and the progressive videostreams.

```
python -m youtube_dl -F http://www.rlxl.nl/#!/rtl-nieuws-132237/97c6e669-8585-3943-87ba-c84a740c3502
[rtl.nl] 97c6e669-8585-3943-87ba-c84a740c3502: Downloading JSON metadata
[rtl.nl] 97c6e669-8585-3943-87ba-c84a740c3502: Downloading m3u8 information
[info] Available formats for 97c6e669-8585-3943-87ba-c84a740c3502:
format code  extension  resolution note
135          m3u8       audio only  135k , mp4a.40.2
meta         m3u8       multiple   Quality selection URL
a2t          mp4        512x288
a3t          mp4        704x400
1079         m3u8       512x288    1079k , mp4a.40.2, avc1.77.31
1725         m3u8       711x400    1725k , mp4a.40.2, avc1.77.31
2809         m3u8       912x512    2809k , mp4a.40.2, avc1.100.41
4640         m3u8       1280x720   4640k , mp4a.40.2, avc1.100.41
nettv        mp4        1280x720   (best)
```