### PR TITLE
Raise exception if jwplayer doesn't have "sources"

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -2243,7 +2243,12 @@ class InfoExtractor(object):
                                 m3u8_id=None, mpd_id=None, rtmp_params=None, base_url=None):
         formats = []
         for source in jwplayer_sources_data:
-            source_url = self._proto_relative_url(source['file'])
+            try:
+                source_file = source['file']
+            except Exception as e:
+                raise ExtractorError("Could not retreive 'file' from 'source'",
+                                     expected=True, cause=e, video_id=video_id)
+            source_url = self._proto_relative_url(source_file)
             if base_url:
                 source_url = compat_urlparse.urljoin(base_url, source_url)
             source_type = source.get('type') or ''


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

YoutubeDL uses a regexp in common.py::_find_jwplayer_data to find the jwplayer options. However the options are found in a javascript function. For example the regexp might match this

    jwplayer('some_string').setup({
        /** Other attributes */
        sources: {
             file: "<url of video>",
             label: "<title of video>",
             type: "mp4"
        }
    });

Since this a valid javascript function, some websites write the options as

    var src = {
        file: "<url of video>",
        label: "<title of video>",
        type: "mp4"
    }
    jwplayer('some_string').setup({
        /** Other attributes */
        sources: src
    });

In this case YoutubeDL won't be able to retrieve sources.file, since the regexp only matches the `.setup(...)` and ignores the `var src = ...` assignment.

This commit makes YoutubeDL raise an ExtractorError in the above case. YoutubeDL will then try alternative methods to retrieve the URL of the video.

This bug is similar to https://github.com/rg3/youtube-dl/pull/12307 . In #12307 The entire `.setup(...)` dict has been extracted into a variable in this bug only the `sources` field has been extracted.