### PR TITLE
[ceskatelevize] Fix initial url replace()s

### DIFF
--- a/youtube_dl/extractor/ceskatelevize.py
+++ b/youtube_dl/extractor/ceskatelevize.py
@@ -92,10 +92,11 @@ class CeskaTelevizeIE(InfoExtractor):
     }]
 
     def _real_extract(self, url):
-        url = url.replace('/porady/', '/ivysilani/').replace('/video/', '')
-
         mobj = re.match(self._VALID_URL, url)
         playlist_id = mobj.group('id')
+        
+        url = url.replace('/porady/', '/ivysilani/', 1)
+        url = url.replace('/video/', '/obsah/', 1)
 
         webpage = self._download_webpage(url, playlist_id)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Fixes: https://github.com/rg3/youtube-dl/issues/7411

Test cases:

```
From: http://www.ceskatelevize.cz/porady/1126666764-toulava-kamera/217562221500004
To:   http://www.ceskatelevize.cz/ivysilani/1126666764-toulava-kamera/217562221500004

From: http://www.ceskatelevize.cz/porady/1126666764-toulava-kamera/217562221500004/video/519429
To:   http://www.ceskatelevize.cz/ivysilani/1126666764-toulava-kamera/217562221500004/obsah/519429

From: http://www.ceskatelevize.cz/ivysilani/1126666764-toulava-kamera/217562221500004/obsah/519429-na-bezkach-po-ceskem-raji
To:   http://www.ceskatelevize.cz/ivysilani/1126666764-toulava-kamera/217562221500004/obsah/519429-na-bezkach-po-ceskem-raji
```
