### PR TITLE
removed all quotes from extracted webpage to solve issue 10455

### DIFF
--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -176,6 +176,7 @@ class BandcampAlbumIE(InfoExtractor):
         entries = [
             self.url_result(compat_urlparse.urljoin(url, t_path), ie=BandcampIE.ie_key())
             for t_path in tracks_paths]
+        webpage = webpage.replace('\\"', "")
         title = self._search_regex(
             r'album_title\s*:\s*"(.*?)"', webpage, 'title', fatal=False)
         return {


### PR DESCRIPTION
Regarding issue #10455 

I had the same issue, hence **here's one possible fix**:
`webpage = webpage.replace('\\"', "")` (added to the file youtube_dl/extractor/bandcamp.py)

Note: possibly this could be done _right before any extraction is performed on the webpage_.

**Cause of the problem** is the `\"` on the extracted webpage (see below)
![webpage](https://cloud.githubusercontent.com/assets/57601/18072412/54e67324-6e5e-11e6-9043-bc934b9162f4.png)

... makes the regex exit immediately (see below)
![regexfail](https://cloud.githubusercontent.com/assets/57601/18072413/54e7e6aa-6e5e-11e6-8402-3d66056274bd.png)

**Alternative Fix**: use the regex itself to jump the quotes

**Details:**
Tested in Mac OSX
Last pull from git (as of Tue Aug 30 02:56:46 CEST 2016)

**Cloned into**: https://github.com/PedroLopes/youtube-dl 

P.s.: @bryc I think your text command should have quotes too (at least I needed those to replicate your issue), hence:
`youtube-dl -v -a urls.txt -i -o "%(playlist)s/%(playlist_index)s - %(title)s.%(ext)s"`

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] New extractor
- [ ] New feature

---