### PR TITLE
Addition to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                      caseless sub-string)
     --max-downloads NUMBER           Abort after downloading NUMBER files
     --min-filesize SIZE              Do not download any videos smaller than
-                                     SIZE (e.g. 50k or 44.6m)
+                                     SIZE (e.g. 50k or 44.6m). Use match-filter
+                                     with the duration key instead of this to
+                                     filter for long videos only as this will
+                                     often download the video track and skip
+                                     the audio if they are downloaded separately.
     --max-filesize SIZE              Do not download any videos larger than SIZE
                                      (e.g. 50k or 44.6m)
     --date DATE                      Download only videos uploaded in this date


### PR DESCRIPTION
Added advice to line 135 regarding not using min-filesize to try and download longer videos only based on their file-size. It will select just the long videos to download and will download the video track, then it will not download the audio track as it's too small and you end up with an un-merged file. Using duration in match-filter works fine however.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Small addition to README.md. Added advice to line 135 regarding not using min-filesize to try and download longer videos only based on their file-size. It will select just the long videos to download and will download the video track, then it will not download the audio track as it's too small and you end up with an un-merged file. Using duration in match-filter works fine however.
