### PR TITLE
[downloader/dash] Abort if the first segment fails

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 version <unreleased>
 
+Core
+* If the first segment of DASH fails, abort the whole download process to
+  prevent throttling (#10497)
+
 Extractors
 * [youjizz] Fix extraction (#10437)
 + [foxnews] Add support for FoxNews Insider (#10445)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Unlike HLS, where each segment can be played directly, DASH segments need to be concatenated to generate a valid MP4 file. Especially, the first segment contains MP4 headers. So the downloaded file won't be recognized without the first segment.

Closes #10497