### PR TITLE
Spiegel.de: support embedded spiegeltv content

### DIFF
--- a/youtube_dl/extractor/spiegel.py
+++ b/youtube_dl/extractor/spiegel.py
@@ -14,7 +14,7 @@ from ..utils import (
 
 
 class SpiegelIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?spiegel\.de/video/[^/]*-(?P<id>[0-9]+)(?:-embed|-iframe)?(?:\.html)?(?:#.*)?$'
+    _VALID_URL = r'https?://(?:www\.)?spiegel\.de/(?:video|sptv/spiegeltv)/[^/]*-(?P<id>[0-9]+)(?:-embed|-iframe)?(?:\.html)?(?:#.*)?$'
     _TESTS = [{
         'url': 'http://www.spiegel.de/video/vulkan-tungurahua-in-ecuador-ist-wieder-aktiv-video-1259285.html',
         'md5': '2c2754212136f35fb4b19767d242f66e',
@@ -48,6 +48,14 @@ class SpiegelIE(InfoExtractor):
             'upload_date': '20140904',
         }
     }, {
+        'url': 'http://www.spiegel.de/sptv/spiegeltv/spiegel-tv-ueber-russische-propaganda-a-1136559.html',
+        'info_dict': {
+            'id': 'putins-trollfabriken',
+            'ext': 'm4v',
+            'description': 'Propagandakrieg in den sozialen Medien',
+            'title': 'Putins Trollfabriken',
+        }
+    }, {
         'url': 'http://www.spiegel.de/video/astronaut-alexander-gerst-von-der-iss-station-beantwortet-fragen-video-1519126-iframe.html',
         'only_matching': True,
     }]
@@ -55,10 +63,13 @@ class SpiegelIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage, handle = self._download_webpage_handle(url, video_id)
+        webpage_url = handle.geturl()
+        if 'spiegel.de/sptv/' in webpage_url:
+            webpage_url = self._search_regex(r'<iframe[^>]+src="([^"]+spiegel.tv/[^"]+)"[^>]+></iframe>', webpage, 'embedded iframe')
 
         # 302 to spiegel.tv, like http://www.spiegel.de/video/der-film-zum-wochenende-die-wahrheit-ueber-maenner-video-99003272.html
-        if SpiegeltvIE.suitable(handle.geturl()):
-            return self.url_result(handle.geturl(), 'Spiegeltv')
+        if SpiegeltvIE.suitable(webpage_url):
+            return self.url_result(webpage_url, 'Spiegeltv')
 
         video_data = extract_attributes(self._search_regex(r'(<div[^>]+id="spVideoElements"[^>]+>)', webpage, 'video element', default=''))
 
@@ -103,7 +114,7 @@ class SpiegelIE(InfoExtractor):
 
 
 class SpiegelArticleIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?spiegel\.de/(?!video/)[^?#]*?-(?P<id>[0-9]+)\.html'
+    _VALID_URL = r'https?://(?:www\.)?spiegel\.de/(?!(?:video|sptv)/)[^?#]*?-(?P<id>[0-9]+)\.html'
     IE_NAME = 'Spiegel:Article'
     IE_DESC = 'Articles on spiegel.de'
     _TESTS = [{

--- a/youtube_dl/extractor/spiegeltv.py
+++ b/youtube_dl/extractor/spiegeltv.py
@@ -25,6 +25,19 @@ class SpiegeltvIE(InfoExtractor):
             'skip_download': True,
         }
     }, {
+        'url': 'http://www.spiegel.tv/filme/putins-trollfabriken/embed/?autoplay=true',
+        'info_dict': {
+            'id': 'putins-trollfabriken',
+            'ext': 'm4v',
+            'title': 'Putins Trollfabriken',
+            'description': 'Propagandakrieg in den sozialen Medien',
+            'thumbnail': r're:http://.*\.jpg$',
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        }
+    }, {
         'url': 'http://www.spiegel.tv/#/filme/alleskino-die-wahrheit-ueber-maenner/',
         'only_matching': True,
     }]
@@ -34,7 +47,10 @@ class SpiegeltvIE(InfoExtractor):
             url = url.replace('/#/', '/')
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
-        title = self._html_search_regex(r'<h1.*?>(.*?)</h1>', webpage, 'title')
+        if '/embed/' not in url:
+            title = self._html_search_regex(r'<h1.*?>(.*?)</h1>', webpage, 'title')
+        else:
+            title = self._html_search_regex(r'<title.*?>(.*?)(?:\s*\-\s* Embed)?</title>', webpage, 'title')
 
         apihost = 'http://spiegeltv-ivms2-restapi.s3.amazonaws.com'
         version_json = self._download_json(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

spiegel.de sometimes embeds content from spiegel.tv with URLs currently not supported by youtube-dl, for example http://www.spiegel.de/sptv/spiegeltv/spiegel-tv-ueber-russische-propaganda-a-1136559.html .

The first part of this pull request targets the Spiegeltv extractor so it ignores some stuff at the end of the embedding url (`/embed/?autoplay=true`).

The second commit enhances the Spiegel extractor so it can pass the embedding url to the Spiegeltv extractor. Part of that is also to ensure that SpiegelArticleIE does not match /sptv/ urls.

I have to say that I'm not really satisfied with the second commit as it feels clumsy to add all the exceptions for /sptv/ in path but in the end this might be just because the spiegel.de website/path structure is pretty complex.
