### PR TITLE
[xfileshare] Support gorillavid.*com* domain

### DIFF
--- a/youtube_dl/extractor/xfileshare.py
+++ b/youtube_dl/extractor/xfileshare.py
@@ -20,6 +20,7 @@ class XFileShareIE(InfoExtractor):
         ('daclips.in', 'DaClips'),
         ('filehoot.com', 'FileHoot'),
         ('gorillavid.in', 'GorillaVid'),
+        ('gorillavid.com', 'GorillaVid'),
         ('movpod.in', 'MovPod'),
         ('powerwatch.pw', 'PowerWatch'),
         ('rapidvideo.ws', 'Rapidvideo.ws'),
@@ -32,7 +33,7 @@ class XFileShareIE(InfoExtractor):
         ('vidlo.us', 'vidlo'),
     )
 
-    IE_DESC = 'XFileShare based sites: %s' % ', '.join(list(zip(*_SITES))[1])
+    IE_DESC = 'XFileShare based sites: %s' % ', '.join(sorted(set(list(zip(*_SITES))[1])))
     _VALID_URL = (r'https?://(?P<host>(?:www\.)?(?:%s))/(?:embed-)?(?P<id>[0-9a-zA-Z]+)'
                   % '|'.join(re.escape(site) for site in list(zip(*_SITES))[0]))
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Previously, only the gorillavid.in domain was supported.  gorillavid.com
redirects to gorillavid.in, but I have run across gorillavid.com links
in certain data from time to time.

I also sorted the names of the xfileshare sites to provide a consistent
order since I ran it through `set`.
