### PR TITLE
MIME type

### DIFF
--- a/download.html
+++ b/download.html
@@ -16,7 +16,7 @@
 
 <p><a href="https://yt-dl.org/downloads/2016.10.16/youtube-dl.exe">Windows exe</a> requires <a href="https://www.microsoft.com/en-US/download/details.aspx?id=5555">Microsoft Visual C++ 2010 Redistributable Package (x86)</a> and does not require Python that is already embedded into the binary.</p>
 
-<h2><a href="https://yt-dl.org/downloads/2016.10.16/youtube-dl">2016.10.16</a> (<a href="https://yt-dl.org/downloads/2016.10.16/youtube-dl.sig">sig</a>)</h2>
+<h2><a href="https://yt-dl.org/downloads/2016.10.16/youtube-dl.exe">2016.10.16</a> (<a href="https://yt-dl.org/downloads/2016.10.16/youtube-dl.sig">sig</a>)</h2>
 
 <p><strong>SHA256</strong>: c84ae0c46c9123d0fae060d348978a4e215a87ac7b25369c8074fe735bdee985</p>
 


### PR DESCRIPTION
Missing .exe forces unknown MIME type in browser when clicked to download.