### PR TITLE
Addition to help for max-filesize in Options.py

### DIFF
--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -280,7 +280,12 @@ def parseOpts(overrideArguments=None):
     selection.add_option(
         '--min-filesize',
         metavar='SIZE', dest='min_filesize', default=None,
-        help='Do not download any videos smaller than SIZE (e.g. 50k or 44.6m)')
+        help=(
+            'Do not download any videos smaller than SIZE (e.g. 50k or 44.6m).
+            'Use match-filter with the duration key instead of this to filter'
+            'for long videos only as this will often download the video track'
+            'and skip the audio if they are downloaded separately.'
+        ))
     selection.add_option(
         '--max-filesize',
         metavar='SIZE', dest='max_filesize', default=None,


### PR DESCRIPTION
Added to the text outputted to the command-line in the help parameter for --min-filesize to match the addition I made in the README.md file with additional advice regarding the use of the min-filesize to try to filter for longer/larger  videos.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Modified Options.py slightly by adding to the text outputted to the command-line in the help parameter for --min-filesize to match the addition I made in the README.md file with additional advice regarding the use of the min-filesize to try to filter for longer/larger  videos.