### PR TITLE
Adjusted aria2 flags

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -153,7 +153,7 @@ class Aria2cFD(ExternalFD):
     def _make_cmd(self, tmpfilename, info_dict):
         cmd = [self.exe, '-c']
         cmd += self._configuration_args([
-            '--min-split-size', '1M', '--max-connection-per-server', '4'])
+            '--min-split-size', '1M', '--max-connection-per-server', '4', '--stream-piece-selector', 'geom', '--enable-http-pipelining'])
         dn = os.path.dirname(tmpfilename)
         if dn:
             cmd += ['--dir', dn]


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

aria2c by default will attempt to reduce the amount of new connections needed for a parallel download, but this may be undesirable for streaming videos as the start of the file may not be finished in time.

Instead, we should use `geom`, which starts downloading the video at the beginning, but still attempts to reduce connections for later pieces of the file.

> https://aria2.github.io/manual/en/html/aria2c.html#cmdoption--stream-piece-selector