### PR TITLE
Add CLI options to filter usable extractors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ which means you can modify it, redistribute it or use it however you like.
                                      extractors
     --force-generic-extractor        Force extraction to use the generic
                                      extractor
+    --enable-extractors EXTRACTORS   Enable only the chosen extractors. Comma-
+                                     separated list of patterns, wildcards
+                                     allowed. Example:
+                                     "twitch:*,youtube:*,vimeo"
+    --disable-extractors EXTRACTORS  Disable the chosen extractors. Comma-
+                                     separated list of patterns, wildcards
+                                     allowed. Example:
+                                     "twitch:*,youtube:*,vimeo"
     --default-search PREFIX          Use this prefix for unqualified URLs. For
                                      example "gvsearch2:" downloads two videos
                                      from google videos for youtube-dl "large

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -11,6 +11,7 @@ import subprocess
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from youtube_dl.utils import encodeArgument
+from youtube_dl.extractor import gen_extractors, get_info_extractor
 
 rootDir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -38,6 +39,71 @@ class TestExecution(unittest.TestCase):
             cwd=rootDir, stdout=_DEV_NULL, stderr=subprocess.PIPE)
         _, stderr = p.communicate()
         self.assertFalse(stderr)
+
+ALL_EXTRACTORS = [ie.IE_NAME for ie in gen_extractors() if ie._WORKING]
+EXTRACTOR_CASES = {
+    'unrestricted': {
+        'result': ALL_EXTRACTORS
+    },
+    'enable_all': {
+        'enable': '*',
+        'result': ALL_EXTRACTORS
+    },
+    'disable_all': {
+        'disable': '*',
+        'result': []
+    },
+    'enable_disable_all': {
+        'enable': '*',
+        'disable': '*',
+        'result': []
+    },
+    'enable_some': {
+        'enable': 'youtube,youporn',
+        'result': ['youtube', 'YouPorn']
+    },
+    'enable_and_filter': {
+        'enable': 'twitch:*',
+        'disable': 'twitch:stream',
+        'result': [ie for ie in ALL_EXTRACTORS if ie.startswith('twitch:') and ie != 'twitch:stream']
+    },
+    'enable_age_restricted': {
+        'enable': 'youporn',
+        'age_limit': 16,
+        'result': []
+    }
+}
+
+def gen_extractor_case(case):
+    enable = case.get('enable')
+    disable = case.get('disable')
+    age_limit = case.get('age_limit')
+    result = case['result']
+
+    def template(self):
+        args = [sys.executable, 'youtube_dl/__main__.py', '--list-extractors']
+        if enable:
+            args.extend(['--enable-extractors', enable])
+        if disable:
+            args.extend(['--disable-extractors', disable])
+        if age_limit:
+            args.extend(['--age-limit', str(age_limit)])
+
+        out = subprocess.check_output(args, cwd=rootDir, stderr=_DEV_NULL).decode('utf-8')
+        extractors = filter(lambda e: e and 'BROKEN' not in e, out.split('\n'))
+        self.assertItemsEqual(extractors, result)
+
+    return template
+
+class TestExtractorSelection(unittest.TestCase):
+    pass
+
+for name, case in EXTRACTOR_CASES.items():
+    test_method = gen_extractor_case(case)
+    test_name = str('test_' + name)
+    test_method.__name__ = test_name
+    setattr(TestExtractorSelection, test_name, test_method)
+    del test_method
 
 if __name__ == '__main__':
     unittest.main()

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -168,6 +168,14 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='force_generic_extractor', default=False,
         help='Force extraction to use the generic extractor')
     general.add_option(
+        '--enable-extractors', metavar='EXTRACTORS',
+        action='append', dest='enable_extractors',
+        help='Enable only the chosen extractors. Comma-separated list of patterns, wildcards allowed. Example: "twitch:*,youtube:*,vimeo"')
+    general.add_option(
+        '--disable-extractors', metavar='EXTRACTORS',
+        action='append', dest='disable_extractors',
+        help='Disable the chosen extractors. Comma-separated list of patterns, wildcards allowed. Example: "twitch:*,youtube:*,vimeo"')
+    general.add_option(
         '--default-search',
         dest='default_search', metavar='PREFIX',
         help='Use this prefix for unqualified URLs. For example "gvsearch2:" downloads two videos from google videos for youtube-dl "large apple". Use the value "auto" to let youtube-dl guess ("auto_warning" to emit a warning when guessing). "error" just throws an error. The default value "fixup_error" repairs broken URLs, but emits an error if this is not possible instead of searching.')


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Add `--enable-extractors` and `--disable-extractors` options, which make
it possible to restrict the set of extractors to be considered when
downloading. This is useful to handle URLs that match multiple
extractors (although this should be rare), or only using particular
modes of some extractors (for example, only live videos for Twitch,
enabling only `twitch:stream`).

Both options can be specified multiple times, and each argument is
interpreted as a comma-separated list of fnmatch patterns, to allow the
use of wildcards. Comparisons to extractor names are case-insensitive.
The order of the arguments is not relevant - matching always proceeds as
follows:

- Initialize the set of considered extractors to all available
- If --enable-extractors is specified, remove all extractors that
*don't* match those patterns from consideration
- If --disable-extractors is specified, remove all extractors that *do*
match those patterns from consideration
- If --age-limit is specified, remove all extractors that are not
suitable from consideration

Therefore, disables and the age limit take precedende over enables.