### PR TITLE
add playlist-skip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                      downloaded videos in it.
     --include-ads                    Download advertisements as well
                                      (experimental)
+    --playlist-skip                  Skip over playlist items that fail to
+                                     download.
 
 ## Download Options:
     -r, --limit-rate RATE            Maximum download rate in bytes per second

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -164,6 +164,7 @@ class YoutubeDL(object):
     playlist_items:    Specific indices of playlist to download.
     playlistreverse:   Download playlist items in reverse order.
     playlistrandom:    Download playlist items in random order.
+    playlistskip:      Skip over playlist items that fail to download.
     matchtitle:        Download only matching titles.
     rejecttitle:       Reject downloads for matching titles.
     logger:            Log messages to a logging.Logger instance.
@@ -957,9 +958,16 @@ class YoutubeDL(object):
                     self.to_screen('[download] ' + reason)
                     continue
 
-                entry_result = self.process_ie_result(entry,
-                                                      download=download,
-                                                      extra_info=extra)
+                try:
+                    entry_result = self.process_ie_result(entry,
+                                                          download=download,
+                                                          extra_info=extra)
+                except DownloadError:
+                    if self.params.get('playlistskip'):
+                        continue
+                    else:
+                        raise
+
                 playlist_results.append(entry_result)
             ie_result['entries'] = playlist_results
             self.to_screen('[download] Finished downloading playlist: %s' % playlist)

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -353,6 +353,7 @@ def _real_main(argv=None):
         'playlistend': opts.playlistend,
         'playlistreverse': opts.playlist_reverse,
         'playlistrandom': opts.playlist_random,
+        'playlistskip': opts.playlist_skip,
         'noplaylist': opts.noplaylist,
         'logtostderr': opts.outtmpl == '-',
         'consoletitle': opts.consoletitle,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -492,6 +492,10 @@ def parseOpts(overrideArguments=None):
         '--playlist-random',
         action='store_true',
         help='Download playlist videos in random order')
+    selection.add_option(
+        '--playlist-skip',
+        action='store_true',
+        help='Skip over playlist items that fail to download.')
     downloader.add_option(
         '--xattr-set-filesize',
         dest='xattr_set_filesize', action='store_true',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

When any item from a playlist is unavailable, youtube-dl stops altogether. I added an option `--playlist-skip` that will simply report the error, but continue downloading subsequent items.

I was not sure where to add tests for this. If you can point me in the right direction, I would happily add them.