### PR TITLE
[polskieradio] Add support for downloading whole programmes.

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -667,7 +667,7 @@ from .pluralsight import (
 )
 from .podomatic import PodomaticIE
 from .pokemon import PokemonIE
-from .polskieradio import PolskieRadioIE
+from .polskieradio import PolskieRadioIE, PolskieRadioProgrammeIE
 from .porn91 import Porn91IE
 from .porncom import PornComIE
 from .pornhd import PornHdIE


### PR DESCRIPTION
A continuation of #10443.

This extends the Polskie Radio (the Polish national radio) extractor to enable the user to download all the broadcasts of a single programme at once.