### PR TITLE
[orf] Update OE1 extractor, merge with FM4.

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -680,8 +680,7 @@ from .openload import OpenloadIE
 from .ora import OraTVIE
 from .orf import (
     ORFTVthekIE,
-    ORFOE1IE,
-    ORFFM4IE,
+    ORFRadioIE,
     ORFIPTVIE,
 )
 from .pandatv import PandaTVIE

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -680,7 +680,8 @@ from .openload import OpenloadIE
 from .ora import OraTVIE
 from .orf import (
     ORFTVthekIE,
-    ORFRadioIE,
+    ORFFM4IE,
+    ORFOE1IE,
     ORFIPTVIE,
 )
 from .pandatv import PandaTVIE

--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -143,38 +143,6 @@ class ORFTVthekIE(InfoExtractor):
 
 
 class ORFRadioIE(InfoExtractor):
-    _VALID_URL = r'https?://(?P<station>oe1|fm4)\.orf\.at/(?:7tage/?#|player/)(?P<date>[0-9]+)/(?P<show>\w+)'
-
-    _TESTS = [
-        {
-            'url': 'http://fm4.orf.at/player/20170107/CC',
-            'md5': '2b0be47375432a7ef104453432a19212',
-            'info_dict': {
-                'id': '2017-01-07_2100_tl_54_7DaysSat18_31295',
-                'ext': 'mp3',
-                'title': 'Solid Steel Radioshow',
-                'description': 'Die Mixshow von Coldcut und Ninja Tune.',
-                'duration': 3599,
-                'timestamp': 1483819257,
-                'upload_date': '20170107',
-            },
-            'skip': 'Shows from ORF radios are only available for 7 days.'
-        },
-        {
-            'url': 'http://oe1.orf.at/player/20170108/456544',
-            'md5': '34d8a6e67ea888293741c86a099b745b',
-            'info_dict': {
-                'id': '2017-01-08_0759_tl_51_7DaysSun6_256141',
-                'ext': 'mp3',
-                'title': 'Morgenjournal',
-                'duration': 609,
-                'timestamp': 1483858796,
-                'upload_date': '20170108',
-            },
-            'skip': 'Shows from ORF radios are only available for 7 days.'
-        }
-    ]
-
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)
         station = mobj.group('station')
@@ -214,11 +182,46 @@ class ORFRadioIE(InfoExtractor):
 class ORFFM4IE(ORFRadioIE):
     IE_NAME = 'orf:fm4'
     IE_DESC = 'radio FM4'
+    _VALID_URL = r'https?://(?P<station>fm4)\.orf\.at/(?:7tage/?#|player/)(?P<date>[0-9]+)/(?P<show>\w+)'
+
+    _TESTS = [
+        {
+            'url': 'http://fm4.orf.at/player/20170107/CC',
+            'md5': '2b0be47375432a7ef104453432a19212',
+            'info_dict': {
+                'id': '2017-01-07_2100_tl_54_7DaysSat18_31295',
+                'ext': 'mp3',
+                'title': 'Solid Steel Radioshow',
+                'description': 'Die Mixshow von Coldcut und Ninja Tune.',
+                'duration': 3599,
+                'timestamp': 1483819257,
+                'upload_date': '20170107',
+            },
+            'skip': 'Shows from ORF radios are only available for 7 days.'
+        }
+    ]
 
 
 class ORFOE1IE(ORFRadioIE):
     IE_NAME = 'orf:oe1'
     IE_DESC = 'Radio Österreich 1'
+    _VALID_URL = r'https?://(?P<station>oe1)\.orf\.at/(?:7tage/?#|player/)(?P<date>[0-9]+)/(?P<show>\w+)'
+
+    _TESTS = [
+       {
+            'url': 'http://oe1.orf.at/player/20170108/456544',
+            'md5': '34d8a6e67ea888293741c86a099b745b',
+            'info_dict': {
+                'id': '2017-01-08_0759_tl_51_7DaysSun6_256141',
+                'ext': 'mp3',
+                'title': 'Morgenjournal',
+                'duration': 609,
+                'timestamp': 1483858796,
+                'upload_date': '20170108',
+            },
+            'skip': 'Shows from ORF radios are only available for 7 days.'
+        }
+    ]
 
 
 class ORFIPTVIE(InfoExtractor):

--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -143,9 +143,6 @@ class ORFTVthekIE(InfoExtractor):
 
 
 class ORFRadioIE(InfoExtractor):
-    IE_NAME = 'orf:radio'
-    IE_DESC = 'ORF Radio'
-
     _VALID_URL = r'https?://(?P<station>oe1|fm4)\.orf\.at/(?:7tage/?#|player/)(?P<date>[0-9]+)/(?P<show>\w+)'
 
     _TESTS = [
@@ -212,6 +209,16 @@ class ORFRadioIE(InfoExtractor):
             'description': data['subtitle'],
             'entries': entries
         }
+
+
+class ORFFM4IE(ORFRadioIE):
+    IE_NAME = 'orf:fm4'
+    IE_DESC = 'radio FM4'
+
+
+class ORFOE1IE(ORFRadioIE):
+    IE_NAME = 'orf:oe1'
+    IE_DESC = 'Radio Österreich 1'
 
 
 class ORFIPTVIE(InfoExtractor):

--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -2,8 +2,6 @@
 from __future__ import unicode_literals
 
 import re
-import calendar
-import datetime
 
 from .common import InfoExtractor
 from ..compat import compat_str
@@ -144,77 +142,60 @@ class ORFTVthekIE(InfoExtractor):
         }
 
 
-class ORFOE1IE(InfoExtractor):
-    IE_NAME = 'orf:oe1'
-    IE_DESC = 'Radio Österreich 1'
-    _VALID_URL = r'https?://oe1\.orf\.at/(?:programm/|konsole\?.*?\btrack_id=)(?P<id>[0-9]+)'
+class ORFRadioIE(InfoExtractor):
+    IE_NAME = 'orf:radio'
+    IE_DESC = 'ORF Radio'
 
-    # Audios on ORF radio are only available for 7 days, so we can't add tests.
-    _TESTS = [{
-        'url': 'http://oe1.orf.at/konsole?show=on_demand#?track_id=394211',
-        'only_matching': True,
-    }, {
-        'url': 'http://oe1.orf.at/konsole?show=ondemand&track_id=443608&load_day=/programm/konsole/tag/20160726',
-        'only_matching': True,
-    }]
+    _VALID_URL = r'https?://(?P<station>oe1|fm4)\.orf\.at/(?:7tage/?#|player/)(?P<date>[0-9]+)/(?P<show>\w+)'
 
-    def _real_extract(self, url):
-        show_id = self._match_id(url)
-        data = self._download_json(
-            'http://oe1.orf.at/programm/%s/konsole' % show_id,
-            show_id
-        )
-
-        timestamp = datetime.datetime.strptime('%s %s' % (
-            data['item']['day_label'],
-            data['item']['time']
-        ), '%d.%m.%Y %H:%M')
-        unix_timestamp = calendar.timegm(timestamp.utctimetuple())
-
-        return {
-            'id': show_id,
-            'title': data['item']['title'],
-            'url': data['item']['url_stream'],
-            'ext': 'mp3',
-            'description': data['item'].get('info'),
-            'timestamp': unix_timestamp
-        }
-
-
-class ORFFM4IE(InfoExtractor):
-    IE_NAME = 'orf:fm4'
-    IE_DESC = 'radio FM4'
-    _VALID_URL = r'https?://fm4\.orf\.at/(?:7tage/?#|player/)(?P<date>[0-9]+)/(?P<show>\w+)'
-
-    _TEST = {
-        'url': 'http://fm4.orf.at/player/20160110/IS/',
-        'md5': '01e736e8f1cef7e13246e880a59ad298',
-        'info_dict': {
-            'id': '2016-01-10_2100_tl_54_7DaysSun13_11244',
-            'ext': 'mp3',
-            'title': 'Im Sumpf',
-            'description': 'md5:384c543f866c4e422a55f66a62d669cd',
-            'duration': 7173,
-            'timestamp': 1452456073,
-            'upload_date': '20160110',
+    _TESTS = [
+        {
+            'url': 'http://fm4.orf.at/player/20170107/CC',
+            'md5': '2b0be47375432a7ef104453432a19212',
+            'info_dict': {
+                'id': '2017-01-07_2100_tl_54_7DaysSat18_31295',
+                'ext': 'mp3',
+                'title': 'Solid Steel Radioshow',
+                'description': 'Die Mixshow von Coldcut und Ninja Tune.',
+                'duration': 3599,
+                'timestamp': 1483819257,
+                'upload_date': '20170107',
+            },
+            'skip': 'Shows from ORF radios are only available for 7 days.'
         },
-        'skip': 'Live streams on FM4 got deleted soon',
-    }
+        {
+            'url': 'http://oe1.orf.at/player/20170108/456544',
+            'md5': '34d8a6e67ea888293741c86a099b745b',
+            'info_dict': {
+                'id': '2017-01-08_0759_tl_51_7DaysSun6_256141',
+                'ext': 'mp3',
+                'title': 'Morgenjournal',
+                'duration': 609,
+                'timestamp': 1483858796,
+                'upload_date': '20170108',
+            },
+            'skip': 'Shows from ORF radios are only available for 7 days.'
+        }
+    ]
 
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)
+        station = mobj.group('station')
         show_date = mobj.group('date')
         show_id = mobj.group('show')
 
+        if station == 'fm4':
+            show_id = '4%s' % show_id
+
         data = self._download_json(
-            'http://audioapi.orf.at/fm4/json/2.0/broadcasts/%s/4%s' % (show_date, show_id),
+            'http://audioapi.orf.at/%s/api/json/current/broadcast/%s/%s' % (station, show_id, show_date),
             show_id
         )
 
         def extract_entry_dict(info, title, subtitle):
             return {
                 'id': info['loopStreamId'].replace('.mp3', ''),
-                'url': 'http://loopstream01.apa.at/?channel=fm4&id=%s' % info['loopStreamId'],
+                'url': 'http://loopstream01.apa.at/?channel=%s&id=%s' % (station, info['loopStreamId']),
                 'title': title,
                 'description': subtitle,
                 'duration': (info['end'] - info['start']) / 1000,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Since oe1.orf.at has been updated, both ORF radios supported by youtube_dl
use the same API. This commit honors this fact by merging both extractors
into one, improving code re-use and making sure that oe1.orf.at will continue to work
whenever the legacy API gets deprecated.

flake8 has no complaints and the tests are passing.