### PR TITLE
PEP 8 fixes

### DIFF
--- a/devscripts/buildserver.py
+++ b/devscripts/buildserver.py
@@ -336,7 +336,7 @@ class YoutubeDLBuilder(object):
         try:
             proc = subprocess.Popen([os.path.join(self.pythonPath, 'python.exe'), 'setup.py', 'py2exe'], stdin=subprocess.PIPE, cwd=self.buildPath)
             proc.wait()
-            #subprocess.check_output([os.path.join(self.pythonPath, 'python.exe'), 'setup.py', 'py2exe'],
+            # subprocess.check_output([os.path.join(self.pythonPath, 'python.exe'), 'setup.py', 'py2exe'],
             #                        cwd=self.buildPath)
         except subprocess.CalledProcessError as e:
             raise BuildError(e.output)

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ else:
     else:
         params['scripts'] = ['bin/youtube-dl']
 
+
 class build_lazy_extractors(Command):
     description = "Build the extractor lazy loading module"
     user_options = []

--- a/youtube_dl/extractor/radiojavan.py
+++ b/youtube_dl/extractor/radiojavan.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import re
 
 from .common import InfoExtractor
-from ..utils import(
+from ..utils import (
     unified_strdate,
     str_to_int,
 )


### PR DESCRIPTION
E265 block comment should start with '# '
E302 expected 2 blank lines, found 1
E275 missing whitespace after keyword