### PR TITLE
[azmedientv] Add new information extractors 

### DIFF
--- a/youtube_dl/extractor/azmedientv.py
+++ b/youtube_dl/extractor/azmedientv.py
@@ -1,0 +1,87 @@
+from __future__ import unicode_literals
+
+import re
+
+from .common import InfoExtractor
+from .kaltura import KalturaIE
+from ..utils import get_element_by_class
+
+
+class AZMedienTVIE(InfoExtractor):
+    IE_DESC = 'telezueri.ch, telebaern.tv and telem1.ch videos'
+    _VALID_URL = r'http://(?:www\.)?(?:telezueri\.ch|telebaern\.tv|telem1\.ch)/[0-9]+-show-[^/#]+(?:/[0-9]+-episode-[^/#]+(?:/[0-9]+-segment-(?:[^/#]+#)?|#)|#)(?P<id>[^#]+)'
+
+    _TESTS = [{
+        # URL with 'segment'
+        'url': 'http://www.telezueri.ch/62-show-zuerinews/13772-episode-sonntag-18-dezember-2016/32419-segment-massenabweisungen-beim-hiltl-club-wegen-pelzboom',
+        'md5': 'fda85ada1299cee517a622bfbc5f6b66',
+        'info_dict': {
+            'id': '1_2444peh4',
+            'ext': 'mov',
+            'title': 'Massenabweisungen beim Hiltl Club wegen Pelzboom',
+            'description': 'md5:9ea9dd1b159ad65b36ddcf7f0d7c76a8',
+            'uploader_id': 'TeleZ?ri',
+            'upload_date': '20161218',
+            'timestamp': 1482084490,
+        }
+    }, {
+        # URL with 'segment' and fragment:
+        'url': 'http://www.telebaern.tv/118-show-news/14240-episode-dienstag-17-januar-2017/33666-segment-achtung-gefahr#zu-wenig-pflegerinnen-und-pfleger',
+        'only_matching': True
+    }, {
+        # URL with 'episode' and fragment:
+        'url': 'http://www.telem1.ch/47-show-sonntalk/13986-episode-soldaten-fuer-grenzschutz-energiestrategie-obama-bilanz#soldaten-fuer-grenzschutz-energiestrategie-obama-bilanz',
+        'only_matching': True
+    }, {
+        # URL with 'show' and fragment:
+        'url': 'http://www.telezueri.ch/66-show-sonntalk#burka-plakate-trump-putin-china-besuch',
+        'only_matching': True
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        kaltura_partner_id = self._html_search_regex(
+            r'<script[^>]+src=["\']https?://www\.kaltura\.com/.*/partner_id/([0-9]+)',
+            webpage, 'Kaltura partner ID')
+        kaltura_entry_id = self._html_search_regex(
+            r'<a[^>]+data-id=["\'](.*?)["\'][^>]+data-slug=["\']%s' % video_id,
+            webpage, 'Kaltura entry ID')
+
+        return self.url_result(
+            'kaltura:%s:%s' % (kaltura_partner_id, kaltura_entry_id),
+            ie=KalturaIE.ie_key())
+
+
+class AZMedienTVShowIE(InfoExtractor):
+    IE_DESC = 'telezueri.ch, telebaern.tv and telem1.ch shows'
+    _VALID_URL = r'http://(?:www\.)?(?:telezueri\.ch|telebaern\.tv|telem1\.ch)/(?P<id>[0-9]+-show-[^/#]+(?:/[0-9]+-episode-[^/#]+)?)$'
+
+    _TESTS = [{
+        # URL with 'episode':
+        'url': 'http://www.telebaern.tv/118-show-news/13735-episode-donnerstag-15-dezember-2016',
+        'info_dict': {
+            'id': '118-show-news/13735-episode-donnerstag-15-dezember-2016',
+            'title': 'News',
+        },
+        'playlist_count': 9,
+    }, {
+        # URL with 'show' only:
+        'url': 'http://www.telezueri.ch/86-show-talktaeglich',
+        'only_matching': True
+    }]
+
+    def _real_extract(self, url):
+        show_id = self._match_id(url)
+        webpage = self._download_webpage(url, show_id)
+
+        title = get_element_by_class('title-block-cell', webpage)
+        if title:
+            title = title.strip()
+
+        entries = [self.url_result(m.group('url'), ie=AZMedienTVIE.ie_key()) for m in re.finditer(
+            r'<a href=["\']#["\'][^>]+data-real=["\'](?P<url>.+?)["\']', webpage)]
+
+        return self.playlist_result(
+            entries, show_id, title)

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -77,6 +77,10 @@ from .awaan import (
     AWAANLiveIE,
     AWAANSeasonIE,
 )
+from .azmedientv import (
+    AZMedienTVIE,
+    AZMedienTVShowIE,
+)
 from .azubu import AzubuIE, AzubuLiveIE
 from .baidu import BaiduVideoIE
 from .bambuser import BambuserIE, BambuserChannelIE


### PR DESCRIPTION
New information extractors AZMedienTVIE and AZMedienTVShowIE for the Swiss regional TV sites telezueri.ch, telebaern.tv and telem1.ch


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description

The Swiss regional TV stations from "AZ Medien TV" (telezueri.ch, telebaern.tv, telem1.ch) have similar websites to view their videos. They all use the Kaltura video player. I have implemented a information extractor for their single videos (AZMedienTVIE) and a information extractor for their shows, which are represented as playlists (AZMedienTVShowIE).