### PR TITLE
Fix hang when backgrounded

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1820,6 +1820,7 @@ def get_exe_version(exe, args=['--version'],
     try:
         out, _ = subprocess.Popen(
             [encodeArgument(exe)] + args,
+            stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()
     except OSError:
         return False


### PR DESCRIPTION
- [x] Bug fix

---
### Description of your *pull request* and other information

youtube-dl hangs when backgrounded because ffmpeg -version tries to read from stdin:

```
pb3:youtube-dl jhawk$ python -m youtube_dl -v 'BaW_jenozKc' &
[1] 4263
pb3:youtube-dl jhawk$ [debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'-v', u'BaW_jenozKc']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2016.10.21.1
[debug] Git HEAD: 69c2d42
[debug] Python version 2.7.10 - Darwin-14.5.0-x86_64-i386-64bit


[1]+  Stopped                 python -m youtube_dl -v 'BaW_jenozKc'
pb3:youtube-dl jhawk$ jobs -l
[1]+  4263 Stopped (tty output): 22python -m youtube_dl -v 'BaW_jenozKc'
pb3:youtube-dl jhawk$ pstree 4263
-+= 04263 jhawk python -m youtube_dl -v BaW_jenozKc
 \--- 04271 jhawk ffmpeg -version
pb3:youtube-dl jhawk$ 
pb3:youtube-dl jhawk$ ffmpeg -version &
[2] 4276
pb3:youtube-dl jhawk$ 

[2]+  Stopped                 ffmpeg -version
pb3:youtube-dl jhawk$ fg %2
ffmpeg -version
ffmpeg version 3.1.4 Copyright (c) 2000-2016 the FFmpeg developers
built with Apple LLVM version 7.0.2 (clang-700.1.81)
configuration: --prefix=/usr/local/Cellar/ffmpeg/3.1.4 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-opencl --enable-libx264 --enable-libmp3lame --enable-libxvid --enable-openssl --disable-lzma --enable-nonfree --enable-vda
libavutil      55. 28.100 / 55. 28.100
libavcodec     57. 48.101 / 57. 48.101
libavformat    57. 41.100 / 57. 41.100
libavdevice    57.  0.101 / 57.  0.101
libavfilter     6. 47.100 /  6. 47.100
libavresample   3.  0.  0 /  3.  0.  0
libswscale      4.  1.100 /  4.  1.100
libswresample   2.  1.100 /  2.  1.100
libpostproc    54.  0.100 / 54.  0.100
pb3:youtube-dl jhawk$ 
pb3:youtube-dl jhawk$ ffmpeg -version <&- &
[2] 4277
pb3:youtube-dl jhawk$ ffmpeg version 3.1.4 Copyright (c) 2000-2016 the FFmpeg developers
built with Apple LLVM version 7.0.2 (clang-700.1.81)
configuration: --prefix=/usr/local/Cellar/ffmpeg/3.1.4 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-opencl --enable-libx264 --enable-libmp3lame --enable-libxvid --enable-openssl --disable-lzma --enable-nonfree --enable-vda
libavutil      55. 28.100 / 55. 28.100
libavcodec     57. 48.101 / 57. 48.101
libavformat    57. 41.100 / 57. 41.100
libavdevice    57.  0.101 / 57.  0.101
libavfilter     6. 47.100 /  6. 47.100
libavresample   3.  0.  0 /  3.  0.  0
libswscale      4.  1.100 /  4.  1.100
libswresample   2.  1.100 /  2.  1.100
libpostproc    54.  0.100 / 54.  0.100

[2]-  Done                    ffmpeg -version 0>&-
pb3:youtube-dl jhawk$ ffmpeg -version </dev/null &
[2] 4278
pb3:youtube-dl jhawk$ ffmpeg version 3.1.4 Copyright (c) 2000-2016 the FFmpeg developers
built with Apple LLVM version 7.0.2 (clang-700.1.81)
configuration: --prefix=/usr/local/Cellar/ffmpeg/3.1.4 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-opencl --enable-libx264 --enable-libmp3lame --enable-libxvid --enable-openssl --disable-lzma --enable-nonfree --enable-vda
libavutil      55. 28.100 / 55. 28.100
libavcodec     57. 48.101 / 57. 48.101
libavformat    57. 41.100 / 57. 41.100
libavdevice    57.  0.101 / 57.  0.101
libavfilter     6. 47.100 /  6. 47.100
libavresample   3.  0.  0 /  3.  0.  0
libswscale      4.  1.100 /  4.  1.100
libswresample   2.  1.100 /  2.  1.100
libpostproc    54.  0.100 / 54.  0.100

[2]-  Done                    ffmpeg -version < /dev/null
pb3:youtube-dl jhawk$ 
```

While of course the best thing to do would be to fix ffmpeg, in the meantime youtube_dl should workaround it. This patch closes stdin, analagous to calling ffmpeg with <&-. Another choice
would be to use </dev/null (see 3cad576), which is arguably a little less fragile (what if ffmpeg calls open() and gets fd0 as the next fd) and a little clearer to read...