### PR TITLE
[Generic] Youtube <object> embed

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -730,6 +730,21 @@ class GenericIE(InfoExtractor):
                 'skip_download': True,
             }
         },
+        # YouTube <object> embed
+        {
+            'url': 'http://www.improbable.com/2017/04/03/untrained-modern-youths-and-ancient-masters-in-selfie-portraits/',
+            'md5': '516718101ec834f74318df76259fb3cc',
+            'info_dict': {
+                'id': 'msN87y-iEx0',
+                'ext': 'webm',
+                'title': 'Feynman: Mirrors FUN TO IMAGINE 6',
+                'upload_date': '20080526',
+                'description': 'md5:0ffc78ea3f01b2e2c247d5f8d1d3c18d',
+                'uploader': 'Christopher Sykes',
+                'uploader_id': 'ChristopherJSykes',
+            },
+            'add_ie': ['Youtube'],
+        },
         # Camtasia studio
         {
             'url': 'http://www.ll.mit.edu/workshops/education/videocourses/antennas/lecture1/video/',
@@ -1938,6 +1953,7 @@ class GenericIE(InfoExtractor):
                 data-video-url=|
                 <embed[^>]+?src=|
                 embedSWF\(?:\s*|
+                <object[^>]+data=|
                 new\s+SWFObject\(
             )
             (["\'])


### PR DESCRIPTION
Fixes #12637. Trivial.

**BUT** something is wrong with the #12680 test harness corrections, with or without the additional 80b2fdf9ac99ebcbd6eec87670aa6d646da7dac4 fixup.

```
pb3:extractor jhawk$ python ../../test/test_download.py -v TestDownload.test_Generic_44
test_Generic_44 (__main__.TestDownload) [Youtube]: ... [generic] untrained-modern-youths-and-ancient-masters-in-selfie-portraits: Requesting header
[generic] untrained-modern-youths-and-ancient-masters-in-selfie-portraits: Downloading webpage
[generic] untrained-modern-youths-and-ancient-masters-in-selfie-portraits: Extracting information
[download] Downloading playlist: Improbable Research » Blog Archive
[generic] playlist Improbable Research » Blog Archive: Collected 1 video ids (downloading 1 of them)
[download] Downloading video 1 of 1
[youtube] msN87y-iEx0: Downloading webpage
[youtube] msN87y-iEx0: Downloading video info webpage
[youtube] msN87y-iEx0: Extracting video information
[youtube] msN87y-iEx0: Downloading MPD manifest
[info] Writing video description metadata as JSON to: test_Generic_44_msN87y-iEx0.info.json
[debug] Invoking downloader on u'https://r6---sn-ab5l6n7k.googlevideo.com/videoplayback?mime=video%2Fwebm&pl=23&itag=43&gir=yes&ratebypass=yes&mm=31&mn=sn-ab5l6n7k&mt=1491780620&mv=m&ei=TMTqWLbaNcee8gTL4LmgCQ&ms=au&requiressl=yes&beids=%5B9466591%5D&key=yt6&ip=73.149.130.31&lmt=1298115043849867&dur=0.000&expire=1491802284&source=youtube&initcwndbps=902500&id=o-ACwibrJ-9KD98vcNo0qB3r4Ip_fgp3ErMwBqGuG7f6m4&sparams=clen%2Cdur%2Cei%2Cgir%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cpl%2Cratebypass%2Crequiressl%2Csource%2Cupn%2Cexpire&ipbits=0&clen=7600202&upn=TtXTMlSBpyY&signature=A29EE684FA173FD27DB86197D939412F7FC040D2.6E6AC6699E6C3AFE74B697B97B891F56E82AFEEC'
[download] Destination: test_Generic_44_msN87y-iEx0.webm
[download] 100% of 10.00KiB in 00:00
[download] Finished downloading playlist: Improbable Research » Blog Archive
FAIL

======================================================================
FAIL: test_Generic_44 (__main__.TestDownload) [Youtube]:
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../../test/test_download.py", line 204, in test_template
    expect_info_dict(self, tc_res_dict, tc.get('info_dict', {}))
  File "/Users/jhawk/src/youtube-dl/test/helper.py", line 177, in expect_info_dict
    expect_dict(self, got_dict, expected_dict)
  File "/Users/jhawk/src/youtube-dl/test/helper.py", line 173, in expect_dict
    expect_value(self, got, expected, info_field)
  File "/Users/jhawk/src/youtube-dl/test/helper.py", line 167, in expect_value
    'Invalid value for field %s, expected %r, got %r' % (field, expected, got))
AssertionError: Invalid value for field ext, expected u'webm', got None

----------------------------------------------------------------------
Ran 1 test in 3.719s

FAILED (failures=1)
```

I don't understand what this means, and why it doesn't seem to affect any other similar tests that I could find. But reverting those commits makes the test work.