### PR TITLE
[Youtube] Add game extractor

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1357,6 +1357,15 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             else:
                 video_description = ''
 
+        # game
+        video_game = self._html_search_regex(
+            r'<h4[^>]+class="title"[^>]*>\s*Game\s*</h4>\s*(<span[^>]*>.*\s*.*\s*.*\s.*\s*</span>\s*)?<ul[^>]*>\s*<li><a[^>]*>(?P<game>.+?)</a></li',
+            video_webpage, 'game', default=None, group="game")
+        if video_game is None:
+            video_game = self._html_search_regex(
+                r'<h4[^>]+class="title"[^>]*>\s*Game\s*</h4>\s*(<span[^>]*>.*\s*.*\s*.*\s.*\s*</span>\s*)?<ul[^>]*>\s*<li>(?P<game>.+?)( \(<a .*>.*</a>\))?</li',
+                video_webpage, 'game', default=None, group="game")
+
         if 'multifeed_metadata_list' in video_info and not smuggled_data.get('force_singlefeed', False):
             if not self._downloader.params.get('noplaylist'):
                 entries = []
@@ -1722,6 +1731,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'thumbnail': video_thumbnail,
             'description': video_description,
             'categories': video_categories,
+            'game': video_game,
             'tags': video_tags,
             'subtitles': video_subtitles,
             'automatic_captions': automatic_captions,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Adds the ability for the Youtube extractor to fetch the selected game on a video. The first regex is for games which have an image, the second for games which don't. The second only gets used if the first didn't return a result (most modern games have an image). As part of this there is also a new return value "game" which is either None or a string depending on if a game was found or not.