### PR TITLE
Added a "filename_hook" parameter to Python interface

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -151,6 +151,10 @@ class YoutubeDL(object):
     simulate:          Do not download the video files.
     format:            Video format code. See options.py for more information.
     outtmpl:           Template for output names.
+    filename_hook:     A function that gets called before creating a filename, 
+                       allowing to change it before the filename is created.
+                       It should accept filename as first positional argument
+                       and return the desired filename (no extensions added)
     restrictfilenames: Do not allow "&" and spaces in file names
     ignoreerrors:      Do not stop on download errors.
     force_generic_extractor: Force downloader to use the generic extractor
@@ -612,7 +616,9 @@ class YoutubeDL(object):
             # to workaround encoding issues with subprocess on python2 @ Windows
             if sys.version_info < (3, 0) and sys.platform == 'win32':
                 filename = encodeFilename(filename, True).decode(preferredencoding())
-            return sanitize_path(filename)
+            filename = sanitize_path(filename)
+            filename = self.params.get('filename_hook', lambda x: x)(filename)
+            return compat_str(filename)
         except ValueError as err:
             self.report_error('Error in output template: ' + str(err) + ' (encoding: ' + repr(preferredencoding()) + ')')
             return None


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Hello! I need the to sanitize the filenames myself since the existing functions do not satisfy me. Thus, I've added a way to add a hook that receives the filename generated by YoutubeDL and returns a filename that'll be used further down the line.

**Reasons:** with "restricted filenames", filenames are sanitized too much to the point of making the filename very ugly, and without "restricted filenames" I get characters that aren't compatible with the software I use. Also I plan to further integrate YoutubeDL with my music collection organizing scripts and such a feature would help. I already use it in my local version but I figure others could benefit from this as well.

**Sidenotes:** The hook is very likely to get called 2 or more times (since  ``process_filename`` is called quite often), but I can't see this causing any problems if we assume the processing function to always return same x for same y (which is the case for any reasonable sanitization function).

Example usage:

```
def filename_hook(filename):
    #An example hook - manual editing
    return raw_input('Edit this: "{}" : '.format(filename)).strip()

opts = {
"filename_hook":filename_hook,
"match_filter":print_info,
"outtmpl":"%(title)s",
"postprocessors":[{"key":'FFmpegExtractAudio', "preferredcodec":"mp3"}]
}
```