### PR TITLE
[periscope] fix playlist extraction (#9967)

### DIFF
--- a/youtube_dl/extractor/periscope.py
+++ b/youtube_dl/extractor/periscope.py
@@ -122,7 +122,7 @@ class PeriscopeUserIE(InfoExtractor):
 
         entries = [
             self.url_result(
-                'https://www.periscope.tv/%s/%s' % (user_id, broadcast['id']))
-            for broadcast in data_store.get('UserBroadcastHistory', {}).get('broadcasts', [])]
+                'https://www.periscope.tv/%s/%s' % (user_id, broadcast))
+            for broadcast in data_store.get('UserBroadcastHistory', {}).get('broadcastIds', [])]
 
         return self.playlist_result(entries, user_id, title, description)


### PR DESCRIPTION
The JSON response changed and the extractor needed to be updated in order to gather the video IDs.