### PR TITLE
[RaiPlay] Add support for raiplay.it URLs

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -779,6 +779,7 @@ from .radiofrance import RadioFranceIE
 from .rai import (
     RaiTVIE,
     RaiIE,
+    RaiPlayIE,
 )
 from .rbmaradio import RBMARadioIE
 from .rds import RDSIE

--- a/youtube_dl/extractor/rai.py
+++ b/youtube_dl/extractor/rai.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
@@ -265,3 +266,23 @@ class RaiIE(RaiBaseIE):
             'title': title,
             'formats': formats,
         }
+
+class RaiPlayIE(RaiBaseIE):
+    _VALID_URL = r'https?://(?:.+?\.)?raiplay\.it/raiplay/video/(?:[^/]+/)+.+?-(?P<id>[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})(?:-.+?)?\.html'
+    _TEST = {
+            'url': 'http://www.raiplay.it/raiplay/video/2016/06/Paolo-Fresu-Il-tempo-di-un-viaggio-5bdc6f5f-74b7-426e-8192-9a1189123522.html',
+            'info_dict': {
+                'id': '5bdc6f5f-74b7-426e-8192-9a1189123522',
+                'ext': 'mp4',
+                'title': '365 Paolo Fresu, il tempo di un viaggio',
+                'description': 'Incontro con con Paolo Fresu, compositore e trombettista di straordinario e talento. Dall\'attaccamento alla terra della nativa Sardegna alle prime avventure musicali, dalla passione per Miles Davis alle collaborazioni con autori e musicisti di ogni nazionalità e estrazione.',
+                'upload_date': '20160628',
+                'duration': 6014.0,
+                'thumbnail': r're:^https?://.*\.jpg$',
+            }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        return self._extract_from_content_id(video_id, url)


### PR DESCRIPTION
Add to rai.py the RaiPlayIE class (modeled after RaiTVIE) to support
URLs for the new raiplay.it website.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Extend the rai.py extractor to support URLs for the new raiplay.it website.