### PR TITLE
Add --playlist-index-size option

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -568,7 +568,10 @@ class YoutubeDL(object):
             autonumber_templ = '%0' + str(autonumber_size) + 'd'
             template_dict['autonumber'] = autonumber_templ % self._num_downloads
             if template_dict.get('playlist_index') is not None:
-                template_dict['playlist_index'] = '%0*d' % (len(str(template_dict['n_entries'])), template_dict['playlist_index'])
+                playlist_index_size = self.params.get('playlist_index_size')
+                if playlist_index_size is None:
+                    playlist_index_size = len(str(template_dict['n_entries']))
+                template_dict['playlist_index'] = '%0*d' % (int(playlist_index_size), template_dict['playlist_index'])
             if template_dict.get('resolution') is None:
                 if template_dict.get('width') and template_dict.get('height'):
                     template_dict['resolution'] = '%dx%d' % (template_dict['width'], template_dict['height'])

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -301,6 +301,7 @@ def _real_main(argv=None):
         'listformats': opts.listformats,
         'outtmpl': outtmpl,
         'autonumber_size': opts.autonumber_size,
+        'playlist_index_size': opts.playlist_index_size,
         'restrictfilenames': opts.restrictfilenames,
         'ignoreerrors': opts.ignoreerrors,
         'force_generic_extractor': opts.force_generic_extractor,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -620,6 +620,10 @@ def parseOpts(overrideArguments=None):
         dest='autonumber_size', metavar='NUMBER',
         help='Specify the number of digits in %(autonumber)s when it is present in output filename template or --auto-number option is given')
     filesystem.add_option(
+        '--playlist-index-size',
+        dest='playlist_index_size', metavar='NUMBER',
+        help='Specify the number of digits in %(playlist_index)s when it is present in output filename template')
+    filesystem.add_option(
         '--restrict-filenames',
         action='store_true', dest='restrictfilenames', default=False,
         help='Restrict filenames to only ASCII characters, and avoid "&" and spaces in filenames')


### PR DESCRIPTION
It works similarly to the --autonumber-size option, i.e. it determines
the length of the '%(playlist_index)s' format string, with '0' as padding. When
it isn't specified it works like before, i.e. the size is determined from the
number of entries to download.

Would be an option for issue #5185.