### PR TITLE
Add post processor to move after completion

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -290,6 +290,11 @@ def _real_main(argv=None):
             'key': 'ExecAfterDownload',
             'exec_cmd': opts.exec_cmd,
         })
+    if opts.move:
+        postprocessors.append({
+            'key': 'Move',
+            'destination': opts.move,
+        })
     external_downloader_args = None
     if opts.external_downloader_args:
         external_downloader_args = compat_shlex_split(opts.external_downloader_args)

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -845,6 +845,9 @@ def parseOpts(overrideArguments=None):
         '--convert-subs', '--convert-subtitles',
         metavar='FORMAT', dest='convertsubtitles', default=None,
         help='Convert the subtitles to other format (currently supported: srt|ass|vtt)')
+    postproc.add_option(
+        '--move', metavar="DESTINATION", dest='move',
+        help="Specify directory to move completed files to")
 
     parser.add_option_group(general)
     parser.add_option_group(network)

--- a/youtube_dl/postprocessor/__init__.py
+++ b/youtube_dl/postprocessor/__init__.py
@@ -16,6 +16,7 @@ from .ffmpeg import (
 from .xattrpp import XAttrMetadataPP
 from .execafterdownload import ExecAfterDownloadPP
 from .metadatafromtitle import MetadataFromTitlePP
+from .move import MovePP
 
 
 def get_postprocessor(key):
@@ -25,6 +26,7 @@ def get_postprocessor(key):
 __all__ = [
     'EmbedThumbnailPP',
     'ExecAfterDownloadPP',
+    'MovePP',
     'FFmpegEmbedSubtitlePP',
     'FFmpegExtractAudioPP',
     'FFmpegFixupM3u8PP',

--- a/youtube_dl/postprocessor/move.py
+++ b/youtube_dl/postprocessor/move.py
@@ -1,0 +1,27 @@
+from __future__ import unicode_literals
+
+import subprocess
+import os
+import shutil
+
+from .common import PostProcessor
+from ..utils import PostProcessingError
+
+
+class MovePP(PostProcessor):
+
+    def __init__(self, downloader, destination):
+        super(MovePP, self).__init__(downloader)
+        self.destination = destination
+
+    def run(self, information):
+        source = os.path.abspath(information['filepath'])
+        destination = os.path.abspath(self.destination)
+        if not os.path.exists(source):
+            raise PostProcessingError('Source file not available')
+        if not os.path.exists(destination):
+            raise PostProcessingError('Destination not available')
+        self._downloader.to_screen(
+            '[exec] Moving %s to %s' % (source, destination))
+        shutil.move(source, destination)
+        return [], information


### PR DESCRIPTION
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This PR provides a post-processor that will easily move the completed files to a specific destination. Consider this use case
1. User uses a Raspberry Pi with limited storage as a head-less video downloader
2. User periodically backup Downloads folder to a NAS
3. Only completed videos should go into Downloads folder, else chances are there the backup script to be ran when downloading is going on, thus copying partial file and removing it from source

This PR, essentially solves point 3 of the above. The files are moved to the specified folder **only after its completion**. 

I understand that there may be already ways to do this, using a combination of options. But, this seems to be a general use case. Also, this PR is created for scratching my personal itch, and I, being a FOSS enthusiast, believe in contributing back to the source. So, reviews/criticisms/rejections welcome. :)