### PR TITLE
[afreecatv] Add new extractor for afreecatv.com VODs

### DIFF
--- a/youtube_dl/extractor/afreecatv.py
+++ b/youtube_dl/extractor/afreecatv.py
@@ -30,7 +30,7 @@ class AfreecaTVIE(InfoExtractor):
             'id': '36164052',
             'ext': 'mp4',
             'title': '데일리 에이프릴 요정들의 시상식!',
-            'thumbnail': 're:^https?://videoimg.afreecatv.com/.*$',
+            'thumbnail': 're:^https?://(?:video|st)img.afreecatv.com/.*$',
             'uploader': 'dailyapril',
             'uploader_id': 'dailyapril',
             'upload_date': '20160503',
@@ -40,7 +40,7 @@ class AfreecaTVIE(InfoExtractor):
         'info_dict': {
             'id': '36153164',
             'title': "BJ유트루와 함께하는 '팅커벨 메이크업!'",
-            'thumbnail': 're:^https?://videoimg.afreecatv.com/.*$',
+            'thumbnail': 're:^https?://(?:video|st)img.afreecatv.com/.*$',
             'uploader': 'dailyapril',
             'uploader_id': 'dailyapril',
         },
@@ -62,6 +62,9 @@ class AfreecaTVIE(InfoExtractor):
                 'upload_date': '20160502',
             },
         }],
+    }, {
+        'url': 'http://www.afreecatv.com/player/Player.swf?szType=szBjId=djleegoon&nStationNo=11273158&nBbsNo=13161095&nTitleNo=36327652',
+        'only_matching': True,
     }]
 
     @staticmethod

--- a/youtube_dl/extractor/afreecatv.py
+++ b/youtube_dl/extractor/afreecatv.py
@@ -58,7 +58,7 @@ class AfreecaTVIE(InfoExtractor):
                 'id': video_file.get('key'),
                 'title': title,
                 'duration': int_or_none(video_file.get('duration')),
-                'formats': [{'url': video_file.text}]
+                'url': video_file.text,
             })
 
         info = {
@@ -74,7 +74,7 @@ class AfreecaTVIE(InfoExtractor):
             info['_type'] = 'multi_video'
             info['entries'] = entries
         elif len(entries) == 1:
-            info['formats'] = entries[0]['formats']
+            info['url'] = entries[0]['url']
         else:
             raise ExtractorError(
                 'No files found for the specified AfreecaTV video, either'

--- a/youtube_dl/extractor/afreecatv.py
+++ b/youtube_dl/extractor/afreecatv.py
@@ -66,7 +66,7 @@ class AfreecaTVIE(InfoExtractor):
 
     @staticmethod
     def parse_video_key(key):
-        video_key = {'upload_date': None, 'part': '0'}
+        video_key = {}
         m = re.match(r'^(?P<upload_date>\d{8})_\w+_(?P<part>\d+)$', key)
         if m:
             video_key['upload_date'] = m.group('upload_date')
@@ -92,12 +92,12 @@ class AfreecaTVIE(InfoExtractor):
         thumbnail = xpath_text(video_xml, './track/titleImage', 'thumbnail')
 
         entries = []
-        for video_file in video_xml.findall('./track/video/file'):
+        for i, video_file in enumerate(video_xml.findall('./track/video/file')):
             video_key = self.parse_video_key(video_file.get('key'))
             entries.append({
-                'id': '%s_%s' % (video_id, video_key['part']),
+                'id': '%s_%s' % (video_id, video_key.get('part', i + 1)),
                 'title': title,
-                'upload_date': video_key['upload_date'],
+                'upload_date': video_key.get('upload_date'),
                 'duration': int_or_none(video_file.get('duration')),
                 'url': video_file.text,
             })

--- a/youtube_dl/extractor/afreecatv.py
+++ b/youtube_dl/extractor/afreecatv.py
@@ -95,8 +95,10 @@ class AfreecaTVIE(InfoExtractor):
         thumbnail = xpath_text(video_xml, './track/titleImage', 'thumbnail')
 
         entries = []
-        for i, video_file in enumerate(video_xml.findall('./track/video/file[@key]')):
-            video_key = self.parse_video_key(video_file.get('key'))
+        for i, video_file in enumerate(video_xml.findall('./track/video/file')):
+            video_key = self.parse_video_key(video_file.get('key', ''))
+            if not video_key:
+                continue
             entries.append({
                 'id': '%s_%s' % (video_id, video_key.get('part', i + 1)),
                 'title': title,

--- a/youtube_dl/extractor/afreecatv.py
+++ b/youtube_dl/extractor/afreecatv.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..compat import (
+    compat_urllib_parse_urlparse,
+    compat_urlparse,
+)
+from ..utils import (
+    ExtractorError,
+    int_or_none,
+)
+
+
+class AfreecaTVIE(InfoExtractor):
+    IE_DESC = 'afreecatv.com'
+    _VALID_URL = r'''(?x)^
+        https?://(?:(live|afbbs|www)\.)?afreeca(?:tv)?\.com(?::\d+)?
+        (?:
+            /app/(?:index|read_ucc_bbs)\.cgi|
+            /player/[Pp]layer\.(?:swf|html))
+        \?.*?\bnTitleNo=(?P<id>\d+)'''
+    _TEST = {
+        'url': 'http://live.afreecatv.com:8079/app/index.cgi?szType=read_ucc_bbs&szBjId=dailyapril&nStationNo=16711924&nBbsNo=18605867&nTitleNo=36164052&szSkin=',
+        'md5': 'f72c89fe7ecc14c1b5ce506c4996046e',
+        'info_dict': {
+            'id': '36164052',
+            'ext': 'mp4',
+            'title': '데일리 에이프릴 요정들의 시상식!',
+            'thumbnail': 're:^https?://videoimg.afreecatv.com/.*$',
+            'uploader': 'dailyapril',
+            'uploader_id': 'dailyapril',
+        }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        parsed_url = compat_urllib_parse_urlparse(url)
+        info_url = compat_urlparse.urlunparse(parsed_url._replace(
+            netloc='afbbs.afreecatv.com:8080',
+            path='/api/video/get_video_info.php'))
+        video_xml = self._download_xml(info_url, video_id)
+
+        track = video_xml.find('track')
+        if track.find('flag').text != 'SUCCEED':
+            raise ExtractorError('Specified AfreecaTV video does not exist',
+                                 expected=True)
+        title = track.find('title').text
+        uploader = track.find('nickname').text
+        uploader_id = track.find('bj_id').text
+        duration = int_or_none(track.find('duration').text)
+        thumbnail = track.find('titleImage').text
+
+        entries = []
+        for video in track.findall('video'):
+            for video_file in video.findall('file'):
+                entries.append({
+                    'id': video_file.get('key'),
+                    'title': title,
+                    'duration': int_or_none(video_file.get('duration')),
+                    'formats': [{'url': video_file.text}]
+                })
+
+        info = {
+            'id': video_id,
+            'title': title,
+            'uploader': uploader,
+            'uploader_id': uploader_id,
+            'duration': duration,
+            'thumbnail': thumbnail,
+        }
+
+        if len(entries) > 1:
+            info['_type'] = 'multi_video'
+            info['entries'] = entries
+        elif len(entries) == 1:
+            info['formats'] = entries[0]['formats']
+        else:
+            raise ExtractorError(
+                'No files found for the specified AfreecaTV video, either'
+                ' the URL is incorrect or the video has been made private.',
+                expected=True)
+
+        return info

--- a/youtube_dl/extractor/afreecatv.py
+++ b/youtube_dl/extractor/afreecatv.py
@@ -23,7 +23,7 @@ class AfreecaTVIE(InfoExtractor):
             /app/(?:index|read_ucc_bbs)\.cgi|
             /player/[Pp]layer\.(?:swf|html))
         \?.*?\bnTitleNo=(?P<id>\d+)'''
-    _TEST = {
+    _TESTS = [{
         'url': 'http://live.afreecatv.com:8079/app/index.cgi?szType=read_ucc_bbs&szBjId=dailyapril&nStationNo=16711924&nBbsNo=18605867&nTitleNo=36164052&szSkin=',
         'md5': 'f72c89fe7ecc14c1b5ce506c4996046e',
         'info_dict': {
@@ -33,8 +33,36 @@ class AfreecaTVIE(InfoExtractor):
             'thumbnail': 're:^https?://videoimg.afreecatv.com/.*$',
             'uploader': 'dailyapril',
             'uploader_id': 'dailyapril',
+            'upload_date': '20160503',
         }
-    }
+    }, {
+        'url': 'http://afbbs.afreecatv.com:8080/app/read_ucc_bbs.cgi?nStationNo=16711924&nTitleNo=36153164&szBjId=dailyapril&nBbsNo=18605867',
+        'info_dict': {
+            'id': '36153164',
+            'title': "BJ유트루와 함께하는 '팅커벨 메이크업!'",
+            'thumbnail': 're:^https?://videoimg.afreecatv.com/.*$',
+            'uploader': 'dailyapril',
+            'uploader_id': 'dailyapril',
+        },
+        'playlist_count': 2,
+        'playlist': [{
+            'md5': 'd8b7c174568da61d774ef0203159bf97',
+            'info_dict': {
+                'id': '36153164_1',
+                'ext': 'mp4',
+                'title': "BJ유트루와 함께하는 '팅커벨 메이크업!'",
+                'upload_date': '20160502',
+            },
+        }, {
+            'md5': '58f2ce7f6044e34439ab2d50612ab02b',
+            'info_dict': {
+                'id': '36153164_2',
+                'ext': 'mp4',
+                'title': "BJ유트루와 함께하는 '팅커벨 메이크업!'",
+                'upload_date': '20160502',
+            },
+        }],
+    }]
 
     @staticmethod
     def parse_video_key(key):

--- a/youtube_dl/extractor/afreecatv.py
+++ b/youtube_dl/extractor/afreecatv.py
@@ -95,7 +95,7 @@ class AfreecaTVIE(InfoExtractor):
         thumbnail = xpath_text(video_xml, './track/titleImage', 'thumbnail')
 
         entries = []
-        for i, video_file in enumerate(video_xml.findall('./track/video/file')):
+        for i, video_file in enumerate(video_xml.findall('./track/video/file[@key]')):
             video_key = self.parse_video_key(video_file.get('key'))
             entries.append({
                 'id': '%s_%s' % (video_id, video_key.get('part', i + 1)),
@@ -119,7 +119,7 @@ class AfreecaTVIE(InfoExtractor):
             info['entries'] = entries
         elif len(entries) == 1:
             info['url'] = entries[0]['url']
-            info['upload_date'] = entries[0]['upload_date']
+            info['upload_date'] = entries[0].get('upload_date')
         else:
             raise ExtractorError(
                 'No files found for the specified AfreecaTV video, either'

--- a/youtube_dl/extractor/afreecatv.py
+++ b/youtube_dl/extractor/afreecatv.py
@@ -11,6 +11,7 @@ from ..compat import (
 from ..utils import (
     ExtractorError,
     int_or_none,
+    xpath_element,
     xpath_text,
 )
 
@@ -84,9 +85,10 @@ class AfreecaTVIE(InfoExtractor):
             path='/api/video/get_video_info.php'))
         video_xml = self._download_xml(info_url, video_id)
 
-        if xpath_text(video_xml, './track/flag', default='FAIL') != 'SUCCEED':
+        if xpath_element(video_xml, './track/video/file') is None:
             raise ExtractorError('Specified AfreecaTV video does not exist',
                                  expected=True)
+
         title = xpath_text(video_xml, './track/title', 'title')
         uploader = xpath_text(video_xml, './track/nickname', 'uploader')
         uploader_id = xpath_text(video_xml, './track/bj_id', 'uploader id')

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -16,6 +16,7 @@ from .adobetv import (
     AdobeTVVideoIE,
 )
 from .adultswim import AdultSwimIE
+from .afreecatv import AfreecaTVIE
 from .aenetworks import AENetworksIE
 from .aftonbladet import AftonbladetIE
 from .airmozilla import AirMozillaIE

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -16,8 +16,8 @@ from .adobetv import (
     AdobeTVVideoIE,
 )
 from .adultswim import AdultSwimIE
-from .afreecatv import AfreecaTVIE
 from .aenetworks import AENetworksIE
+from .afreecatv import AfreecaTVIE
 from .aftonbladet import AftonbladetIE
 from .airmozilla import AirMozillaIE
 from .aljazeera import AlJazeeraIE


### PR DESCRIPTION
afreecatv.com is a Korean streaming service. This adds support for handling afreeca VODs but it does not handle any live stream URLs.

This resolves #2026, #3611, #2054, but the videos for all three of those issues no longer exist.