### PR TITLE
utils.py: Workaround TypeError with Python 2.7.13 in Windows

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1684,6 +1684,11 @@ def setproctitle(title):
         libc = ctypes.cdll.LoadLibrary('libc.so.6')
     except OSError:
         return
+    except TypeError:
+        # LoadLibrary in Windows Python 2.7.13 only expects
+        # a bytestring, but since unicode_literals turns
+        # every string into a unicode string, it fails.
+        return
     title_bytes = title.encode('utf-8')
     buf = ctypes.create_string_buffer(len(title_bytes))
     buf.value = title_bytes


### PR DESCRIPTION
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix

---

Fixes #11540 
More exactly it's a workaround, not a fix, but people shouldn't be forced to use a months old version just because of a TypeError in a LoadLibrary that isn't even relevant in Windows.

Also recommend using Python2 for the official builds, since using 3.4.4 (more than a year old) is probably one of the bigger reasons why [this error](https://github.com/rg3/youtube-dl/issues?q=is%3Aissue+CERTIFICATE_VERIFY_FAILED+is%3Aclosed) is so prevalent in Windows lately.