### PR TITLE
[FFmpegExtractAudioPP] info dict return audio filepath and ext instead of the video filepath if file already exists

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -278,6 +278,9 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
 
         prefix, sep, ext = path.rpartition('.')  # not os.path.splitext, since the latter does not work on unicode in all setups
         new_path = prefix + sep + extension
+        
+        information['filepath'] = new_path
+        information['ext'] = extension
 
         # If we download foo.mp3 and convert it to... foo.mp3, then don't delete foo.mp3, silly.
         if (new_path == path or
@@ -299,9 +302,6 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
             self.try_utime(
                 new_path, time.time(), information['filetime'],
                 errnote='Cannot update utime of audio file')
-
-        information['filepath'] = new_path
-        information['ext'] = extension
 
         return [path], information
 


### PR DESCRIPTION
If the converted audio file already exists, the `FFmpegExtractAudioPP.run` method returns the original video filepath instead of the converted audio filepath and ext which is the expected behavior, so if we set the filepath and the ext before checking if the file already exists it will return the correct values:

```python
# set the converted file path and ext before checking if it already exists
information['filepath'] = new_path
information['ext'] = extension

# now this will return the correct values
if (new_path == path or
        (self._nopostoverwrites and os.path.exists(encodeFilename(new_path)))):
    self._downloader.to_screen('[ffmpeg] Post-process file %s exists, skipping' % new_path)
    return [], information
```