### PR TITLE
Fix embedding the thumbnails

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -47,7 +47,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
             self._downloader.to_screen('[ffmpeg] Adding thumbnail to "%s"' % filename)
 
-            self.run_ffmpeg_multiple_files([filename, thumbnail_filename], temp_filename, options)
+            self.run_ffmpeg_multiple_files([filename, thumbnail_filename], temp_filename, options, False)
 
             if not self._already_have_thumbnail:
                 os.remove(encodeFilename(thumbnail_filename))

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -139,7 +139,7 @@ class FFmpegPostProcessor(PostProcessor):
     def probe_executable(self):
         return self._paths[self.probe_basename]
 
-    def run_ffmpeg_multiple_files(self, input_paths, out_path, opts):
+    def run_ffmpeg_multiple_files(self, input_paths, out_path, opts, prefix_input_paths=True):
         self.check_version()
 
         oldest_mtime = min(
@@ -151,7 +151,7 @@ class FFmpegPostProcessor(PostProcessor):
         for path in input_paths:
             files_cmd.extend([
                 encodeArgument('-i'),
-                encodeFilename(self._ffmpeg_filename_argument(path), True)
+                encodeFilename(self._ffmpeg_filename_argument(path) if prefix_input_paths else path, True)
             ])
         cmd = ([encodeFilename(self.executable, True), encodeArgument('-y')] +
                files_cmd +


### PR DESCRIPTION
The thumbnails fail to embed on the latest version with below error:

```
$ avconv -y -i 'file:Alif Allah, Jugni, Arif Lohar & Meesha-gjaH2iuoYWE.mp3' -i 'file:Alif Allah, Jugni, Arif Lohar & Meesha-gjaH2iuoYWE.jpg' -c copy -map 0 -map 1 -metadata:s:v 'title="Album cover"' -metadata:s:v 'comment="Cover (Front)"' 'file:Alif Allah, Jugni, Arif Lohar & Meesha-gjaH2iuoYWE.temp.mp3' -v 1000
avconv version 11.4, Copyright (c) 2000-2014 the Libav developers
  built on Oct 16 2015 09:05:58 with Apple LLVM version 7.0.0 (clang-700.0.72)

-- snip --

Opening an input file: file:Alif Allah, Jugni, Arif Lohar & Meesha-gjaH2iuoYWE.mp3.
[mp3 @ 0x7fa9ea800000] Probed with size=2048 and score=55
[mp3 @ 0x7fa9ea800000] max_analyze_duration 5000000 reached
Guessed Channel Layout for  Input Stream #0.0 : stereo
Input #0, mp3, from 'file:Alif Allah, Jugni, Arif Lohar & Meesha-gjaH2iuoYWE.mp3':
  Metadata:
    encoder         : Lavf56.1.0
  Duration: 00:08:43.00, start: 0.000000, bitrate: 143 kb/s
    Stream #0.0, 211, 1/14112000: Audio: mp3, 48000 Hz, 2 channels, s16p, 143 kb/s
Successfully opened the file.
Parsing a group of options: input file file:Alif Allah, Jugni, Arif Lohar & Meesha-gjaH2iuoYWE.jpg.
Successfully parsed a group of options.
Opening an input file: file:Alif Allah, Jugni, Arif Lohar & Meesha-gjaH2iuoYWE.jpg.
file:Alif Allah, Jugni, Arif Lohar & Meesha-gjaH2iuoYWE.jpg: No such file or directory
```

It seems that the ffpmeg fails to recognize the "file:" prefix/protocol for the thumbnail files.

The change addresses the issue by not using the protocol prefix when embedding thumbnails.
This is harmless because by this time the av file must be downloaded and the inputfile protocol will default to "file".