### PR TITLE
[GoogleDrive] support downloading original video file

### DIFF
--- a/youtube_dl/extractor/googledrive.py
+++ b/youtube_dl/extractor/googledrive.py
@@ -105,16 +105,16 @@ class GoogleDriveIE(InfoExtractor):
         if 'html' in downloadPage:
             confirm = self._search_regex(r'confirm=([^&"]+)', downloadPage, 'confirm', default=None)
             if confirm:
-                dlstring = 'https://docs.google.com/uc?export=download&confirm=%s&id=%s' % (confirm, video_id)
+                originalURL = 'https://docs.google.com/uc?export=download&confirm=%s&id=%s' % (confirm, video_id)
             else:
                 downloadable = False
         else:
-            dlstring = 'https://docs.google.com/uc?export=download&id=%s' % video_id
+            originalURL = 'https://docs.google.com/uc?export=download&id=%s' % video_id
         if downloadable:
             originalExtension = self._search_regex(r'"([^"]+)",[^,]*,[^,]*$', webpage, 'original extension', default=None)
             originalSize = int_or_none(self._search_regex(r'"([^"]+)"[^"]*\n[^\n]*,[^,]*$', webpage, 'original size', default=None))
             formats.append({
-                'url': dlstring,
+                'url': originalURL,
                 'format_id': 'Original',
                 'ext': originalExtension,
                 'filesize': originalSize,

--- a/youtube_dl/extractor/googledrive.py
+++ b/youtube_dl/extractor/googledrive.py
@@ -13,12 +13,27 @@ class GoogleDriveIE(InfoExtractor):
     _VALID_URL = r'https?://(?:(?:docs|drive)\.google\.com/(?:uc\?.*?id=|file/d/)|video\.google\.com/get_player\?.*?docid=)(?P<id>[a-zA-Z0-9_-]{28,})'
     _TESTS = [{
         'url': 'https://drive.google.com/file/d/0ByeS4oOUV-49Zzh4R1J6R09zazQ/edit?pli=1',
-        'md5': '881f7700aec4f538571fa1e0eed4a7b6',
+        'md5': '5c602afbbf2c1db91831f5d82f678554',
+        'params': {
+            'format': "Original"
+        },
         'info_dict': {
             'id': '0ByeS4oOUV-49Zzh4R1J6R09zazQ',
             'ext': 'mp4',
             'title': 'Big Buck Bunny.mp4',
-            'duration': 46,
+            'duration': 45,
+        }
+    }, {
+        'url': 'https://drive.google.com/file/d/0ByeS4oOUV-49Zzh4R1J6R09zazQ/edit?pli=1',
+        'md5': 'd109872761f7e7ecf353fa108c0dbe1e',
+        'params': {
+            'format': "37"
+        },
+        'info_dict': {
+            'id': '0ByeS4oOUV-49Zzh4R1J6R09zazQ',
+            'ext': 'mp4',
+            'title': 'Big Buck Bunny.mp4',
+            'duration': 45,
         }
     }, {
         # video id is longer than 28 characters
@@ -105,7 +120,7 @@ class GoogleDriveIE(InfoExtractor):
                 'filesize': originalSize,
                 'protocol': 'https',
             })
-        
+
         return {
             'id': video_id,
             'title': title,


### PR DESCRIPTION
Adds the original video to the format list in the google drive downloader (the actual file that was uploaded, rather than one that was reencoded by Google).  Useful for playing videos from google drive using mpv.

Also updates the GoogleDrive test cases, which were probably broken by a google drive encoding change.
