### PR TITLE
[ComedyCentral] Add support for tosh.cc.com and cc.com/video-clips (Closes #4098)

### DIFF
--- a/youtube_dl/extractor/comedycentral.py
+++ b/youtube_dl/extractor/comedycentral.py
@@ -44,10 +44,10 @@ class ComedyCentralShowsIE(MTVServicesInfoExtractor):
     #                     or: http://www.colbertnation.com/the-colbert-report-collections/422008/festival-of-lights/79524
     _VALID_URL = r'''(?x)^(:(?P<shortname>tds|thedailyshow)
                       |https?://(:www\.)?
-                          (?P<showname>thedailyshow|thecolbertreport)\.(?:cc\.)?com/
+                          (?P<showname>thedailyshow|thecolbertreport|tosh)\.(?:cc\.)?com/
                          ((?:full-)?episodes/(?:[0-9a-z]{6}/)?(?P<episode>.*)|
                           (?P<clip>
-                              (?:(?:guests/[^/]+|videos|video-playlists|special-editions|news-team/[^/]+)/[^/]+/(?P<videotitle>[^/?#]+))
+                              (?:(?:guests/[^/]+|videos|video-clips|video-playlists|special-editions|news-team/[^/]+)/[^/]+/(?P<videotitle>[^/?#]+))
                               |(the-colbert-report-(videos|collections)/(?P<clipID>[0-9]+)/[^/]*/(?P<cntitle>.*?))
                               |(watch/(?P<date>[^/]*)/(?P<tdstitle>.*))
                           )|


### PR DESCRIPTION
This change recognizes urls in the form `http://tosh.cc.com/video-clips/68g93d/twitter-users-share-summer-plans`.

The extractors works fine as far as I can see, except for extracting the title for the url above and for some tests I saw. Running youtube-dl with `-e` yields

`tosh twitter-users-share-summer-plans part 1`

Extracting the title from the page source would be better, at least in this case

`<title>Twitter Users Share Summer Plans - Video Clip | Tosh.0 | Comedy Central</title>
`