### PR TITLE
Always decode the Location header

### DIFF
--- a/test/test_http.py
+++ b/test/test_http.py
@@ -17,7 +17,7 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def http_server_port(httpd):
-    if os.name == 'java':
+    if os.name == 'java' and isinstance(httpd.socket, ssl.SSLSocket):
         # In Jython SSLSocket is not a subclass of socket.socket
         sock = httpd.socket.sock
     else:

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -866,6 +866,8 @@ class YoutubeDLHandler(compat_urllib_request.HTTPHandler):
                 location_escaped = escape_url(location)
                 if location != location_escaped:
                     del resp.headers['Location']
+                    if sys.version_info < (3, 0):
+                        location_escaped = location_escaped.encode('utf-8')
                     resp.headers['Location'] = location_escaped
         return resp
 

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -861,6 +861,8 @@ class YoutubeDLHandler(compat_urllib_request.HTTPHandler):
                 # As of RFC 2616 default charset is iso-8859-1 that is respected by python 3
                 if sys.version_info >= (3, 0):
                     location = location.encode('iso-8859-1').decode('utf-8')
+                else:
+                    location = location.decode('utf-8')
                 location_escaped = escape_url(location)
                 if location != location_escaped:
                     del resp.headers['Location']


### PR DESCRIPTION
Fixes #9588

@dstftw How about this? I guess using ```utf-8``` is ok as it's already done on Python 3.