### PR TITLE
[nbc] Support SNL videos that need ?snl=0

### DIFF
--- a/youtube_dl/extractor/nbc.py
+++ b/youtube_dl/extractor/nbc.py
@@ -119,14 +119,14 @@ class NBCIE(AdobePassIE):
         # it load the page with ?snl=1 and then with ?snl=0.
         # Emulate that, but shortcircuit straight to ?snl=0.
         urlmeta = self._html_search_meta(
-            ['al:ios:url','al:android:url', 'twitter:app:url:googleplay'],
+            ['al:ios:url', 'al:android:url', 'twitter:app:url:googleplay'],
             webpage)
-        if urlmeta and urlmeta.startswith('nbcsnl://') and \
-           compat_parse_qs(parsed_url.query).get('snl') != 0:
-               url = update_url_query(url, { 'snl': 0})
-               parsed_url = compat_urllib_parse_urlparse(url)
-               webpage = self._download_webpage(url, video_id)
-            
+        if (urlmeta and urlmeta.startswith('nbcsnl://') and
+                compat_parse_qs(parsed_url.query).get('snl') != 0):
+            url = update_url_query(url, {'snl': 0})
+            parsed_url = compat_urllib_parse_urlparse(url)
+            webpage = self._download_webpage(url, video_id)
+
         video_data = None
         preload = self._search_regex(
             r'PRELOAD\s*=\s*({.+})', webpage, 'preload data', default=None)

--- a/youtube_dl/extractor/nbc.py
+++ b/youtube_dl/extractor/nbc.py
@@ -116,8 +116,8 @@ class NBCIE(AdobePassIE):
         # http://www.nbc.com/generetic/generated/generetic-responsive.js?v2.31.26
         # does the following in browers: if the page is Saturday Night
         # Live (snl), check for the query parameter ?snl=0; If absent,
-        # it load the page with ?snl=1 and then with ?snl=0.
-        # Emulate that, but shortcircuit straight to ?snl=0.
+        # it loads the page with ?snl=1 and then with ?snl=0.
+        # Emulate that, but shortcut straight to ?snl=0.
         urlmeta = self._html_search_meta(
             ['al:ios:url', 'al:android:url', 'twitter:app:url:googleplay'],
             webpage)


### PR DESCRIPTION
- [x] Bug fix

Currently http://www.nbc.com/saturday-night-live links to various clips with normal-looking links that don't work in youtube-dl:

```
$ youtube-dl -v 'http://www.nbc.com/saturday-night-live/video/snl-host-octavia-spencer-finds-studio-8h/3477499' 
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'-v', u'http://www.nbc.com/saturday-night-live/video/snl-host-octavia-spencer-finds-studio-8h/3477499']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2017.03.05
[debug] Python version 2.7.10 - Darwin-14.5.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg git-2017-02-28-7f62368, ffprobe git-2017-02-28-7f62368, rtmpdump 2.4
[debug] Proxy map: {}
[NBC] 3477499: Downloading webpage
ERROR: Unable to extract theplatform url; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 761, in extract_info
    ie_result = ie.extract(url)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 427, in extract
    ie_result = self._real_extract(url)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/nbc.py", line 139, in _real_extract
    webpage, 'theplatform url').replace('_no_endcard', '').replace('\\/', '/')))
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 768, in _html_search_regex
    res = self._search_regex(pattern, string, name, default, fatal, flags, group)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 759, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
RegexNotFoundError: Unable to extract theplatform url; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

Apparently this is because the after following the link in a browser, it returns an intermediate page with JS that checks to see if `?snl=1` is in the URL query string, and if not reloads the page with `?snl=1`, and then again with `?snl=0`.

See http://www.nbc.com/generetic/generated/generetic-responsive.js?v2.31.26 unminified as:
```js
    if ("saturday-night-live" === e.params.showAlias && (0, l["default"])(e, "location.state.isClip"))

    {
        var r = !!parseInt((0, l["default"])(e, "location.query.snl") || "1", 10);

        if (r && "undefined" != typeof window) {
            var i = e.location.pathname + "?snl=1";
            return c["default"].log("Forcingpage refresh", i), void(window.location = i)
        }

    }
```

So this code tries to determine if is an SNL video by checking for any of
```html
<meta property="al:ios:url" content="nbcsnl://video/undefined">
<meta property="al:android:url" content="nbcsnl://video/undefined">
<meta name="twitter:app:url:googleplay" content="nbcsnl://video/undefined">
```
and if so, if `?snl=0` is not already present, adding it and re-trieving the page.

I don't see a particularly less cumbersome way to handle this. I hope this is not too fragile, and in any event should be no worse than before.

Oh, and with a test. Does download/external.py not calculate checksums for ffmpeg? 'md5' generated a test error for me so I omit it.