### PR TITLE
[kaltura][azmedien-live] Add support for live streams

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -82,6 +82,7 @@ from .awaan import (
 )
 from .azmedien import (
     AZMedienIE,
+    AZMedienLiveIE,
     AZMedienPlaylistIE,
     AZMedienShowPlaylistIE,
 )


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

I have added support for AZ Medien live streams. To do this, I had to add support for Kaltura live streams in the Kaltura information extractor. There might be some lower quality formats, which I did not manage to extract, maybe someone could have a look at this.

Also, I've noticed that there is something wrong with the Kaltura information extractor: `data_url` does not always seem to be available. The second Kaltura test fails.