### PR TITLE
[external:ffmpeg] In test harness, Limit to 10k download size

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -270,6 +270,10 @@ class FFmpegFD(ExternalFD):
                 args += ['-rtmp_live', 'live']
 
         args += ['-i', url, '-c', 'copy']
+
+        if self.params.get('test', False):
+            args += ['-fs', compat_str(self._TEST_FILE_SIZE)] # -fs limit_size (output), expressed in bytes
+
         if protocol in ('m3u8', 'm3u8_native'):
             if self.params.get('hls_use_mpegts', False) or tmpfilename == '-':
                 args += ['-f', 'mpegts']


### PR DESCRIPTION
Otherwise, if you screw up a playlist test by including a playlist
dictionary key, you'll be there for eons while it downloads all the
files before erroring out.

Other downloaders check for running under the test harness and enforce a 10k limit.

Found while working on  #12361, where this test:

```
    _TEST = {
        'url': 'http://www.cbs.com/shows/the-late-show-with-stephen-colbert',
        'info_dict': {
            'id': 61456254,
            'title': 'The Late Show with Stephen Colbert',
        },
        'playlist_mincount': 14,
        # If uncommented, the test harness tries to download all 30 playlist entries.
        # Even limited to 10KB each, this can take 15 minutes. Not reasonable.
        'playlist': [{
            'info_dict': {
                'id': 'xxx',
                'ext': 'xxx.mp4',
                },
        }],
    }
```

would download hours and hours of video before erroring out (or maybe succeeding).
