### PR TITLE
"MiTele" May not have a title

### DIFF
--- a/youtube_dl/extractor/mitele.py
+++ b/youtube_dl/extractor/mitele.py
@@ -15,7 +15,7 @@ class MiTeleIE(InfoExtractor):
     IE_DESC = 'mitele.es'
     _VALID_URL = r'https?://www\.mitele\.es/[^/]+/[^/]+/[^/]+/(?P<id>[^/]+)/'
 
-    _TEST = {
+    _TESTS = [{
         'url': 'http://www.mitele.es/programas-tv/diario-de/la-redaccion/programa-144/',
         # MD5 is unstable
         'info_dict': {
@@ -27,7 +27,19 @@ class MiTeleIE(InfoExtractor):
             'thumbnail': 're:(?i)^https?://.*\.jpg$',
             'duration': 2913,
         },
-    }
+    }, {
+        'url': 'http://www.mitele.es/programas-tv/cuarto-milenio/temporada-6/programa-226/',
+        # MD5 is unstable
+        'info_dict': {
+            'id': 'eLZSwoEd1S3pVyUm8lc6F',
+            'display_id': 'programa-226',
+            'ext': 'flv',
+            'title': 'programa-226', #This is what we are testing, should be same as display_id since the video has no title
+            'description': 'md5:50daf9fadefa4e62d9fc866d0c015701',
+            'thumbnail': 're:(?i)^https?://.*\.jpg$',
+            'duration': 7312,
+        },
+    }]
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
@@ -70,7 +82,7 @@ class MiTeleIE(InfoExtractor):
         self._sort_formats(formats)
 
         title = self._search_regex(
-            r'class="Destacado-text"[^>]*>\s*<strong>([^<]+)</strong>', webpage, 'title', 'NO_TITLE')
+            r'class="Destacado-text"[^>]*>\s*<strong>([^<]+)</strong>', webpage, 'title', display_id)
 
         video_id = self._search_regex(
             r'data-media-id\s*=\s*"([^"]+)"', webpage,

--- a/youtube_dl/extractor/mitele.py
+++ b/youtube_dl/extractor/mitele.py
@@ -35,7 +35,6 @@ class MiTeleIE(InfoExtractor):
             'display_id': 'programa-226',
             'ext': 'flv',
             'title': 'Programa 226', #This is what we are testing, should be same as display_id since the video has no title
-            'title': 'Programa 226', #This is what we are testing, should be same as display_id since the video has no title
             'description': 'md5:50daf9fadefa4e62d9fc866d0c015701',
             'thumbnail': 're:(?i)^https?://.*\.jpg$',
             'duration': 7312,

--- a/youtube_dl/extractor/mitele.py
+++ b/youtube_dl/extractor/mitele.py
@@ -34,7 +34,8 @@ class MiTeleIE(InfoExtractor):
             'id': 'eLZSwoEd1S3pVyUm8lc6F',
             'display_id': 'programa-226',
             'ext': 'flv',
-            'title': 'programa-226', #This is what we are testing, should be same as display_id since the video has no title
+            'title': 'Programa 226', #This is what we are testing, should be same as display_id since the video has no title
+            'title': 'Programa 226', #This is what we are testing, should be same as display_id since the video has no title
             'description': 'md5:50daf9fadefa4e62d9fc866d0c015701',
             'thumbnail': 're:(?i)^https?://.*\.jpg$',
             'duration': 7312,
@@ -81,8 +82,14 @@ class MiTeleIE(InfoExtractor):
                 display_id, f4m_id=loc))
         self._sort_formats(formats)
 
+        alt_title = self._search_regex(
+            r'class="temp"[^>]*>\s*<h1>(?:\s*<span>([^<]+)</span>\s*)+</h1>', webpage, 'alt_title', display_id)
+        #Alternative, but it is not good since it adds "Watch online" (Ver online) to the title
+        #alt_title = self._search_regex(
+        #    r'<title>([^>]*)<\/title>', webpage, 'alt_title', display_id)
+
         title = self._search_regex(
-            r'class="Destacado-text"[^>]*>\s*<strong>([^<]+)</strong>', webpage, 'title', display_id)
+            r'class="Destacado-text"[^>]*>\s*<strong>([^<]+)</strong>', webpage, 'title', alt_title)
 
         video_id = self._search_regex(
             r'data-media-id\s*=\s*"([^"]+)"', webpage,

--- a/youtube_dl/extractor/mitele.py
+++ b/youtube_dl/extractor/mitele.py
@@ -70,7 +70,7 @@ class MiTeleIE(InfoExtractor):
         self._sort_formats(formats)
 
         title = self._search_regex(
-            r'class="Destacado-text"[^>]*>\s*<strong>([^<]+)</strong>', webpage, 'title')
+            r'class="Destacado-text"[^>]*>\s*<strong>([^<]+)</strong>', webpage, 'title', 'NO_TITLE')
 
         video_id = self._search_regex(
             r'data-media-id\s*=\s*"([^"]+)"', webpage,


### PR DESCRIPTION
Example episode:
http://www.mitele.es/programas-tv/cuarto-milenio/temporada-6/programa-226/

Has no title, and trying to download just gives a crash error. The error
is not there because something actually failed, but just because the
video has no title. Setting it to NO_TITLE default makes it work
properly, and only points out that it is missing in a download list.