### PR TITLE
[adobepass] Add Playstation Vue login

### DIFF
--- a/youtube_dl/extractor/adobepass.py
+++ b/youtube_dl/extractor/adobepass.py
@@ -1486,6 +1486,12 @@ class AdobePassIE(InfoExtractor):
                             'Content-Type': 'application/x-www-form-urlencoded'
                         })
                 else:
+                    provider_redirect_page, urlh = provider_redirect_page_res
+                    if '<body onload="document.loginform.submit()">' in provider_redirect_page:
+                        provider_login_page_res = post_form(
+                            provider_redirect_page_res, 'Downloading Provider Login Page')
+                    else:
+                        provider_login_page_res = provider_redirect_page_res
                     provider_login_page_res = process_redirects(
                         provider_redirect_page_res, video_id, 'Downloading Provider Login Page')
                     mvpd_confirm_page_res = post_form(provider_login_page_res, 'Logging in', {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Adding support for Playstation Vue logins and hopefully any MSO that's added to the dict.  Fixes #11878.

```
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['http://www.fox.com/watch/911715395559', '--ap-mso', 'sony_auth-gateway_net', '--ap-username', 'PRIVATE', '--ap-password', 'PRIVATE', '-o', 'C:\\Users\\Greg\\Videos\\%(title)s.%(ext)s', '--test', '-v']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8, pref cp1252
[debug] youtube-dl version 2017.04.03
[debug] Python version 3.6.1 - Windows-10-10.0.14393-SP0
[debug] exe versions: ffmpeg 3.2.4, ffprobe 3.2.4, rtmpdump 2.3
[debug] Proxy map: {}
[FOX] 911715395559: Downloading webpage
[FOX] 911715395559: Downloading Provider Redirect Page
[FOX] 911715395559: Downloading Provider Login Page
[FOX] 911715395559: Downloading Provider Login Page
[FOX] 911715395559: Downloading Provider Login Page
[FOX] 911715395559: Logging in
[FOX] 911715395559: Logging in
[FOX] 911715395559: Logging in
[FOX] 911715395559: Confirming Login
[FOX] 911715395559: Confirming Login
[FOX] 911715395559: Confirming Login
[FOX] 911715395559: Confirming Login
[FOX] 911715395559: Retrieving Session
[FOX] 911715395559: Retrieving Authorization Token
[FOX] 911715395559: Retrieving Media Token
[ThePlatform] G3aA1RN7K8oK: Downloading SMIL data
[ThePlatform] G3aA1RN7K8oK: Checking video URL
[ThePlatform] G3aA1RN7K8oK: Checking video URL
[ThePlatform] G3aA1RN7K8oK: Checking video URL
[ThePlatform] G3aA1RN7K8oK: Checking video URL
[ThePlatform] G3aA1RN7K8oK: Checking video URL
[ThePlatform] G3aA1RN7K8oK: Checking video URL
[ThePlatform] G3aA1RN7K8oK: Checking video URL
[ThePlatform] G3aA1RN7K8oK: Checking video URL
[ThePlatform] G3aA1RN7K8oK: Downloading JSON metadata
[debug] Invoking downloader on 'http://dlv.fox.com/Fox.com/403/395/TheSimpsons_WABF12_911722563561_mp4_video_1280x720_2500000_primary_audio_8.mp4?__gda__=1491313556_7644c0d32de7a1dcefa8a394959f6764'
[download] Destination: C:\Users\Greg\Videos\Caper Chase.mp4
[download] 100% of 10.00KiB in 00:00
```