### PR TITLE
[Spiegel] Support embedded spiegel.tv links (fixes #13006)

### DIFF
--- a/youtube_dl/extractor/spiegel.py
+++ b/youtube_dl/extractor/spiegel.py
@@ -136,6 +136,13 @@ class SpiegelArticleIE(InfoExtractor):
                 self.http_scheme() + '//spiegel.de/', video_link)
             return self.url_result(video_url)
 
+        # Embedded Spiegel.tv link
+        video_link = self._search_regex(
+            r'<iframe[^>]+src="(.+?spiegel\.tv.*?)"', webpage,'video page URL', default=None)
+        if video_link:
+            video_url = video_link.replace('/embed/?autoplay=true', '')
+            return self.url_result(video_url)
+        
         # Multiple embedded videos
         embeds = re.findall(
             r'<div class="vid_holder[0-9]+.*?</div>\s*.*?url\s*=\s*"([^"]+)"',


### PR DESCRIPTION
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Improvement

---

### Description of your *pull request* and other information
Support embedded spiegel.tv links - Fixes https://github.com/rg3/youtube-dl/issues/13006

Sample link: http://www.spiegel.de/sptv/spiegeltv/spiegel-tv-ueber-schnellste-katapult-achterbahn-der-welt-taron-a-1137884.html
