### PR TITLE
Fix incorrect handling of cookiejars with '0' or empty 'expires'

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2186,7 +2186,13 @@ class YoutubeDL(object):
             self.cookiejar = compat_cookiejar.MozillaCookieJar(
                 opts_cookiefile)
             if os.access(opts_cookiefile, os.R_OK):
-                self.cookiejar.load()
+                self.cookiejar.load(ignore_discard=True, ignore_expires=True)
+                # Force CookieJar to treat 'expires=0' cookies as session/discard cookies
+                # Fixes https://bugs.python.org/issue17164
+                for cookie in self.cookiejar:
+                    if cookie.expires == 0:
+                        cookie.expires = None
+                        cookie.discard = True
 
         cookie_processor = YoutubeDLCookieProcessor(self.cookiejar)
         if opts_proxy is not None:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This fixes cookies not being sent by youtube-dl if the entry in the cookiejar has an 'expires' column set to either 0 or '' (empty). Both of these indicate that the cookie is a session cookie (expires only when the browser is closed). At least YouTube uses this type of cookie to store/send important session information. Previously, you would have to manually set the 'expires' column to some date in the distant future for all of these cookies in your cookiejar if you wanted youtube-dl to use them.

This is related to a Python bug https://bugs.python.org/issue17164 in MozillaCookieJar. 
Despite the `ignore_expires=True` line, truly expired cookies (`0 < expires_at <= current_time`) will not actually be sent -- urllib2/cookielib do not send cookies that are expired anyway. This just prevents the cookiejar library from prematurely discarding 'expires_at=0' cookies. 

Example of a cookie that would normally be sent:
`.youtube.com	TRUE	/	FALSE	1498715626	PREF	f1=50000000&hl=en`

Example of cookies that would not have been sent before (but should have been):
`.youtube.com	TRUE	/	FALSE	0	PREF	f1=50000000&hl=en`
`.youtube.com	TRUE	/	FALSE		PREF	f1=50000000&hl=en`