### PR TITLE
Give the URL of failed m3u8 downloads

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -1188,7 +1188,7 @@ class InfoExtractor(object):
         res = self._download_webpage_handle(
             m3u8_url, video_id,
             note=note or 'Downloading m3u8 information',
-            errnote=errnote or 'Failed to download m3u8 information',
+            errnote=errnote or 'Failed to download m3u8 information: %s' % m3u8_url,
             fatal=fatal)
         if res is False:
             return []


### PR DESCRIPTION
When an M3U8 download fails (because of a screwup on the server-side), youtube-dl ought to print the URL that fails, rather than simply saying it's 404 Not Found.

E.g.:

```
pb3:youtube-dl jhawk$ python -m youtube_dl -v 'https://CambridgeMA.IQM2.com/Citizens/VideoMain.aspx?MeetingID=1859'
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'-v', u'https://CambridgeMA.IQM2.com/Citizens/VideoMain.aspx?MeetingID=1859']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2016.10.02
[debug] Git HEAD: 3cd6469
[debug] Python version 2.7.10 - Darwin-14.5.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 3.1.5, ffprobe 3.1.5, rtmpdump 2.4
[debug] Proxy map: {}
[IQM2] 1859: Downloading webpage
[IQM2] 1593: Downloading webpage
[IQM2] 1593: Downloading m3u8 information
WARNING: Failed to download m3u8 information: HTTP Error 404: Not Found
ERROR: No video formats found; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "youtube_dl/YoutubeDL.py", line 694, in extract_info
    ie_result = ie.extract(url)
  File "youtube_dl/extractor/common.py", line 355, in extract
    return self._real_extract(url)
  File "youtube_dl/extractor/iqm2.py", line 105, in _real_extract
    webpage, video_id, require_title=False)
  File "youtube_dl/extractor/iqm2.py", line 81, in _extract_jwplayer_data
    jwplayer_data, video_id, *args, **kwargs)
  File "youtube_dl/extractor/jwplatform.py", line 108, in _parse_jwplayer_data
    self._sort_formats(formats)
  File "youtube_dl/extractor/common.py", line 922, in _sort_formats
    raise ExtractorError('No video formats found')
ExtractorError: No video formats found; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

With the patch:
```
pb3:youtube-dl jhawk$ python -m youtube_dl -v 'https://CambridgeMA.IQM2.com/Citizens/VideoMain.aspx?MeetingID=1859'
[debug] System config: []
[debug] User config: []
[debug] Command-line args: [u'-v', u'https://CambridgeMA.IQM2.com/Citizens/VideoMain.aspx?MeetingID=1859']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2016.10.02
[debug] Git HEAD: 3cd6469
[debug] Python version 2.7.10 - Darwin-14.5.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 3.1.5, ffprobe 3.1.5, rtmpdump 2.4
[debug] Proxy map: {}
[IQM2] 1859: Downloading webpage
[IQM2] 1593: Downloading webpage
[IQM2] 1593: Downloading m3u8 information
WARNING: Failed to download m3u8 information: http://MediaIAD-cdn.IQM2.com/DVR/CambridgeMA/1593/Segment001/CambridgeMA_Sullivan Chamber-m3u8-aapl.ism/Events(1593)/manifest(format=m3u8-aapl).m3u8: HTTP Error 404: Not Found
ERROR: No video formats found; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "youtube_dl/YoutubeDL.py", line 694, in extract_info
    ie_result = ie.extract(url)
  File "youtube_dl/extractor/common.py", line 355, in extract
    return self._real_extract(url)
  File "youtube_dl/extractor/iqm2.py", line 105, in _real_extract
    webpage, video_id, require_title=False)
  File "youtube_dl/extractor/iqm2.py", line 81, in _extract_jwplayer_data
    jwplayer_data, video_id, *args, **kwargs)
  File "youtube_dl/extractor/jwplatform.py", line 108, in _parse_jwplayer_data
    self._sort_formats(formats)
  File "youtube_dl/extractor/common.py", line 922, in _sort_formats
    raise ExtractorError('No video formats found')
ExtractorError: No video formats found; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

Or without -v, where it is still helpful:
```
pb3:youtube-dl jhawk$ python -m youtube_dl 'https://CambridgeMA.IQM2.com/Citizens/VideoMain.aspx?MeetingID=1859'
[IQM2] 1859: Downloading webpage
[IQM2] 1593: Downloading webpage
[IQM2] 1593: Downloading m3u8 information
WARNING: Failed to download m3u8 information: http://MediaIAD-cdn.IQM2.com/DVR/CambridgeMA/1593/Segment001/CambridgeMA_Sullivan Chamber-m3u8-aapl.ism/Events(1593)/manifest(format=m3u8-aapl).m3u8: HTTP Error 404: Not Found
ERROR: No video formats found; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
pb3:youtube-dl jhawk$ 
```

Thanks!