### PR TITLE
[svtplay] Work around broken fragment URLs for svtplay as described in issue 10909

### DIFF
--- a/youtube_dl/extractor/svt.py
+++ b/youtube_dl/extractor/svt.py
@@ -37,6 +37,14 @@ class SVTBaseIE(InfoExtractor):
                     'format_id': player_type,
                     'url': vurl,
                 })
+
+        # Work around issue 10909 by manually rewriting fragment URLs to URLs that appear to work
+        for format in formats:
+            if 'fragments' in format:
+                for segment in format['fragments']:
+                    segment_url = re.sub('dash-live/[^.].*/./', 'dash-live/./', segment['url'])
+                    segment.update({'url': segment_url})
+
         if not formats and video_info.get('rights', {}).get('geoBlockedSweden'):
             self.raise_geo_restricted('This video is only available in Sweden')
         self._sort_formats(formats)


### PR DESCRIPTION
## Please follow the guide below
- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your _pull request_ (like that [x])
- Use _Preview_ tab to see how your _pull request_ will actually look like
---
### Before submitting a _pull request_ make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
### What is the purpose of your _pull request_?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature
---
### Description of your _pull request_ and other information

This pull request works around (or fixes, depending on your PoV) issue #10909 I have compared svtplay downloads that succeeded with svtplay downloads that failed. The succesful ones download their fragments from URLs of the form '<...>/dash-live/./< subdir >/< file >.m4a', whereas the failed ones attempted a download from '<...>/dash-live/< file >.mpd?alt=http://switcher.cdn.svt.se/./< subdir >/< file >.m4a' (note the lack of '/./' after 'dash-live' in this case). Immediately trying to download from the url specified in the alt= parameter failed, but rewriting the full url by collapsing the part after 'dash-live/' until the '/./' in the alt= parameter did work.

It looks (and is) somewhat ad hoc, but at least it works on the examples I tried.
