### PR TITLE
Pandoratv extractor fix

### DIFF
--- a/youtube_dl/extractor/pandoratv.py
+++ b/youtube_dl/extractor/pandoratv.py
@@ -12,7 +12,6 @@ from ..utils import (
     float_or_none,
     parse_duration,
     str_to_int,
-    urlencode_postdata,
 )
 
 
@@ -60,11 +59,13 @@ class PandoraTVIE(InfoExtractor):
                 continue
 
             post_data = ('prgid=%s&runtime=%s&vod_url=%s' % (video_id, info.get('runtime'), format_url)).encode()
-            ret = compat_urllib_request.urlopen("http://m.pandora.tv/?c=api&m=play_url", data=post_data).read()
-            encoding = self._guess_encoding_from_content('json', ret)
-            ret = self._parse_json(ret.decode(encoding, errors='ignore'), video_id)
-            format_url = ret['url']
-            
+            data = compat_urllib_request.urlopen("http://m.pandora.tv/?c=api&m=play_url", data=post_data).read()
+            encoding = self._guess_encoding_from_content('json', data)
+            play_url = self._parse_json(data.decode(encoding, errors='ignore'), video_id)
+            format_url = play_url.get('url')
+            if not format_url:
+                continue
+
             formats.append({
                 'format_id': '%sp' % height,
                 'url': format_url,

--- a/youtube_dl/extractor/pandoratv.py
+++ b/youtube_dl/extractor/pandoratv.py
@@ -12,6 +12,7 @@ from ..utils import (
     float_or_none,
     parse_duration,
     str_to_int,
+    urlencode_postdata,
 )
 
 
@@ -58,10 +59,13 @@ class PandoraTVIE(InfoExtractor):
             if not height:
                 continue
 
-            post_data = ('prgid=%s&runtime=%s&vod_url=%s' % (video_id, info.get('runtime'), format_url)).encode()
-            data = compat_urllib_request.urlopen("http://m.pandora.tv/?c=api&m=play_url", data=post_data).read()
-            encoding = self._guess_encoding_from_content('json', data)
-            play_url = self._parse_json(data.decode(encoding, errors='ignore'), video_id)
+            post_data = {'prgid': video_id, 'runtime': info.get('runtime'), 'vod_url': format_url}
+            play_url = self._download_json('http://m.pandora.tv/?c=api&m=play_url', video_id, 
+                data=urlencode_postdata(post_data), 
+                headers={
+                    'Origin': url,
+                    'Content-Type': 'application/x-www-form-urlencoded'
+            })
             format_url = play_url.get('url')
             if not format_url:
                 continue

--- a/youtube_dl/extractor/pandoratv.py
+++ b/youtube_dl/extractor/pandoratv.py
@@ -5,12 +5,14 @@ from .common import InfoExtractor
 from ..compat import (
     compat_str,
     compat_urlparse,
+    compat_urllib_request,
 )
 from ..utils import (
     ExtractorError,
     float_or_none,
     parse_duration,
     str_to_int,
+    urlencode_postdata,
 )
 
 
@@ -56,6 +58,13 @@ class PandoraTVIE(InfoExtractor):
                 r'^v(\d+)[Uu]rl$', format_id, 'height', default=None)
             if not height:
                 continue
+
+            post_data = ('prgid=%s&runtime=%s&vod_url=%s' % (video_id, info.get('runtime'), format_url)).encode()
+            ret = compat_urllib_request.urlopen("http://m.pandora.tv/?c=api&m=play_url", data=post_data).read()
+            encoding = self._guess_encoding_from_content('json', ret)
+            ret = self._parse_json(ret.decode(encoding, errors='ignore'), video_id)
+            format_url = ret['url']
+            
             formats.append({
                 'format_id': '%sp' % height,
                 'url': format_url,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/) (well, the code that I inserted is by me)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix

---

### Description of your *pull request* and other information

Apparently, pandora.tv has changed the way the data is retrieved, so previous extractor is not completely usable. This pull request adds the necessary steps to get the direct media link. Specifically, this link must have a timestamp and hash code which the code added now obtains. More info can be found here #11023 