### PR TITLE
Support Vimeo urls with query strings

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -190,7 +190,7 @@ class VimeoIE(VimeoBaseInfoExtractor):
                             )
                             \.
                         )?
-                        vimeo(?P<pro>pro)?\.com/
+                        vimeo\.com/
                         (?!(?:channels|album)/[^/?#]+/?(?:$|[?#])|[^/]+/review/|ondemand/)
                         (?:.*?/)?
                         (?:
@@ -201,7 +201,7 @@ class VimeoIE(VimeoBaseInfoExtractor):
                         (?:videos?/)?
                         (?P<id>[0-9]+)
                         (?:/[\da-f]+)?
-                        /?(?:[?&].*)?(?:[#].*)?$
+                        /?(?P<qs>(?:[?&].*)?(?:[#].*)?)$
                     '''
     IE_NAME = 'vimeo'
     _TESTS = [
@@ -453,10 +453,14 @@ class VimeoIE(VimeoBaseInfoExtractor):
         mobj = re.match(self._VALID_URL, url)
         video_id = mobj.group('id')
         orig_url = url
-        if mobj.group('pro') or mobj.group('player'):
+        if mobj.group('player'):
             url = 'https://player.vimeo.com/video/' + video_id
         elif any(p in url for p in ('play_redirect_hls', 'moogaloop.swf')):
             url = 'https://vimeo.com/' + video_id
+
+        if mobj.group('qs'):
+            # Some vimeopro embeds have query strings (`?portfolio_id=NNNNNN`) which are necessary
+            url += mobj.group('qs')
 
         # Retrieve video webpage to extract further information
         request = sanitized_Request(url, headers=headers)
@@ -571,7 +575,7 @@ class VimeoIE(VimeoBaseInfoExtractor):
         if not video_description:
             video_description = self._html_search_meta(
                 'description', webpage, default=None)
-        if not video_description and mobj.group('pro'):
+        if not video_description:
             orig_webpage = self._download_webpage(
                 orig_url, video_id,
                 note='Downloading webpage for description',


### PR DESCRIPTION
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] Bug fix
- [x] Improvement

---

This PR makes it possible to download Vimeo Pro URLs that have embedded query strings (`portfolio_id`); case in point: https://vimeopro.com/user39826906/studia-medicina-1812017/video/200122547

Since I'm a newbie to the Youtube-DL codebase, I did this in the simplest way possible, i.e. by disallowing the `vimeo` information extractor from directly attempting to use `vimeopro.com` urls; instead, they're read by the `generic` extractor, which is better able to find the embedded query string in the `player.vimeo.com` URL. If there are better approaches, please do let me know and/or edit the PR to match.