### PR TITLE
[dvtv] Parse adaptive formats as well

### DIFF
--- a/youtube_dl/extractor/dvtv.py
+++ b/youtube_dl/extractor/dvtv.py
@@ -71,6 +71,14 @@ class DVTVIE(InfoExtractor):
     }, {
         'url': 'http://video.aktualne.cz/v-cechach-poprve-zazni-zelenkova-zrestaurovana-mse/r~45b4b00483ec11e4883b002590604f2e/',
         'only_matching': True,
+    }, {
+        'url': 'https://video.aktualne.cz/dvtv/zeman-si-jen-leci-mindraky-sobotku-nenavidi-a-babis-se-mu-te/r~960cdb3a365a11e7a83b0025900fea04/',
+        'md5': 'f8efe9656017da948369aa099788c8ea',
+        'info_dict': {
+            'id': '3c496fec365911e7a6500025900fea04',
+            'ext': 'm3u8',
+            'title': 'Zeman si jen léčí mindráky, Sobotku nenávidí a Babiš se mu teď hodí, tvrdí Kmenta',
+        }
     }]
 
     def _parse_video_metadata(self, js, video_id):
@@ -79,13 +87,22 @@ class DVTVIE(InfoExtractor):
         formats = []
         for video in metadata['sources']:
             ext = video['type'][6:]
-            formats.append({
-                'url': video['file'],
-                'ext': ext,
-                'format_id': '%s-%s' % (ext, video['label']),
-                'height': int(video['label'].rstrip('p')),
-                'fps': 25,
-            })
+            if video['label'] != 'adaptive':
+                formats.append({
+                    'url': video['file'],
+                    'ext': ext,
+                    'format_id': '%s-%s' % (ext, video['label']),
+                    'height': int(video['label'].rstrip('p')),
+                    'fps': 25,
+                })
+            elif video['type'] == 'application/dash+xml':
+                formats.extend(self._extract_mpd_formats(video['file'],
+                                                         video_id,
+                                                         fatal=False))
+            elif video['type'] == 'application/vnd.apple.mpegurl':
+                formats.extend(self._extract_m3u8_formats(video['file'],
+                                                          video_id,
+                                                          fatal=False))
 
         self._sort_formats(formats)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The old code hit an error when it attempted to parse the string ``adaptive`` for video height. Actually parsing the returned playlists is a good idea because it adds more output formats, including some audio-only-ones.