### PR TITLE
[nhk] Add extractor for VoD.

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -541,6 +541,7 @@ from .nextmedia import (
 )
 from .nfb import NFBIE
 from .nfl import NFLIE
+from .nhk import NhkVodIE
 from .nhl import (
     NHLVideocenterIE,
     NHLNewsIE,

--- a/youtube_dl/extractor/nhk.py
+++ b/youtube_dl/extractor/nhk.py
@@ -1,0 +1,29 @@
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class NhkVodIE(InfoExtractor):
+    _VALID_URL = r'http://www3\.nhk\.or\.jp/nhkworld/en/vod/(?P<id>.+)\.html'
+    _TESTS = [{
+        'url': 'http://www3.nhk.or.jp/nhkworld/en/vod/tokyofashion/20160815.html',
+        'info_dict': {
+            'id': 'A1bnNiNTE6nY3jLllS-BIISfcC_PpvF5',
+            'ext': 'flv',
+            'title': '[nhkworld]VOD;2009-251-2016;TOKYO FASHION EXPRESS;The Kimono as Global Fashion;en',
+        },
+        'params': {
+            'skip_download': True  # Videos available only for a limited period of time.
+        },
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        embed_code = self._search_regex(
+            r'''nw_vod_ooplayer\('movie-area', '([^']+)'\);''',
+            webpage,
+            'ooyala embed code')
+
+        return self.url_result('ooyala:' + embed_code, 'Ooyala')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Extractor for NHK VoD.
Was requested by at least 2 people in #4437 and by myself.

Heavily based on Vice extractor, which also sometimes uses Ooyala player.

I haven't find a suitable test case, as all videos I've visited are available only for a limited period of time.

Example URL: http://www3.nhk.or.jp/nhkworld/en/vod/tokyofashion/20160815.html


This is my first contribution to youtube-dl. Please point me out if I missed something important.