### PR TITLE
Make metadata-from-title parsing failure non-critical

### DIFF
--- a/youtube_dl/postprocessor/metadatafromtitle.py
+++ b/youtube_dl/postprocessor/metadatafromtitle.py
@@ -38,7 +38,8 @@ class MetadataFromTitlePP(PostProcessor):
         title = info['title']
         match = re.match(self._titleregex, title)
         if match is None:
-            raise MetadataFromTitlePPError('Could not interpret title of video as "%s"' % self._titleformat)
+            self._downloader.to_screen('[fromtitle] Could not interpret title of video as "%s"' % self._titleformat)
+            return [], info
         for attribute, value in match.groupdict().items():
             value = match.group(attribute)
             info[attribute] = value


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

__Behaviour at the moment__
If the metadata can't be parsed from the title (no match for the string passed with --metadata-from-title) a critical error will be raised that will cause the program to exit.

__Proposed change with this pull request__
IMO failing to parse the metadata from the title is not a critical error (one simply cannot assure that all titles have the same format) and it can be really annoying that it is treated as one e.g. when downloading a playlist. Therefore i would suggest to just output a warning instead of raising an error and just write the default metadata.