### PR TITLE
[xhamster] extract tags from xhamster movie page

### DIFF
--- a/youtube_dl/extractor/xhamster.py
+++ b/youtube_dl/extractor/xhamster.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import unicode_literals
 
 import re
@@ -9,6 +10,8 @@ from ..utils import (
     parse_duration,
     unified_strdate,
 )
+
+
 
 
 class XHamsterIE(InfoExtractor):
@@ -24,6 +27,7 @@ class XHamsterIE(InfoExtractor):
             'uploader': 'Ruseful2011',
             'duration': 893,
             'age_limit': 18,
+            'tags': ['Amateur', 'MILFs', 'POV', 'Reality', 'Sexy', 'Office', 'Oral', 'Boss', 'Fake Hub']
         },
     }, {
         'url': 'http://xhamster.com/movies/2221348/britney_spears_sexy_booty.html?hd',
@@ -35,6 +39,7 @@ class XHamsterIE(InfoExtractor):
             'uploader': 'jojo747400',
             'duration': 200,
             'age_limit': 18,
+            'tags:': ['Britney Spears', 'Berühmtheiten', 'HD Videos', 'Sexy', 'Sexy Booty']
         },
         'params': {
             'skip_download': True,
@@ -50,6 +55,7 @@ class XHamsterIE(InfoExtractor):
             'uploader': 'parejafree',
             'duration': 72,
             'age_limit': 18,
+            'tags': []
         },
         'params': {
             'skip_download': True,
@@ -83,6 +89,9 @@ class XHamsterIE(InfoExtractor):
              r'<meta[^>]+itemprop=".*?caption.*?"[^>]+content="(.+?)"',
              r'<title[^>]*>(.+?)(?:,\s*[^,]*?\s*Porn\s*[^,]*?:\s*xHamster[^<]*| - xHamster\.com)</title>'],
             webpage, 'title')
+
+        video_tags = re.findall(r'<meta itemprop="name" content="(.+?)"', webpage)[2:]
+
 
         # Only a few videos have an description
         mobj = re.search(r'<span>Description: </span>([^<]+)', webpage)
@@ -154,6 +163,7 @@ class XHamsterIE(InfoExtractor):
             'dislike_count': int_or_none(dislike_count),
             'comment_count': int_or_none(comment_count),
             'age_limit': age_limit,
+            'tags': video_tags,
             'formats': formats,
         }
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

xhamster provides a list of tags for hosted videos. purpose of this change is to extract  the names of the tags from the movie webpage and return them as a list of strings in the tags property.