### PR TITLE
Fixes #11572 Use cfscrape to avoid Crunchyroll error 503

### DIFF
--- a/youtube_dl/extractor/crunchyroll.py
+++ b/youtube_dl/extractor/crunchyroll.py
@@ -53,7 +53,7 @@ class CrunchyrollBaseIE(InfoExtractor):
             print 'cfscrape not found. Please install it if you want use login function for CrunchyRoll.'
             return False
 
-        # Scrape cookie from cloudfront and insert them
+        # Scrape cookie from cloudflare and insert them
         scraper = cfscrape.create_scraper()
         tokens = scraper.get_tokens(self._LOGIN_URL, std_headers['User-Agent'])
         self._set_crunchyroll_cookie('cf_clearance', tokens[0]['cf_clearance'])

--- a/youtube_dl/extractor/crunchyroll.py
+++ b/youtube_dl/extractor/crunchyroll.py
@@ -24,6 +24,7 @@ from ..utils import (
     lowercase_escape,
     remove_end,
     sanitized_Request,
+    std_headers,
     unified_strdate,
     urlencode_postdata,
     xpath_text,
@@ -46,7 +47,7 @@ class CrunchyrollBaseIE(InfoExtractor):
 
         # Scrape cookie from cloudfront and insert them
         scraper = cfscrape.create_scraper()
-        tokens = scraper.get_tokens(self._LOGIN_URL, 'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20150101 Firefox/47.0 (Chrome)')
+        tokens = scraper.get_tokens(self._LOGIN_URL, std_headers['User-Agent'])
         self._set_crunchyroll_cookie('cf_clearance', tokens[0]['cf_clearance'])
         self._set_crunchyroll_cookie('__cfduid', tokens[0]['__cfduid'])
 

--- a/youtube_dl/extractor/crunchyroll.py
+++ b/youtube_dl/extractor/crunchyroll.py
@@ -51,8 +51,8 @@ class CrunchyrollBaseIE(InfoExtractor):
             tokens = scraper.get_tokens(self._LOGIN_URL, std_headers['User-Agent'])
             self._set_crunchyroll_cookie('cf_clearance', tokens[0]['cf_clearance'])
             self._set_crunchyroll_cookie('__cfduid', tokens[0]['__cfduid'])
-        else
-            print 'cfscrape not found. Please install it if you want use login function for CrunchyRoll.'
+        else:
+            self.report_warning('cfscrape not found. Please install it if you want use login function for CrunchyRoll.')
             
         (username, password) = self._get_login_info()
         if username is None:

--- a/youtube_dl/extractor/crunchyroll.py
+++ b/youtube_dl/extractor/crunchyroll.py
@@ -7,9 +7,9 @@ import base64
 import zlib
 try:
     import cfscrape
-    install_cfscrape_flag = True
+    cfscrape_available = True
 except ImportError:
-    install_cfscrape_flag = False
+    cfscrape_available = False
 
 from hashlib import sha1
 from math import pow, sqrt, floor
@@ -45,19 +45,18 @@ class CrunchyrollBaseIE(InfoExtractor):
     _NETRC_MACHINE = 'crunchyroll'
 
     def _login(self):
+        if cfscrape_available:
+            # Scrape cookie from cloudflare and insert them
+            scraper = cfscrape.create_scraper()
+            tokens = scraper.get_tokens(self._LOGIN_URL, std_headers['User-Agent'])
+            self._set_crunchyroll_cookie('cf_clearance', tokens[0]['cf_clearance'])
+            self._set_crunchyroll_cookie('__cfduid', tokens[0]['__cfduid'])
+        else
+            print 'cfscrape not found. Please install it if you want use login function for CrunchyRoll.'
+            
         (username, password) = self._get_login_info()
         if username is None:
             return
-
-        if install_cfscrape_flag == False:
-            print 'cfscrape not found. Please install it if you want use login function for CrunchyRoll.'
-            return False
-
-        # Scrape cookie from cloudflare and insert them
-        scraper = cfscrape.create_scraper()
-        tokens = scraper.get_tokens(self._LOGIN_URL, std_headers['User-Agent'])
-        self._set_crunchyroll_cookie('cf_clearance', tokens[0]['cf_clearance'])
-        self._set_crunchyroll_cookie('__cfduid', tokens[0]['__cfduid'])
 
         login_page = self._download_webpage(
             self._LOGIN_URL, None, 'Downloading login page')

--- a/youtube_dl/extractor/crunchyroll.py
+++ b/youtube_dl/extractor/crunchyroll.py
@@ -5,7 +5,11 @@ import re
 import json
 import base64
 import zlib
-import cfscrape
+try:
+    import cfscrape
+    install_cfscrape_flag = True
+except ImportError:
+    install_cfscrape_flag = False
 
 from hashlib import sha1
 from math import pow, sqrt, floor
@@ -44,6 +48,10 @@ class CrunchyrollBaseIE(InfoExtractor):
         (username, password) = self._get_login_info()
         if username is None:
             return
+
+        if install_cfscrape_flag == False:
+            print 'cfscrape not found. Please install it if you want use login function for CrunchyRoll.'
+            return False
 
         # Scrape cookie from cloudfront and insert them
         scraper = cfscrape.create_scraper()


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Crunchyroll use not cloudfront when we login. To avoid a 503 error we need to insert the cookies that coudfront send.

I use cfscrape (https://github.com/Anorov/cloudflare-scrape) to grab the cookie that we need and insert them back. It is important that cfscrape have the same user-agent than youtube-dl, so it would be better not to hardcode it (I didn't find how I must do, so feel free to change it).
