### PR TITLE
[test_download] Improve diagnostic on wrong 'id'

### DIFF
--- a/test/test_download.py
+++ b/test/test_download.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from test.helper import (
     assertGreaterEqual,
     expect_warnings,
+    expect_value,
     get_params,
     gettestcases,
     expect_info_dict,
@@ -200,6 +201,7 @@ def generator(test_case, tname):
                     test_case['playlist_duration_sum'], got_duration)
 
             for tc in test_cases:
+                expect_value(self, res_dict['id'], tc['info_dict']['id'], 'id')
                 tc_filename = get_tc_filename(tc)
                 if not test_case.get('params', {}).get('skip_download', False):
                     self.assertTrue(os.path.exists(tc_filename), msg='Missing file ' + tc_filename)

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -152,7 +152,7 @@ def generator(test_case, tname):
             try_num = 1
             while True:
                 try:
-                    # We're not using .download here sine that is just a shim
+                    # We're not using .download here since that is just a shim
                     # for outside error handling, and returns the exit code
                     # instead of the result dict.
                     res_dict = ydl.extract_info(


### PR DESCRIPTION
As a relatively new contributor, I find it's easy to get confused when you write a test and don't specify the 'id' field correctly. E.g., if `id` is given as `1` instead of `1_1jc2y3e4`:

```
[download] Destination: test_Kaltura_1_1jc2y3e4.mp4
[download] 100% of 10.00KiB in 00:00
F
======================================================================
FAIL: test_Kaltura (__main__.TestDownload):
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_download.py", line 205, in test_template
    self.assertTrue(os.path.exists(tc_filename), msg='Missing file ' + tc_filename)
AssertionError: Missing file test_Kaltura_1.mp4
```

Whereas for most other fields, you get something much more intelligible:

```
Traceback (most recent call last):
  File "test/test_download.py", line 227, in test_template
    expect_info_dict(self, info_dict, tc.get('info_dict', {}))
  File "/Users/jhawk/src/youtube-dl/test/helper.py", line 177, in expect_info_dict
    expect_dict(self, got_dict, expected_dict)
  File "/Users/jhawk/src/youtube-dl/test/helper.py", line 173, in expect_dict
    expect_value(self, got, expected, info_field)
  File "/Users/jhawk/src/youtube-dl/test/helper.py", line 167, in expect_value
    'Invalid value for field %s, expected %r, got %r' % (field, expected, got))
AssertionError: Invalid value for field title, expected u'xStraight from the Heart', got u'Straight from the Heart'
```

So instead, I suggest checking 'id' explicitly to help out new contributors, giving us this:

```
Traceback (most recent call last):
  File "test/test_download.py", line 205, in test_template
    expect_value(self, res_dict['id'], tc['info_dict']['id'], 'id') # , 'Wrong id. Expected x got y')
  File "/Users/jhawk/src/youtube-dl/test/helper.py", line 167, in expect_value
    'Invalid value for field %s, expected %r, got %r' % (field, expected, got))
AssertionError: Invalid value for field id, expected u'1', got u'1_1jc2y3e4'
```

Thanks!

While we're here, fix a typo in a comment just before this section of the file.