### PR TITLE
Vimeo: When parsing vimeo user playlist, include video id in url result.

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -631,7 +631,7 @@ class VimeoChannelIE(VimeoBaseInfoExtractor):
                 yield self._extract_list_title(webpage)
 
             for video_id in re.findall(r'id="clip_(\d+?)"', webpage):
-                yield self.url_result('https://vimeo.com/%s' % video_id, 'Vimeo')
+                yield self.url_result('https://vimeo.com/%s' % video_id, 'Vimeo', video_id=video_id)
 
             if re.search(self._MORE_PAGES_INDICATOR, webpage, re.DOTALL) is None:
                 break


### PR DESCRIPTION
This will allow us to decide much faster that we don't want an already archived video,
and will allow us NOT to download webpages for each video that has already been downloaded,
thus significantly speeding up the archival of channels that have no new content.