### PR TITLE
Add --playlist-index-offset [number] command line parameter

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -583,7 +583,7 @@ class YoutubeDL(object):
             autonumber_templ = '%0' + str(autonumber_size) + 'd'
             template_dict['autonumber'] = autonumber_templ % self._num_downloads
             if template_dict.get('playlist_index') is not None:
-                template_dict['playlist_index'] = '%0*d' % (len(str(template_dict['n_entries'])), template_dict['playlist_index'])
+                template_dict['playlist_index'] = '%0*d' % (len(str(template_dict['n_entries'])), (int(template_dict['playlist_index']) + int(self.params.get('playlist_index_offset'))))
             if template_dict.get('resolution') is None:
                 if template_dict.get('width') and template_dict.get('height'):
                     template_dict['resolution'] = '%dx%d' % (template_dict['width'], template_dict['height'])

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -583,7 +583,7 @@ class YoutubeDL(object):
             autonumber_templ = '%0' + str(autonumber_size) + 'd'
             template_dict['autonumber'] = autonumber_templ % self._num_downloads
             if template_dict.get('playlist_index') is not None:
-                template_dict['playlist_index'] = '%0*d' % (len(str(template_dict['n_entries'])), (int(template_dict['playlist_index']) + int(self.params.get('playlist_index_offset'))))
+                template_dict['playlist_index'] = '%0*d' % (len(str(template_dict['n_entries'])), (template_dict['playlist_index'] + int(self.params.get('playlist_index_offset'))))
             if template_dict.get('resolution') is None:
                 if template_dict.get('width') and template_dict.get('height'):
                     template_dict['resolution'] = '%dx%d' % (template_dict['width'], template_dict['height'])

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -326,6 +326,7 @@ def _real_main(argv=None):
         'playliststart': opts.playliststart,
         'playlistend': opts.playlistend,
         'playlistreverse': opts.playlist_reverse,
+        'playlist_index_offset': opts.playlist_index_offset,
         'noplaylist': opts.noplaylist,
         'logtostderr': opts.outtmpl == '-',
         'consoletitle': opts.consoletitle,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -699,6 +699,10 @@ def parseOpts(overrideArguments=None):
         '--rm-cache-dir',
         action='store_true', dest='rm_cachedir',
         help='Delete all filesystem cache files')
+    filesystem.add_option(
+        '--playlist-index-offset',
+        dest="playlist_index_offset", metavar='NUMBER', type=int, default=0,
+        help='Offsets %(playlist_index)s by the specified value.')
 
     thumbnail = optparse.OptionGroup(parser, 'Thumbnail images')
     thumbnail.add_option(


### PR DESCRIPTION
### Before submitting a _pull request_ make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
### What is the purpose of your _pull request_?
- [ ] Bug fix
- [ ] New extractor
- [x] New feature

---
### Description of your _pull request_ and other information

This is just a small change to the formatting of `%(playlist_index)s` that adds the ability to give it an offset. This way you could combine multiple playlists by downloading 10 videos from one playlist and 10 from another but name from 1 to 20. For example:

> youtube-dl --yes-playlist -o "/location/%(title)s_S0E%(playlist_index).%(ext)s" "http://yourlink.com/playlistone"

Would produce episodes S0E (1 through 10)

And then you can continue from another playlist with one addition

> youtube-dl --yes-playlist **--playlist_index_offset 10** -o "/location/%(title)s_S0E%(playlist_index).%(ext)s" "http://yourlink.com/playlisttwo"

which would produce S0E (11-20)
