### PR TITLE
[extractor/generic] fix RollingStone test and improve Brightcove embed extraction

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -1658,10 +1658,10 @@ class GenericIE(InfoExtractor):
 
         # Look for Ooyala videos
         mobj = (re.search(r'player\.ooyala\.com/[^"?]+[?#][^"]*?(?:embedCode|ec)=(?P<ec>[^"&]+)', webpage) or
-                re.search(r'OO\.Player\.create\([\'"].*?[\'"],\s*[\'"](?P<ec>\w{32})[\'"]', webpage) or
-                re.search(r'SBN\.VideoLinkset\.ooyala\([\'"](?P<ec>\w{32})[\'"]\)', webpage) or
-                re.search(r'data-ooyala-video-id\s*=\s*[\'"](?P<ec>\w{32})[\'"]', webpage) or
-                re.search(r'"ooyalaplayer-1",\s*"(?P<ec>\w{32})"', webpage))
+                re.search(r'OO\.Player\.create\([\'"].*?[\'"],\s*[\'"](?P<ec>.{32})[\'"]', webpage) or
+                re.search(r'SBN\.VideoLinkset\.ooyala\([\'"](?P<ec>.{32})[\'"]\)', webpage) or
+                re.search(r'data-ooyala-video-id\s*=\s*[\'"](?P<ec>.{32})[\'"]', webpage) or
+                re.search(r'"ooyalaplayer-1",\s*"(?P<ec>.{32})"', webpage))
         if mobj is not None:
             return OoyalaIE._build_url_result(smuggle_url(mobj.group('ec'), {'domain': url}))
 

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -385,17 +385,16 @@ class GenericIE(InfoExtractor):
                 'skip_download': True,  # m3u8 download
             },
         },
-        # ooyala video
         {
             'url': 'http://www.rollingstone.com/music/videos/norwegian-dj-cashmere-cat-goes-spartan-on-with-me-premiere-20131219',
-            'md5': '166dd577b433b4d4ebfee10b0824d8ff',
+            'md5': '1cef60edeafd0800b57bf8cbb851ae72',
             'info_dict': {
-                'id': 'BwY2RxaTrTkslxOfcan0UCf0YqyvWysJ',
+                'id': '4404576300001',
                 'ext': 'mp4',
-                'title': '2cc213299525360.mov',  # that's what we get
+                'title': 'Music Video',
                 'duration': 238.231,
             },
-            'add_ie': ['Ooyala'],
+            'add_ie': ['BrightcoveNew'],
         },
         {
             # ooyala video embedded with http://player.ooyala.com/iframe.js
@@ -1659,9 +1658,10 @@ class GenericIE(InfoExtractor):
 
         # Look for Ooyala videos
         mobj = (re.search(r'player\.ooyala\.com/[^"?]+[?#][^"]*?(?:embedCode|ec)=(?P<ec>[^"&]+)', webpage) or
-                re.search(r'OO\.Player\.create\([\'"].*?[\'"],\s*[\'"](?P<ec>.{32})[\'"]', webpage) or
-                re.search(r'SBN\.VideoLinkset\.ooyala\([\'"](?P<ec>.{32})[\'"]\)', webpage) or
-                re.search(r'data-ooyala-video-id\s*=\s*[\'"](?P<ec>.{32})[\'"]', webpage))
+                re.search(r'OO\.Player\.create\([\'"].*?[\'"],\s*[\'"](?P<ec>\w{32})[\'"]', webpage) or
+                re.search(r'SBN\.VideoLinkset\.ooyala\([\'"](?P<ec>\w{32})[\'"]\)', webpage) or
+                re.search(r'data-ooyala-video-id\s*=\s*[\'"](?P<ec>\w{32})[\'"]', webpage) or
+                re.search(r'"ooyalaplayer-1",\s*"(?P<ec>\w{32})"', webpage))
         if mobj is not None:
             return OoyalaIE._build_url_result(smuggle_url(mobj.group('ec'), {'domain': url}))
 


### PR DESCRIPTION
- Updated the RollingStone test in extractor/generic which switched from Ooyla to Brightcove.
- Brightcove ids seems to always be alphanumeric; improved regex
