### PR TITLE
[test_download] print additional IEs in summary output

### DIFF
--- a/test/test_download.py
+++ b/test/test_download.py
@@ -71,6 +71,18 @@ class TestDownload(unittest.TestCase):
 
     maxDiff = None
 
+    def __str__(self):
+        """Identify each test with the `add_ie` attribute, if available."""
+
+        def strclass(cls):
+            """From 2.7's unittest; 2.6 had _strclass so we can't import it."""
+            return '%s.%s' % (cls.__module__, cls.__name__)
+
+        add_ie = getattr(self, self._testMethodName).add_ie
+        return '%s (%s)%s:' % (self._testMethodName,
+                               strclass(self.__class__),
+                               ' [%s]' % add_ie if add_ie else '')
+
     def setUp(self):
         self.defs = defs
 
@@ -233,6 +245,8 @@ for n, test_case in enumerate(defs):
         i += 1
     test_method = generator(test_case, tname)
     test_method.__name__ = str(tname)
+    ie_list = test_case.get('add_ie')
+    test_method.add_ie = ie_list and ','.join(ie_list)
     setattr(TestDownload, test_method.__name__, test_method)
     del test_method
 


### PR DESCRIPTION
It's rather inconvenient that the test run Travis uses gives output like this:

```
test_Generic (test.test_download.TestDownload) ... ok
test_Generic_1 (test.test_download.TestDownload) ... ok
test_Generic_10 (test.test_download.TestDownload) ... ok
test_GameSpot_1 (test.test_download.TestDownload) ... ok
test_Generic_100 (test.test_download.TestDownload) ... ERROR
test_Gazeta_1 (test.test_download.TestDownload) ... FAIL
test_Generic_103 (test.test_download.TestDownload) ... FAIL
test_Generic_101 (test.test_download.TestDownload) ... ok
test_Generic_104 (test.test_download.TestDownload) ... ok
test_Generic_106 (test.test_download.TestDownload) ... ok
test_Generic_102 (test.test_download.TestDownload) ... ERROR
```

This patch changes the test identifer to include the `add_ie` test parameter, if given, so you can tell which extractor the test author intended to be used (if specified):

```
test_Generic (test.test_download.TestDownload):  ... ok
test_Generic_1 (test.test_download.TestDownload):  ... ok
test_Generic_10 (test.test_download.TestDownload):  ... ok
test_Generic_100 (test.test_download.TestDownload) [Vbox7]: ... ERROR
test_Generic_101 (test.test_download.TestDownload):  ... FAIL
test_Generic_102 (test.test_download.TestDownload):  ... ok
test_Generic_103 (test.test_download.TestDownload) [TwentyMinuten]: ... ok
test_Generic_104 (test.test_download.TestDownload) [VideoPress]: ... ok
test_Generic_105 (test.test_download.TestDownload) [Rutube]: ... ok
test_Generic_11 (test.test_download.TestDownload):  ... ok
test_Generic_12 (test.test_download.TestDownload):  ... ok
```

Of course it relies on the `add_ie` key being specified in the test, e.g.:

```
        {
            'url': 'http://nova.bg/news/view/2016/08/16/156543/%D0%BD%D0%B0-%D0%BA%D0%BE%D1%81%D1%8A%D0%BC-%D0%BE%D1%82-%D0%B2%D0%B7%D1%80%D0%B8%D0%B2-%D0%BE%D1%82%D1%86%D0%B5%D0%BF%D0%B8%D1%85%D0%B0-%D1%86%D1%8F%D0%BB-%D0%BA%D0%B2%D0%B0%D1%80%D1%82%D0%B0%D0%BB-%D0%B7%D0%B0%D1%80%D0%B0%D0%B4%D0%B8-%D0%B8%D0%B7%D1%82%D0%B8%D1%87%D0%B0%D0%BD%D0%B5-%D0%BD%D0%B0-%D0%B3%D0%B0%D0%B7-%D0%B2-%D0%BF%D0%BB%D0%BE%D0%B2%D0%B4%D0%B8%D0%B2/',
            'info_dict': {
                'id': '1c7141f46c',
                'ext': 'mp4',
                'title': 'НА КОСЪМ ОТ ВЗРИВ: Изтичане на газ на бензиностанция в Пловдив',
            },
            'params': {
                'skip_download': True,
            },
            'add_ie': [Vbox7IE.ie_key()],
        },
```

So it's not perfect, and it may lead to additional commits that add `add_ie` keys to tests.
But it certainly makes it much easier to have a clue what test is failing without a lot of annoying digging.

Also, I have to say, it took me _way too long_ digging in the unittest framework to figure out where and how to display this. I want my life back.