### PR TITLE
[imgur] Updating album resolution endpoint

### DIFF
--- a/youtube_dl/extractor/imgur.py
+++ b/youtube_dl/extractor/imgur.py
@@ -132,7 +132,7 @@ class ImgurAlbumIE(InfoExtractor):
         album_id = self._match_id(url)
 
         album_images = self._download_json(
-            'http://imgur.com/gallery/%s/album_images/hit.json?all=true' % album_id,
+            'http://imgur.com/ajaxalbums/getimages/%s/hit.json?all=true' % album_id,
             album_id, fatal=False)
 
         if album_images:


### PR DESCRIPTION
The old album endpoint, `http://imgur.com/gallery/%s/album_images/hit.json?all=true`, worked for some older albums but not recent ones. The new one, `http://imgur.com/ajaxalbums/getimages/%s/hit.json?all=true`, should work for both old and new albums.

It might be beneficial to eventually change to the [official Imgur API](http://api.imgur.com/) - it requires registration to receive a key, but we won't have to worry about unannounced API changes.
