### PR TITLE
Fix ninenow extractor.

### DIFF
--- a/youtube_dl/extractor/ninenow.py
+++ b/youtube_dl/extractor/ninenow.py
@@ -29,11 +29,11 @@ class NineNowIE(InfoExtractor):
         'skip': 'Only available in Australia',
     }, {
         # episode
-        'url': 'https://www.9now.com.au/afl-footy-show/2016/episode-19',
+        'url': 'https://www.9now.com.au/afl-footy-show/2016/episode-26',
         'only_matching': True,
     }, {
         # DRM protected
-        'url': 'https://www.9now.com.au/andrew-marrs-history-of-the-world/season-1/episode-1',
+        'url': 'https://www.9now.com.au/black-adder-goes-forth/season-4/episode-5',
         'only_matching': True,
     }]
     BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/4460760524001/default_default/index.html?videoId=%s'
@@ -44,7 +44,14 @@ class NineNowIE(InfoExtractor):
         page_data = self._parse_json(self._search_regex(
             r'window\.__data\s*=\s*({.*?});', webpage,
             'page data'), display_id)
-        common_data = page_data.get('episode', {}).get('episode') or page_data.get('clip', {}).get('clip')
+        current_key = (
+            page_data.get('episode', {}).get('currentEpisodeKey', {}) or
+            page_data.get('clip', {}).get('currentClipKey', {})
+        )
+        common_data = (
+            page_data.get('episode', {}).get('episodeCache', {}).get(current_key, {}).get('episode') or
+            page_data.get('clip', {}).get('clipCache', {}).get(current_key, {}).get('clip')
+        )
         video_data = common_data['video']
 
         if video_data.get('drm'):

--- a/youtube_dl/extractor/ninenow.py
+++ b/youtube_dl/extractor/ninenow.py
@@ -45,8 +45,8 @@ class NineNowIE(InfoExtractor):
             r'window\.__data\s*=\s*({.*?});', webpage,
             'page data'), display_id)
         current_key = (
-            page_data.get('episode', {}).get('currentEpisodeKey', {}) or
-            page_data.get('clip', {}).get('currentClipKey', {})
+            page_data.get('episode', {}).get('currentEpisodeKey') or
+            page_data.get('clip', {}).get('currentClipKey')
         )
         common_data = (
             page_data.get('episode', {}).get('episodeCache', {}).get(current_key, {}).get('episode') or


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The `ninenow` extractor was broken due to a change in the structure of the JSON for both clips and episodes. This fixes it.