### PR TITLE
[vimeo] Add support for extracting licenses

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -575,6 +575,9 @@ class VimeoIE(VimeoBaseInfoExtractor):
             like_count = None
             comment_count = None
 
+        # Extract license
+        license = self._search_regex(r'<link [^>]+rel="license" href="(.*?)">', webpage, 'license', default=None)
+
         formats = []
         download_request = sanitized_Request('https://vimeo.com/%s?action=load_download_config' % video_id, headers={
             'X-Requested-With': 'XMLHttpRequest'})
@@ -609,6 +612,7 @@ class VimeoIE(VimeoBaseInfoExtractor):
             'view_count': view_count,
             'like_count': like_count,
             'comment_count': comment_count,
+            'license': license,
         })
 
         return info_dict


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This will extract the URL to the relevant Creative Commons license, if
the video is licensed using one of those. Otherwise it'll be `None`
since vimeo does not specify a license.

Fixes #8726

I wasn't really able to run the tests, they were spewing random http/url errors that seemed unrelated to my change. Also, my patch currently is returning a license URL rather than a human readable license name, is that acceptable?
