### PR TITLE
[vevo] fix extractor, update test cases

### DIFF
--- a/youtube_dl/extractor/vevo.py
+++ b/youtube_dl/extractor/vevo.py
@@ -158,12 +158,13 @@ class VevoIE(VevoBaseIE):
 
         uploader = None
         artist = None
-        featured_artist = None
+        featured_artists = []
         for curr_artist in artists:
             if curr_artist.get('role') == 'Featured':
-                featured_artist = curr_artist['name'] if featured_artist is None else '%s & %s' % (featured_artist, curr_artist['name'])
+                featured_artists.append(curr_artist['name'])
             else:
                 artist = uploader = curr_artist['name']
+        featured_artists.sort()
 
         formats = []
         for video_version in video_versions:
@@ -212,8 +213,8 @@ class VevoIE(VevoBaseIE):
         self._sort_formats(formats)
 
         track = meta['title']
-        if featured_artist:
-            artist = '%s ft. %s' % (artist, featured_artist)
+        if featured_artists:
+            artist = '%s ft. %s' % (artist, ' & '.join(featured_artists))
         title = '%s - %s' % (artist, track) if artist else track
 
         is_explicit = meta.get('explicit')

--- a/youtube_dl/extractor/vevo.py
+++ b/youtube_dl/extractor/vevo.py
@@ -152,7 +152,7 @@ class VevoIE(VevoBaseIE):
                 artists.append(value)
             elif key.startswith('%s.streamsV3.' % video_id):
                 video_versions.append(value)
-  
+
         if 'streams' in json_data.get('default', {}):
             video_versions = json_data['default']['streams'][video_id][0]
 
@@ -171,6 +171,8 @@ class VevoIE(VevoBaseIE):
             version = self._VERSIONS.get(video_version.get('version'), 'generic')
             version_url = video_version.get('url')
             if not version_url:
+                if video_version.get('errorCode') == 'video-not-viewable-in-country':
+                    raise self.raise_geo_restricted()
                 continue
 
             if '.ism' in version_url:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

It seems that Vevo no longer provides API that was used in previous version of extractor.

Vevo changed some publish dates (they are all earlier than before), some dates are missing. I couldn't find genre for any video so I removed it from test cases. They all just have `Music Video` category.

I also made use of `--no-playlist` in playlist extractor.

Fixes #12678.