### PR TITLE
[utils] add a base exception class and initialize exceptions properly

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -780,7 +780,7 @@ class ContentTooShortError(YoutubeDLError):
 
     def __init__(self, downloaded, expected):
         super(ContentTooShortError, self).__init__(
-            'Downloaded {} bytes, expected {} bytes'.format(downloaded, expected)
+            'Downloaded {0} bytes, expected {1} bytes'.format(downloaded, expected)
         )
         # Both in bytes
         self.downloaded = downloaded

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -752,6 +752,7 @@ class PostProcessingError(YoutubeDLError):
     """
 
     def __init__(self, msg):
+        super(PostProcessingError, self).__init__(msg)
         self.msg = msg
 
 
@@ -778,6 +779,9 @@ class ContentTooShortError(YoutubeDLError):
     """
 
     def __init__(self, downloaded, expected):
+        super(ContentTooShortError, self).__init__(
+            'Downloaded {} bytes, expected {} bytes'.format(downloaded, expected)
+        )
         # Both in bytes
         self.downloaded = downloaded
         self.expected = expected

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -675,7 +675,12 @@ def bug_reports_message():
     return msg
 
 
-class ExtractorError(Exception):
+class YoutubeDLError(Exception):
+    """Base exception for YoutubeDL errors."""
+    pass
+
+
+class ExtractorError(YoutubeDLError):
     """Error during info extraction."""
 
     def __init__(self, msg, tb=None, expected=False, cause=None, video_id=None):
@@ -716,7 +721,7 @@ class RegexNotFoundError(ExtractorError):
     pass
 
 
-class DownloadError(Exception):
+class DownloadError(YoutubeDLError):
     """Download Error exception.
 
     This exception may be thrown by FileDownloader objects if they are not
@@ -730,7 +735,7 @@ class DownloadError(Exception):
         self.exc_info = exc_info
 
 
-class SameFileError(Exception):
+class SameFileError(YoutubeDLError):
     """Same File exception.
 
     This exception will be thrown by FileDownloader objects if they detect
@@ -739,7 +744,7 @@ class SameFileError(Exception):
     pass
 
 
-class PostProcessingError(Exception):
+class PostProcessingError(YoutubeDLError):
     """Post Processing exception.
 
     This exception may be raised by PostProcessor's .run() method to
@@ -750,12 +755,12 @@ class PostProcessingError(Exception):
         self.msg = msg
 
 
-class MaxDownloadsReached(Exception):
+class MaxDownloadsReached(YoutubeDLError):
     """ --max-downloads limit has been reached. """
     pass
 
 
-class UnavailableVideoError(Exception):
+class UnavailableVideoError(YoutubeDLError):
     """Unavailable Format exception.
 
     This exception will be thrown when a video is requested
@@ -764,7 +769,7 @@ class UnavailableVideoError(Exception):
     pass
 
 
-class ContentTooShortError(Exception):
+class ContentTooShortError(YoutubeDLError):
     """Content Too Short exception.
 
     This exception may be raised by FileDownloader objects when a file they
@@ -778,7 +783,7 @@ class ContentTooShortError(Exception):
         self.expected = expected
 
 
-class XAttrMetadataError(Exception):
+class XAttrMetadataError(YoutubeDLError):
     def __init__(self, code=None, msg='Unknown error'):
         super(XAttrMetadataError, self).__init__(msg)
         self.code = code
@@ -794,7 +799,7 @@ class XAttrMetadataError(Exception):
             self.reason = 'NOT_SUPPORTED'
 
 
-class XAttrUnavailableError(Exception):
+class XAttrUnavailableError(YoutubeDLError):
     pass
 
 


### PR DESCRIPTION
It's always a good practice to have a base exception class and inherit from it, this way when handling exceptions you can differentiate the library errors from other exceptions, for example handling `Exception` will catch all the exceptions of youtube-dl and any other exceptions based on `Exception`, but now you can handle `YoutubeDLError` and `Exception` separately:

``` python
try:
    youtubedl = YoutubeDL(url, options)
    # ...
except YoutubeDLError:
    # handle all YoutubeDL errors
except Exception:
    # handle all the other exceptions

```

Also 2 exception classes didn't call the parent's `__init__` which is recommended and will set the `args` attribute of the exception which is used by the `__str__` and `__repr__` methods.
