### PR TITLE
fix determine_ext helper to check in KNOWN_EXTENSION

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1209,7 +1209,7 @@ def determine_ext(url, default_ext='unknown_video'):
     if url is None:
         return default_ext
     guess = url.partition('?')[0].rpartition('.')[2]
-    if re.match(r'^[A-Za-z0-9]+$', guess):
+    if re.match(r'^[A-Za-z0-9]+$', guess) and guess in KNOWN_EXTENSIONS:
         return guess
     # Try extract ext from URLs like http://example.com/foo/bar.mp4/?download
     elif guess.rstrip('/') in KNOWN_EXTENSIONS:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

determine_ext helper dosen't check know extension and return script extension for url in format: //www.host.com/vod.php?code=1234 - helper returns php extension in that case