### PR TITLE
[telequebec] description array may be empty

### DIFF
--- a/youtube_dl/extractor/telequebec.py
+++ b/youtube_dl/extractor/telequebec.py
@@ -33,7 +33,7 @@ class TeleQuebecIE(InfoExtractor):
             'id': media_id,
             'url': smuggle_url('limelight:media:' + media_data['streamInfo']['sourceId'], {'geo_countries': ['CA']}),
             'title': media_data['title'],
-            'description': media_data.get('descriptions', [{'text': None}])[0].get('text') if media_data.get('descriptions') else ''
+            'description': media_data.get('descriptions', [{'text': None}])[0].get('text') if media_data.get('descriptions') else '',
             'duration': int_or_none(media_data.get('durationInMilliseconds'), 1000),
             'ie_key': 'LimelightMedia',
         }

--- a/youtube_dl/extractor/telequebec.py
+++ b/youtube_dl/extractor/telequebec.py
@@ -33,7 +33,7 @@ class TeleQuebecIE(InfoExtractor):
             'id': media_id,
             'url': smuggle_url('limelight:media:' + media_data['streamInfo']['sourceId'], {'geo_countries': ['CA']}),
             'title': media_data['title'],
-            'description': media_data.get('descriptions', [{'text': None}])[0].get('text'),
+            'description': media_data.get('descriptions', [{'text': None}])[0].get('text') if media_data.get('descriptions') else ''
             'duration': int_or_none(media_data.get('durationInMilliseconds'), 1000),
             'ie_key': 'LimelightMedia',
         }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some telequebec videos do not contain any description metadata. In this case, the downloaded json reports an empty array which crashes the extractor on line 36.

Behavior can be reproduced with this video: http://zonevideo.telequebec.tv/media/30261