### PR TITLE
[amc] Add extractor for amc.com

### DIFF
--- a/youtube_dl/extractor/amc.py
+++ b/youtube_dl/extractor/amc.py
@@ -1,0 +1,46 @@
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import (
+    smuggle_url,
+    url_basename
+)
+
+
+class AMCIE(InfoExtractor):
+    IE_NAME = 'amc'
+    _VALID_URL = r'https?://www\.amc\.com/.*?'
+    _TESTS = [
+        {
+            'url': 'http://www.amc.com/shows/talking-bad/video-extras/episode-509-online-bonus-video-talking-bad',
+            'md5': '0ee064a81e6043ae53d8d1fd8216a60f',
+            'info_dict': {
+                'id': 'JI4ZCEoT4cne',
+                'ext': 'mp4',
+                'title': 'Episode 509 Online Bonus Video: Talking Bad',
+                'description': 'md5:b451732ab2bf70452a689e9024d81ba3',
+                'timestamp': 1376324809,
+                'upload_date': '20130812',
+                'uploader': 'AMCN',
+            },
+            'add_ie': ['ThePlatform']
+        }
+    ]
+
+    def _real_extract(self, url):
+        name = url_basename(url)
+        webpage = self._download_webpage(url, name)
+        account_id = 'M_UwQC'
+        video_id = self._search_regex(
+            r"class='platform-container'[^>]+data-video-id='([^']+)'",
+            webpage, 'video_id')
+
+        return {
+            '_type': 'url_transparent',
+            'ie_key': 'ThePlatform',
+            'url': smuggle_url(
+                'http://link.theplatform.com/s/%s/media/%s?mbr=true' % (account_id, video_id),
+                {'force_smil_url': True}),
+            'id': video_id
+        }
+

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -21,6 +21,7 @@ from .aftonbladet import AftonbladetIE
 from .airmozilla import AirMozillaIE
 from .aljazeera import AlJazeeraIE
 from .alphaporno import AlphaPornoIE
+from .amc import AMCIE
 from .animeondemand import AnimeOnDemandIE
 from .anitube import AnitubeIE
 from .anysex import AnySexIE


### PR DESCRIPTION
amc.com uses ThePlatform so this is pretty much just copy&paste. Closes #8636

It works, only for some reason have to retry after like every 5%

```
[download] Destination: Episode 509 Online Bonus Video - Talking Bad-JI4ZCEoT4cne.mp4
[download]  11.4% of 594.87MiB at 538.19KiB/s ETA 16:42
ERROR: content too short (expected 623770884 bytes and served 71303168)
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/youtube_dl/YoutubeDL.py", line 1643, in process_info
    success = dl(filename, info_dict)
  File "/usr/lib/python3.5/site-packages/youtube_dl/YoutubeDL.py", line 1585, in dl
    return fd.download(name, info)
  File "/usr/lib/python3.5/site-packages/youtube_dl/downloader/common.py", line 350, in download
    return self.real_download(filename, info_dict)
  File "/usr/lib/python3.5/site-packages/youtube_dl/downloader/http.py", line 236, in real_download
    raise ContentTooShortError(byte_counter, int(data_len))
youtube_dl.utils.ContentTooShortError: (71303168, 623770884)
```

Don't know if it's because of my internet or something else/them...
