### PR TITLE
Update README.md to mention MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ If you do not have curl, you can alternatively use a recent wget:
 
 Windows users can [download an .exe file](https://yt-dl.org/latest/youtube-dl.exe) and place it in any location on their [PATH](http://en.wikipedia.org/wiki/PATH_%28variable%29) except for `%SYSTEMROOT%\System32` (e.g. **do not** put in `C:\Windows\System32`).
 
-OS X users can install **youtube-dl** with [Homebrew](http://brew.sh/).
+OS X users can install **youtube-dl** with [Homebrew](http://brew.sh/):
 
     brew install youtube-dl
+
+Or with [MacPorts](https://www.macports.org/):
+
+    sudo port install youtube-dl
 
 You can also use pip:
 


### PR DESCRIPTION
The README already mentions that youtube-dl can be installed using Homebrew (one of the third-party OS X package managers). This pull request adds information on how to install youtube-dl using MacPorts (another OS X package manager).

(I am the maintainer of the youtube-dl port in MacPorts.)