### PR TITLE
Added --autonumber-start [number] option

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -578,10 +578,13 @@ class YoutubeDL(object):
 
             template_dict['epoch'] = int(time.time())
             autonumber_size = self.params.get('autonumber_size')
+            autonumber_start = self.params.get('autonumber_start')
             if autonumber_size is None:
                 autonumber_size = 5
+            if autonumber_start is None or autonumber_start < 1:
+                autonumber_start = 1
             autonumber_templ = '%0' + str(autonumber_size) + 'd'
-            template_dict['autonumber'] = autonumber_templ % self._num_downloads
+            template_dict['autonumber'] = autonumber_templ % (self._num_downloads + int(autonumber_start)-1)
             if template_dict.get('playlist_index') is not None:
                 template_dict['playlist_index'] = '%0*d' % (len(str(template_dict['n_entries'])), template_dict['playlist_index'])
             if template_dict.get('resolution') is None:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -311,6 +311,7 @@ def _real_main(argv=None):
         'listformats': opts.listformats,
         'outtmpl': outtmpl,
         'autonumber_size': opts.autonumber_size,
+        'autonumber_start': opts.autonumber_start,
         'restrictfilenames': opts.restrictfilenames,
         'ignoreerrors': opts.ignoreerrors,
         'force_generic_extractor': opts.force_generic_extractor,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -634,6 +634,10 @@ def parseOpts(overrideArguments=None):
         dest='autonumber_size', metavar='NUMBER',
         help='Specify the number of digits in %(autonumber)s when it is present in output filename template or --auto-number option is given')
     filesystem.add_option(
+        '--autonumber-start',
+        dest='autonumber_start', metavar='NUMBER', default=0,
+        help='Starts %(autonumber)s at the passed number (positive numbers only).')
+    filesystem.add_option(
         '--restrict-filenames',
         action='store_true', dest='restrictfilenames', default=False,
         help='Restrict filenames to only ASCII characters, and avoid "&" and spaces in filenames')
@@ -699,6 +703,7 @@ def parseOpts(overrideArguments=None):
         '--rm-cache-dir',
         action='store_true', dest='rm_cachedir',
         help='Delete all filesystem cache files')
+
 
     thumbnail = optparse.OptionGroup(parser, 'Thumbnail images')
     thumbnail.add_option(


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] New extractor
- [x] New feature

---

### Description

Added --autonumber-start [number]. This only does anything when autonumber is called. It works properly with autonumber-size and overrides the size if needed. Note that it will start exactly on the number entered (3 would yield 00003) and does not accept negative numbers (-2 would yield 00000).

This way you could combine multiple playlists by downloading 10 videos from one playlist and 10 from another but name from 1 to 20. For example:

> youtube-dl --yes-playlist -o "/location/%(title)s_S0E%(autonumber).%(ext)s" "http://yourlink.com/playlistone"

Would produce episodes S0E (1 through 10)

And then you can continue from another playlist with one addition

> youtube-dl --yes-playlist --autonumber-start 11 -o "/location/%(title)s_S0E%(autonumber).%(ext)s" "http://yourlink.com/playlisttwo"

which would produce S0E (11-20)