### PR TITLE
[generic] Make generic extractor use hlsnative for m3u8 files

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -1379,7 +1379,7 @@ class GenericIE(InfoExtractor):
         if m:
             format_id = m.group('format_id')
             if format_id.endswith('mpegurl'):
-                formats = self._extract_m3u8_formats(url, video_id, 'mp4')
+                formats = self._extract_m3u8_formats(url, video_id, 'mp4', entry_protocol='m3u8_native', m3u8_id='hls')
             elif format_id == 'f4m':
                 formats = self._extract_f4m_formats(url, video_id)
             else:
@@ -1415,7 +1415,7 @@ class GenericIE(InfoExtractor):
 
         # Is it an M3U playlist?
         if first_bytes.startswith(b'#EXTM3U'):
-            info_dict['formats'] = self._extract_m3u8_formats(url, video_id, 'mp4')
+            info_dict['formats'] = self._extract_m3u8_formats(url, video_id, 'mp4', entry_protocol='m3u8_native', m3u8_id='hls')
             self._sort_formats(info_dict['formats'])
             return info_dict
 
@@ -2167,7 +2167,7 @@ class GenericIE(InfoExtractor):
             elif ext == 'xspf':
                 return self.playlist_result(self._extract_xspf_playlist(video_url, video_id), video_id)
             elif ext == 'm3u8':
-                entry_info_dict['formats'] = self._extract_m3u8_formats(video_url, video_id, ext='mp4')
+                entry_info_dict['formats'] = self._extract_m3u8_formats(video_url, video_id, ext='mp4', entry_protocol='m3u8_native', m3u8_id='hls')
             elif ext == 'mpd':
                 entry_info_dict['formats'] = self._extract_mpd_formats(video_url, video_id)
             elif ext == 'f4m':


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

The generic extractor should use the built-in `hlsnative` utility instead of ffmpeg because it supports resuming downloads and reduces dependency on external downloaders. I've also noticed that m3u8 videos downloaded through ffmpeg are buggy, tend to desync, and cause weird playback issues.