### PR TITLE
New test-case: extractor names are supposed to be unique

### DIFF
--- a/test/test_all_urls.py
+++ b/test/test_all_urls.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import os
 import sys
 import unittest
+import collections
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
@@ -129,6 +130,13 @@ class TestAllURLsMatching(unittest.TestCase):
         self.assertMatch(
             'https://screen.yahoo.com/smartwatches-latest-wearable-gadgets-163745379-cbs.html',
             ['Yahoo'])
+
+    def test_no_duplicated_ie_names(self):
+        name_accu = collections.defaultdict(list)
+        for ie in self.ies:
+            name_accu[ie.IE_NAME.lower()].append(ie)
+        for (ie_name,ie_list) in name_accu.items():
+            self.assertEqual(len(ie_list), 1, 'Only 1 extractor with IE_NAME "%s" (%s)' % (ie_name, ie_list))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@dstftw explained in https://github.com/rg3/youtube-dl/pull/9918#issuecomment-228625878 that extractor names are supposed to be unique.
@dstftw has fixed the two offending extractors, and here I add a test to ensure this does not happen in the future.