### PR TITLE
[funnyordie] Improve bitrate regex, add _check_formats call for video

### DIFF
--- a/youtube_dl/extractor/funnyordie.py
+++ b/youtube_dl/extractor/funnyordie.py
@@ -51,7 +51,7 @@ class FunnyOrDieIE(InfoExtractor):
 
         formats = []
 
-        bitrates = [int(bitrate) for bitrate in re.findall(r'v(\d+)(?=,|/)', m3u8_url)]
+        bitrates = [int(bitrate) for bitrate in re.findall(r'[,/]v(\d+)(?=[,/])', m3u8_url)]
         bitrates.sort()
 
         for bitrate in bitrates:

--- a/youtube_dl/extractor/funnyordie.py
+++ b/youtube_dl/extractor/funnyordie.py
@@ -11,7 +11,7 @@ class FunnyOrDieIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?funnyordie\.com/(?P<type>embed|articles|videos)/(?P<id>[0-9a-f]+)(?:$|[?#/])'
     _TESTS = [{
         'url': 'http://www.funnyordie.com/videos/0732f586d7/heart-shaped-box-literal-video-version',
-        'md5': 'bcd81e0c4f26189ee09be362ad6e6ba9',
+        'md5': 'c26b9ee0e1ca138c12071f59572ba9c7',
         'info_dict': {
             'id': '0732f586d7',
             'ext': 'mp4',
@@ -51,7 +51,7 @@ class FunnyOrDieIE(InfoExtractor):
 
         formats = []
 
-        bitrates = [int(bitrate) for bitrate in re.findall(r'v(\d+)[,/]', m3u8_url)]
+        bitrates = [int(bitrate) for bitrate in re.findall(r'v(\d+)(?=,|/)', m3u8_url)]
         bitrates.sort()
 
         for bitrate in bitrates:
@@ -80,7 +80,7 @@ class FunnyOrDieIE(InfoExtractor):
 
         return {
             'id': video_id,
-            'title': post.get('name'),
+            'title': post['name'],
             'description': post.get('description'),
             'thumbnail': post.get('picture'),
             'formats': formats,

--- a/youtube_dl/extractor/funnyordie.py
+++ b/youtube_dl/extractor/funnyordie.py
@@ -51,10 +51,7 @@ class FunnyOrDieIE(InfoExtractor):
 
         formats = []
 
-        formats.extend(self._extract_m3u8_formats(
-            m3u8_url, video_id, 'mp4', 'm3u8_native', m3u8_id='hls', fatal=False))
-
-        bitrates = [int(bitrate) for bitrate in re.findall(r'[,/]v(\d+)[,/]', m3u8_url)]
+        bitrates = [int(bitrate) for bitrate in re.findall(r'v(\d+)[,/]', m3u8_url)]
         bitrates.sort()
 
         for bitrate in bitrates:
@@ -64,6 +61,11 @@ class FunnyOrDieIE(InfoExtractor):
                     'format_id': '%s-%d' % (link[1], bitrate),
                     'vbr': bitrate,
                 })
+
+        self._check_formats(formats, video_id)
+
+        formats.extend(self._extract_m3u8_formats(
+            m3u8_url, video_id, 'mp4', 'm3u8_native', m3u8_id='hls', fatal=False))
 
         subtitles = {}
         for src, src_lang in re.findall(r'<track kind="captions" src="([^"]+)" srclang="([^"]+)"', webpage):
@@ -78,7 +80,7 @@ class FunnyOrDieIE(InfoExtractor):
 
         return {
             'id': video_id,
-            'title': post['name'],
+            'title': post.get('name'),
             'description': post.get('description'),
             'thumbnail': post.get('picture'),
             'formats': formats,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x ] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ x] Improvement
- [ ] New extractor
- [ ] New feature

---

old bitrate regex won't capture all vbrs, see https://regex101.com/r/FXaWjL/2
new version (in this PR): https://regex101.com/r/FXaWjL/1

Also, for some .webm urls server return 403 error
Example: http://www.funnyordie.com/videos/d182501dfe/world-war-g/ , v1200 (.webm)
