### PR TITLE
[YouTube, Improvement] Skip handle "age-restricted content" if possible

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1028,7 +1028,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
     def _parse_sig_js(self, jscode):
         funcname = self._search_regex(
-            r'\.sig\|\|([a-zA-Z0-9$]+)\(', jscode,
+            r'"signature",\s?([a-zA-Z0-9$]+)\(', jscode,
             'Initial JS player signature function name')
 
         jsi = JSInterpreter(jscode)
@@ -1050,6 +1050,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         if player_url.startswith('//'):
             player_url = 'https:' + player_url
+        elif player_url.startswith('/'):
+            player_url = 'https://youtube.com' + player_url
+            
         try:
             player_id = (player_url, self._signature_cache_id(s))
             if player_id not in self._player_cache:


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Related to this issue: https://github.com/rg3/youtube-dl/issues/12035

>YouTube-DL detects age-restricted content, but when I skip this check, it works without problem.
>So I think, it's better to skip the step handle "age-restricted content" if possible.
https://github.com/Khang-NT/youtube-dl/blob/master/youtube_dl/extractor/youtube.py#L1305-L1376
To do that, just do "get video info" first. Then if "get video info" success, we can skip "age-restricted" block.

https://github.com/rg3/youtube-dl/pull/12057/commits/c59d4abb0eeaad07932f2b7b36be670d494375a1