### PR TITLE
[youtube:playlist] Fix 'this playlist doesn't exist/is private' error not working (#11604)

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1955,7 +1955,8 @@ class YoutubePlaylistIE(YoutubePlaylistBaseInfoExtractor):
         url = self._TEMPLATE_URL % playlist_id
         page = self._download_webpage(url, playlist_id)
 
-        for match in re.findall(r'<div class="yt-alert-message">([^<]+)</div>', page):
+        # the yt-alert-message now has tabindex attribute (see https://github.com/rg3/youtube-dl/issues/11604)
+        for match in re.findall(r'<div class="yt-alert-message"[^>]+?>([^<]+)</div>', page):
             match = match.strip()
             # Check if the playlist exists or is private
             if re.match(r'[^<]*(The|This) playlist (does not exist|is private)[^<]*', match):

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1956,7 +1956,7 @@ class YoutubePlaylistIE(YoutubePlaylistBaseInfoExtractor):
         page = self._download_webpage(url, playlist_id)
 
         # the yt-alert-message now has tabindex attribute (see https://github.com/rg3/youtube-dl/issues/11604)
-        for match in re.findall(r'<div class="yt-alert-message"[^>]+?>([^<]+)</div>', page):
+        for match in re.findall(r'<div class="yt-alert-message"[^>]*>([^<]+)</div>', page):
             match = match.strip()
             # Check if the playlist exists or is private
             if re.match(r'[^<]*(The|This) playlist (does not exist|is private)[^<]*', match):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request fixes bug #11604.
The issue at hand is the fact that YouTube's page structure has changed such that the previous method of checking whether the playlist exists/is private ceased working. The notice now looks like this:
```html
    <div class="yt-alert-message" tabindex="0">
          This playlist is private.
    </div>
```
the old method only checks for `<div class="yt-alert-message">` and thus broke.