### PR TITLE
[eporner] fix for the new URL layout

### DIFF
--- a/youtube_dl/extractor/eporner.py
+++ b/youtube_dl/extractor/eporner.py
@@ -11,8 +11,8 @@ from ..utils import (
 
 
 class EpornerIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?eporner\.com/hd-porn/(?P<id>\d+)/(?P<display_id>[\w-]+)'
-    _TEST = {
+    _VALID_URL = r'https?://(?:www\.)?eporner\.com/hd-porn/(?P<id>\w+)/(?P<display_id>[\w-]+)'
+    _TESTS = [{
         'url': 'http://www.eporner.com/hd-porn/95008/Infamous-Tiffany-Teen-Strip-Tease-Video/',
         'md5': '39d486f046212d8e1b911c52ab4691f8',
         'info_dict': {
@@ -23,8 +23,22 @@ class EpornerIE(InfoExtractor):
             'duration': 1838,
             'view_count': int,
             'age_limit': 18,
-        }
-    }
+        },
+    },
+    # New (May 2016) URL layout
+    {
+        'url': 'http://www.eporner.com/hd-porn/3YRUtzMcWn0/Star-Wars-XXX-Parody/',
+        'md5': '3469eeaa93b6967a34cdbdbb9d064b33',
+        'info_dict': {
+            'id': '3YRUtzMcWn0',
+            'display_id': 'Star-Wars-XXX-Parody',
+            'ext': 'mp4',
+            'title': 'Star Wars XXX Parody',
+            'duration': 361.0,
+            'view_count': int,
+            'age_limit': 18,
+        },
+    }]
 
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)


### PR DESCRIPTION
Recently eporner slightly changed the URL layout, the ID that used to
be digits only are now digits and letters, so youtube-dl falls back to the
generic extractor that doesn't work.

Fix the matching regex to allow letters in ID.