### PR TITLE
[Twitch] Add support for player.twitch.tv urls

### DIFF
--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -231,6 +231,26 @@ class TwitchVodIE(TwitchItemBaseIE):
             'skip_download': True,
         },
     }, {
+        # player.twitch.tv URL
+        'url': 'http://player.twitch.tv/?video=v6528877&t=5m10s',
+        'info_dict': {
+            'id': 'v6528877',
+            'ext': 'mp4',
+            'title': 'LCK Summer Split - Week 6 Day 1',
+            'thumbnail': 're:^https?://.*\.jpg$',
+            'duration': 17208,
+            'timestamp': 1435131709,
+            'upload_date': '20150624',
+            'uploader': 'Riot Games',
+            'uploader_id': 'riotgames',
+            'view_count': int,
+            'start_time': 310,
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        },
+    }, {
         # Untitled broadcast (title is None)
         'url': 'http://www.twitch.tv/belkao_o/v/11230755',
         'info_dict': {

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -206,7 +206,8 @@ class TwitchChapterIE(TwitchItemBaseIE):
 
 class TwitchVodIE(TwitchItemBaseIE):
     IE_NAME = 'twitch:vod'
-    _VALID_URL = r'%s/[^/]+/v/(?P<id>\d+)' % TwitchBaseIE._VALID_URL_BASE
+    _VALID_URL_BASE = r'https?://(?:www\.|player\.)?twitch\.tv'
+    _VALID_URL = r'%s/(?:[^/]+/v/|\?video=v)(?P<id>\d+)' % _VALID_URL_BASE
     _ITEM_TYPE = 'vod'
     _ITEM_SHORTCUT = 'v'
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Addresses issue #11535 by modifying the VOD (video on demand) regex pattern in the Twitch Information Extractor to be compatible with urls of the form "player.twitch.tv/?video=v12345...."
