### PR TITLE
Add metadata to extracted audio file too.

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -221,7 +221,7 @@ def _real_main(argv=None):
             'key': 'MetadataFromTitle',
             'titleformat': opts.metafromtitle
         })
-    if opts.addmetadata:
+    if opts.addmetadata and opts.keepvideo:
         postprocessors.append({'key': 'FFmpegMetadata'})
     if opts.extractaudio:
         postprocessors.append({
@@ -230,6 +230,8 @@ def _real_main(argv=None):
             'preferredquality': opts.audioquality,
             'nopostoverwrites': opts.nopostoverwrites,
         })
+        if opts.addmetadata:
+            postprocessors.append({'key': 'FFmpegMetadata'})
     if opts.recodevideo:
         postprocessors.append({
             'key': 'FFmpegVideoConvertor',

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -230,13 +230,13 @@ def _real_main(argv=None):
             'preferredquality': opts.audioquality,
             'nopostoverwrites': opts.nopostoverwrites,
         })
-    if opts.addmetadata:
-        postprocessors.append({'key': 'FFmpegMetadata'})
     if opts.recodevideo:
         postprocessors.append({
             'key': 'FFmpegVideoConvertor',
             'preferedformat': opts.recodevideo,
         })
+    if opts.addmetadata:
+        postprocessors.append({'key': 'FFmpegMetadata'})
     if opts.convertsubtitles:
         postprocessors.append({
             'key': 'FFmpegSubtitlesConvertor',

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -222,8 +222,6 @@ def _real_main(argv=None):
             'titleformat': opts.metafromtitle
         })
     if opts.extractaudio:
-        if opts.addmetadata and opts.keepvideo:
-            postprocessors.append({'key': 'FFmpegMetadata'})
         postprocessors.append({
             'key': 'FFmpegExtractAudio',
             'preferredcodec': opts.audioformat,
@@ -384,6 +382,7 @@ def _real_main(argv=None):
         'external_downloader_args': external_downloader_args,
         'postprocessor_args': postprocessor_args,
         'cn_verification_proxy': opts.cn_verification_proxy,
+        'addmetadata': opts.addmetadata,
     }
 
     with YoutubeDL(ydl_opts) as ydl:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -221,17 +221,17 @@ def _real_main(argv=None):
             'key': 'MetadataFromTitle',
             'titleformat': opts.metafromtitle
         })
-    if opts.addmetadata and opts.keepvideo:
-        postprocessors.append({'key': 'FFmpegMetadata'})
     if opts.extractaudio:
+        if opts.addmetadata and opts.keepvideo:
+            postprocessors.append({'key': 'FFmpegMetadata'})
         postprocessors.append({
             'key': 'FFmpegExtractAudio',
             'preferredcodec': opts.audioformat,
             'preferredquality': opts.audioquality,
             'nopostoverwrites': opts.nopostoverwrites,
         })
-        if opts.addmetadata:
-            postprocessors.append({'key': 'FFmpegMetadata'})
+    if opts.addmetadata:
+        postprocessors.append({'key': 'FFmpegMetadata'})
     if opts.recodevideo:
         postprocessors.append({
             'key': 'FFmpegVideoConvertor',


### PR DESCRIPTION
This fixes metadata not being present if not supported by the initial container (i.e. artist attribute in webm).
