### PR TITLE
[Iwara] Fix download

### DIFF
--- a/youtube_dl/extractor/iwara.py
+++ b/youtube_dl/extractor/iwara.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 from ..compat import compat_urllib_parse_urlparse
-from ..utils import remove_end
+from ..utils import (
+    remove_end,
+    mimetype2ext,
+)
 
 
 class IwaraIE(InfoExtractor):
@@ -97,9 +100,9 @@ class IwaraIE(InfoExtractor):
 
         for raw_format in raw_formats:
             new_format = {
-                'url': raw_format['uri'],
-                'resolution': raw_format['resolution'],
-                'format_id': raw_format['resolution'],
+                'url': raw_format.get('uri'),
+                'resolution': raw_format.get('resolution'),
+                'format_id': raw_format.get('resolution'),
             }
 
             if raw_format.get('resolution') == '1080p':
@@ -117,8 +120,8 @@ class IwaraIE(InfoExtractor):
                 new_format['width'] = int(height / 9.0 * 16.0)
                 new_format['height'] = height
 
-            if raw_format.get('mime') == 'video/mp4':
-                new_format['ext'] = 'mp4'
+            if raw_format.get('mime'):
+                new_format['ext'] = mimetype2ext(raw_format.get('mime'))
 
             formats.append(new_format)
 

--- a/youtube_dl/extractor/iwara.py
+++ b/youtube_dl/extractor/iwara.py
@@ -10,12 +10,21 @@ class IwaraIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.|ecchi\.)?iwara\.tv/videos/(?P<id>[a-zA-Z0-9]+)'
     _TESTS = [{
         'url': 'http://iwara.tv/videos/amVwUl1EHpAD9RD',
-        'md5': '1d53866b2c514b23ed69e4352fdc9839',
+        'md5': 'c9c35657eff2fda5af7f78e69637d2d6',
         'info_dict': {
             'id': 'amVwUl1EHpAD9RD',
             'ext': 'mp4',
             'title': '【MMD R-18】ガールフレンド carry_me_off',
             'age_limit': 18,
+        },
+    }, {
+        'url': 'http://www.iwara.tv/videos/64zbul0qujvjavm',
+        'md5': '727d0f869035247781469aa7a06e2365',
+        'info_dict': {
+            'id': '64zbul0qujvjavm',
+            'ext': 'mp4',
+            'title': 'レアさん Dark Sea Adventure',
+            'age_limit': 0,
         },
     }, {
         'url': 'http://ecchi.iwara.tv/videos/Vb4yf2yZspkzkBO',
@@ -28,12 +37,12 @@ class IwaraIE(InfoExtractor):
         },
         'add_ie': ['GoogleDrive'],
     }, {
-        'url': 'http://www.iwara.tv/videos/nawkaumd6ilezzgq',
-        'md5': '1d85f1e5217d2791626cff5ec83bb189',
+        'url': 'http://ecchi.iwara.tv/videos/nawkaumd6ilezzgq',
+        'md5': '729a1e0a830469fe2c56d20aed06f852',
         'info_dict': {
             'id': '6liAP9s2Ojc',
             'ext': 'mp4',
-            'age_limit': 0,
+            'age_limit': 18,
             'title': '[MMD] Do It Again Ver.2 [1080p 60FPS] (Motion,Camera,Wav+DL)',
             'description': 'md5:590c12c0df1443d833fbebe05da8c47a',
             'upload_date': '20160910',
@@ -54,6 +63,29 @@ class IwaraIE(InfoExtractor):
 
         title = remove_end(self._html_search_regex(
             r'<title>([^<]+)</title>', webpage, 'title'), ' | Iwara')
+
+        entries = self._parse_html5_media_entries(url, webpage, video_id)
+
+        if entries:
+            info_dict = entries[0]
+            info_dict.update({
+                'id': video_id,
+                'title': title,
+                'age_limit': age_limit,
+            })
+
+            return info_dict
+
+        iframe_url = self._html_search_regex(
+            r'<iframe[^>]+src=([\'"])(?P<url>[^\'"]+)\1',
+            webpage, 'iframe URL', group='url', default=None)
+
+        if iframe_url:
+            return {
+                '_type': 'url_transparent',
+                'url': iframe_url,
+                'age_limit': age_limit,
+            }
 
         api_url = 'http://%s/api/video/%s' % (hostname, video_id)
 

--- a/youtube_dl/extractor/iwara.py
+++ b/youtube_dl/extractor/iwara.py
@@ -102,13 +102,13 @@ class IwaraIE(InfoExtractor):
                 'format_id': raw_format['resolution'],
             }
 
-            if raw_format['resolution'] == '1080p':
+            if raw_format.get('resolution') == '1080p':
                 height = 1080
-            elif raw_format['resolution'] == '720p':
+            elif raw_format.get('resolution') == '720p':
                 height = 720
-            elif raw_format['resolution'] == '540p':
+            elif raw_format.get('resolution') == '540p':
                 height = 540
-            elif raw_format['resolution'] == '360p':
+            elif raw_format.get('resolution') == '360p':
                 height = 360
             else:
                 height = None
@@ -117,7 +117,7 @@ class IwaraIE(InfoExtractor):
                 new_format['width'] = int(height / 9.0 * 16.0)
                 new_format['height'] = height
 
-            if raw_format['mime'] == 'video/mp4':
+            if raw_format.get('mime') == 'video/mp4':
                 new_format['ext'] = 'mp4'
 
             formats.append(new_format)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

[Iwara](http://www.iwara.tv/) now switched their player to get media URLs from API, not HTML. So the previous extractor is now [failing](https://travis-ci.org/rg3/youtube-dl/jobs/192039917#L892).

This patch fixes the extractor to use API to extract video URL and fixed some test cases as the following.

* Some MD5 are updated according to the source change. I manually confirmed the downloaded content is correct.
* The video of the last test case was re-rated to 18+, and I updated the field.
* Then there are no test cases for 0+ video (which has `www.iwara.tv` domain), and I added one.