### PR TITLE
Added option --max-sleep-interval to support random sleep between downloads. Fixes #9930

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -250,6 +250,7 @@ class YoutubeDL(object):
     call_home:         Boolean, true iff we are allowed to contact the
                        youtube-dl servers for debugging.
     sleep_interval:    Number of seconds to sleep before each download.
+    max_sleep_interval:Max number of random seconds to sleep.
     listformats:       Print an overview of available video formats and exit.
     list_thumbnails:   Print a table of all thumbnails and exit.
     match_filter:      A function that gets called with the info_dict of

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -145,6 +145,12 @@ def _real_main(argv=None):
         if numeric_limit is None:
             parser.error('invalid max_filesize specified')
         opts.max_filesize = numeric_limit
+    if opts.sleep_interval is not None:
+        if opts.sleep_interval < 0:
+            parser.error('sleep interval should not be negative')
+        elif opts.max_sleep_interval is not None:
+            if opts.max_sleep_interval < opts.sleep_interval:
+                parser.error('max sleep interval should not be less than sleep interval')
 
     def parse_retries(retries):
         if retries in ('inf', 'infinite'):
@@ -370,6 +376,7 @@ def _real_main(argv=None):
         'source_address': opts.source_address,
         'call_home': opts.call_home,
         'sleep_interval': opts.sleep_interval,
+        'max_sleep_interval': opts.max_sleep_interval,
         'external_downloader': opts.external_downloader,
         'list_thumbnails': opts.list_thumbnails,
         'playlist_items': opts.playlist_items,

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import time
+import random
 
 from ..compat import compat_os_name
 from ..utils import (
@@ -342,8 +343,10 @@ class FileDownloader(object):
             })
             return True
 
-        sleep_interval = self.params.get('sleep_interval')
-        if sleep_interval:
+        sleep_lower_bound = self.params.get('sleep_interval')
+        if sleep_lower_bound:
+            sleep_upper_bound = self.params.get('max_sleep_interval') if self.params.get('max_sleep_interval') else sleep_lower_bound
+            sleep_interval = random.uniform(sleep_lower_bound, sleep_upper_bound)
             self.to_screen('[download] Sleeping %s seconds...' % sleep_interval)
             time.sleep(sleep_interval)
 

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -502,6 +502,11 @@ def parseOpts(overrideArguments=None):
         '--sleep-interval', metavar='SECONDS',
         dest='sleep_interval', type=float,
         help='Number of seconds to sleep before each download.')
+    workarounds.add_option(
+        '--max-sleep-interval', metavar='SECONDS',
+        dest='max_sleep_interval', type=float,
+        help='Max number of random seconds to sleep.'
+    )
 
     verbosity = optparse.OptionGroup(parser, 'Verbosity / Simulation Options')
     verbosity.add_option(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] New extractor
- [x] New feature

---

### Added option `--max-sleep-interval` to support random sleep between downloads.

The new option allows user to perform sleep between consecutive downloads in the interval `[a, b]` where `0 <= a <= b` and are set by the options `--sleep-interval` and `--max-sleep-interval` respectively.

#### Example usage :
```bash
youtube-dl https://www.youtube.com/playlist?list=PLsPUh22kYmNDnezZ15MkicBGVDm2ypthG --sleep-interval 10 --max-sleep-interval 20
```