### PR TITLE
added --autonumber-start NUMBER as a command line option

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -563,7 +563,7 @@ class YoutubeDL(object):
             if autonumber_size is None:
                 autonumber_size = 5
             autonumber_templ = '%0' + str(autonumber_size) + 'd'
-            template_dict['autonumber'] = autonumber_templ % self._num_downloads
+            template_dict['autonumber'] = autonumber_templ % (self.params.get('autonumber_start', 1) - 1 + self._num_downloads)
             if template_dict.get('playlist_index') is not None:
                 template_dict['playlist_index'] = '%0*d' % (len(str(template_dict['n_entries'])), template_dict['playlist_index'])
             if template_dict.get('resolution') is None:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -300,6 +300,7 @@ def _real_main(argv=None):
         'listformats': opts.listformats,
         'outtmpl': outtmpl,
         'autonumber_size': opts.autonumber_size,
+        'autonumber_start': opts.autonumber_start,
         'restrictfilenames': opts.restrictfilenames,
         'ignoreerrors': opts.ignoreerrors,
         'force_generic_extractor': opts.force_generic_extractor,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -617,6 +617,10 @@ def parseOpts(overrideArguments=None):
         dest='autonumber_size', metavar='NUMBER',
         help='Specify the number of digits in %(autonumber)s when it is present in output filename template or --auto-number option is given')
     filesystem.add_option(
+        '--autonumber-start',
+        dest='autonumber_start', metavar='NUMBER', type="int", default=1,
+        help='Specify the start value for the %(autonumber)s counter. Defaults to 1.')
+    filesystem.add_option(
         '--restrict-filenames',
         action='store_true', dest='restrictfilenames', default=False,
         help='Restrict filenames to only ASCII characters, and avoid "&" and spaces in filenames')


### PR DESCRIPTION
Added --autonumber-start NUMBER as a command line option to be able to offset the index at which autonumber formats filenames.
I often want to keep my videos sorted into an order I've chosen at the time when I downloaded them.

I also found 2 old requests about this: #727 and #2702.

```
➜  youtube-dl -v -o '%(uploader_id)s-%(autonumber)s-%(upload_date)s-%(title)s.%(ext)s' --no-playlist -f best --autonumber-start 8 "https://www.youtube.com/watch?v=<id>"
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'-v', u'-o', u'%(uploader_id)s-%(autonumber)s-%(upload_date)s-%(title)s.%(ext)s', u'--no-playlist', u'-f', u'best', u'--autonumber-start', u'8', u'https://www.youtube.com/watch?v=<id>']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2016.05.01
[debug] Git HEAD: a7f915a
[debug] Python version 2.7.11+ - Linux-4.4.0
[debug] exe versions: ffmpeg 2.8.6, ffprobe 2.8.6, rtmpdump 2.4
[debug] Proxy map: {}
[youtube] <id>: Downloading webpage
[youtube] <id>: Downloading video info webpage
[youtube] <id>: Extracting video information
[youtube] {22} signature length 41.40, html5 player en_US-vflA_6ZRP
[...truncated...]
[debug] Invoking downloader on u'https://.....googlevideo.com/videoplayback?upn=tso....AA'
[download] Destination: <uploader_id>-00008-20140619-<title>.mp4
[download] 100% of 94.63MiB in 00:08
```
