### PR TITLE
Made the generation of supported sites repeatable

### DIFF
--- a/devscripts/make_supportedsites.py
+++ b/devscripts/make_supportedsites.py
@@ -33,10 +33,10 @@ def main():
                 ie_md += ' (Currently broken)'
             yield ie_md
 
-    ies = sorted(youtube_dl.gen_extractors(), key=lambda i: i.IE_NAME.lower())
+    ies = sorted(gen_ies_md(youtube_dl.gen_extractors()), key=lambda s: s.lower())
     out = '# Supported sites\n' + ''.join(
         ' - ' + md + '\n'
-        for md in gen_ies_md(ies))
+        for md in ies)
 
     with io.open(outfile, 'w', encoding='utf-8') as outf:
         outf.write(out)


### PR DESCRIPTION
sorted() was not called on the string that's actually printed, but on its prefix (IE_NAME), resulting in some strings being printed in a random order.
This commit makes the sorting repeatable.