### PR TITLE
[nytimes] Support downloading podcasts

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -641,7 +641,6 @@ from .ntvde import NTVDeIE
 from .ntvru import NTVRuIE
 from .nytimes import (
     NYTimesIE,
-    NYTimesPodcastIE,
     NYTimesArticleIE,
 )
 from .nuvid import NuvidIE

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -641,6 +641,7 @@ from .ntvde import NTVDeIE
 from .ntvru import NTVRuIE
 from .nytimes import (
     NYTimesIE,
+    NYTimesPodcastIE,
     NYTimesArticleIE,
 )
 from .nuvid import NuvidIE

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -125,11 +125,11 @@ class NYTimesBaseIE(InfoExtractor):
             'id': video_id,
             'title': title,
             'creator': audio_data['track'].get('credit'),
-            'series': audio_data['podcast']['title'],
+            'series': podcast_title,
             'episode': episode_title,
             'episode_number': episode_number,
             'url': audio_data['track']['source'],
-            'duration': audio_data['track']['duration'],
+            'duration': audio_data['track'].get('duration'),
             'description': description,
         }
         

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -13,6 +13,7 @@ from ..utils import (
     parse_iso8601,
     mimetype2ext,
     determine_ext,
+    UnsupportedError,
 )
 
 

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -105,7 +105,7 @@ class NYTimesBaseIE(InfoExtractor):
         if not description:
             description = self._html_search_meta(['og:description', 'twitter:description'], webpage)
 
-        episode_title = audio_data['track']['title'].strip("‘’") # strip curlyquotes
+        episode_title = audio_data['track']['title']
         episode_number = None
         episode = audio_data['podcast']['episode'].split()
         if episode:
@@ -182,7 +182,7 @@ class NYTimesArticleIE(NYTimesBaseIE):
         'md5': 'e0d52040cafb07662acf3c9132db3575',
         'info_dict': {
             'id': '20',
-            'title': "The Run-Up: He Was Like an Octopus",
+            'title': "The Run-Up: \u2018He Was Like an Octopus\u2019",
             'ext': 'mp3',
             'description': 'We go behind the story of the two women who told us that Donald Trump touched them inappropriately (which he denies) and check in on Hillary Clinton’s campaign.',
         }

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -102,13 +102,13 @@ class NYTimesBaseIE(InfoExtractor):
         audio_data = self._parse_json(json, page_id, transform_source=js_to_json)['data']
         
         description = audio_data['track']['description']
-        if not len(description):
+        if not description:
             description = self._html_search_meta(['og:description', 'twitter:description'], webpage)
 
         episode_title = audio_data['track']['title'].strip("‘’") # strip curlyquotes
         episode_number = None
         episode = audio_data['podcast']['episode'].split()
-        if len(episode):
+        if episode:
             episode_number = int_or_none(episode[-1])
             video_id = episode[-1]
         else:

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -209,5 +209,5 @@ class NYTimesArticleIE(NYTimesBaseIE):
         if video_id is not None:
             return self._extract_video_from_id(video_id)
         
-        data_json = self._html_search_regex(r'NYTD.FlexTypes.push\(({[^)]*)\)', webpage, 'json data')
+        data_json = self._html_search_regex(r'NYTD\.FlexTypes\.push\(({.*})\);', webpage, 'json data')
         return self._extract_podcast_from_json(data_json, page_id, webpage)

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -13,7 +13,6 @@ from ..utils import (
     parse_iso8601,
     mimetype2ext,
     determine_ext,
-    UnsupportedError,
 )
 
 
@@ -210,8 +209,5 @@ class NYTimesArticleIE(NYTimesBaseIE):
         if video_id is not None:
             return self._extract_video_from_id(video_id)
         
-        data_json = self._html_search_regex(r'NYTD.FlexTypes.push\(({[^)]*)\)', webpage, 'json data', None, False);
-        if data_json is not None:
-            return self._extract_podcast_from_json(data_json, page_id, webpage)
-        else:
-            raise UnsupportedError(url)
+        data_json = self._html_search_regex(r'NYTD.FlexTypes.push\(({[^)]*)\)', webpage, 'json data')
+        return self._extract_podcast_from_json(data_json, page_id, webpage)

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -101,7 +101,7 @@ class NYTimesBaseIE(InfoExtractor):
     def _extract_podcast_from_json(self, json, page_id, webpage):
         audio_data = self._parse_json(json, page_id, transform_source=js_to_json)['data']
         
-        description = audio_data['track']['description']
+        description = audio_data['track'].get('description')
         if not description:
             description = self._html_search_meta(['og:description', 'twitter:description'], webpage)
 

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -105,7 +105,7 @@ class NYTimesBaseIE(InfoExtractor):
         if not len(description):
             description = self._html_search_meta(['og:description', 'twitter:description'], webpage)
 
-        episode_title = audio_data['track']['title'].strip(u"‘’") # strip curlyquotes
+        episode_title = audio_data['track']['title'].strip("‘’") # strip curlyquotes
         episode_number = None
         episode = audio_data['podcast']['episode'].split()
         if len(episode):

--- a/youtube_dl/extractor/nytimes.py
+++ b/youtube_dl/extractor/nytimes.py
@@ -212,14 +212,5 @@ class NYTimesArticleIE(NYTimesBaseIE):
         data_json = self._html_search_regex(r'NYTD.FlexTypes.push\(({[^)]*)\)', webpage, 'json data', None, False);
         if data_json is not None:
             return self._extract_podcast_from_json(data_json, page_id, webpage)
-
-        # Fallback case
-        # "source":"https:\/\/rss.art19.com\/episodes\/0e2bd0b3-10ef-42c4-9494-0e3d21d2b82a.mp3","
-        url=self._html_search_regex(r'"source":"(https?:[^"]+)"', webpage, 'mp3 url')
-        url = url.replace('\\/','/')
-        if url is not None:
-            return {
-                'id': page_id,
-                'title': self._og_search_title(webpage),
-                'url': url
-            }
+        else:
+            raise UnsupportedError(url)


### PR DESCRIPTION
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] Improvement

---

### Description of your *pull request* and other information

Support New York Times podcasts.
Since this parses an array of JS from inside the page, it's potentially fragile, so add a fallback with simpler parsing (no metadata) as well. I don't have a test case where it actually fails, so I don't have a test for the fallback code.