### PR TITLE
[utils] Add try error type

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1063,7 +1063,7 @@ def unified_strdate(date_str, day_first=True):
     for expression in format_expressions:
         try:
             upload_date = datetime.datetime.strptime(date_str, expression).strftime('%Y%m%d')
-        except ValueError:
+        except (ValueError, TypeError):
             pass
     if upload_date is None:
         timetuple = email.utils.parsedate_tz(date_str)


### PR DESCRIPTION
Hi, I using youtube-dl to get youtube video link, and showed TypeError message.

> r Type: <type 'exceptions.TypeError'>
> Error Contents: attribute of type 'NoneType' is not callable
> Traceback (most recent call last):
>   File "addon.py", line 56, in <module>
>     info = ydl.extract_info(url)
>   File "youtube_dl/YoutubeDL.py", line 676, in extract_info
>     ie_result = ie.extract(url)
>   File "youtube_dl/extractor/common.py", line 341, in extract
>     return self._real_extract(url)
>   File "youtube_dl/extractor/youtube.py", line 1422, in _real_extract
>     upload_date = unified_strdate(upload_date)
>   File "youtube_dl/utils.py", line 1054, in unified_strdate
>     upload_date = datetime.datetime.strptime(date_str, expression).strftime('%Y%m%d')
> TypeError: attribute of type 'NoneType' is not callable
