### PR TITLE
[YoutubeDL] Include `playlist_description` in post-processing

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -846,6 +846,7 @@ class YoutubeDL(object):
                     'playlist': playlist,
                     'playlist_id': ie_result.get('id'),
                     'playlist_title': ie_result.get('title'),
+                    'playlist_description': ie_result.get('description'),
                     'playlist_index': i + playliststart,
                     'extractor': ie_result['extractor'],
                     'webpage_url': ie_result['webpage_url'],


### PR DESCRIPTION
`playlist_id` and `playlist_title` are already supported, and there doesn't seem to be any other use for `playlist_description`, even though it's often returned by extractors