### PR TITLE
[ESPN] Include additional URL formats (fixes issue #13244)

### DIFF
--- a/youtube_dl/extractor/espn.py
+++ b/youtube_dl/extractor/espn.py
@@ -17,8 +17,14 @@ class ESPNIE(InfoExtractor):
                             (?:www\.)?espn
                         )\.com/
                         (?:
-                            video/clip(?:\?.*?\bid=|/_/id/)|
-                            watch/player(?:\?.*?\bid=|/_/id/)
+                            (?:
+                                video/clip|
+                                watch/player
+                            )
+                            (?:
+                                \?.*?\bid=|
+                                /_/id/
+                            )
                         )
                         (?P<id>\d+)
                     '''

--- a/youtube_dl/extractor/espn.py
+++ b/youtube_dl/extractor/espn.py
@@ -18,7 +18,7 @@ class ESPNIE(InfoExtractor):
                         )\.com/
                         (?:
                             video/clip(?:\?.*?\bid=|/_/id/)|
-                            watch/player\?.*?\bid=
+                            watch/player(?:\?.*?\bid=|/_/id/)
                         )
                         (?P<id>\d+)
                     '''
@@ -61,6 +61,9 @@ class ESPNIE(InfoExtractor):
         'only_matching': True,
     }, {
         'url': 'http://www.espn.com/watch/player?bucketId=257&id=19505875',
+        'only_matching': True,
+    }, {
+        'url': 'http://www.espn.com/watch/player/_/id/19141491',
         'only_matching': True,
     }, {
         'url': 'http://www.espn.com/video/clip?id=10365079',

--- a/youtube_dl/extractor/espn.py
+++ b/youtube_dl/extractor/espn.py
@@ -10,7 +10,7 @@ from ..utils import (
 
 
 class ESPNIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:espn\.go|(?:www\.)?espn)\.com/video/clip(?:\?.*?\bid=|/_/id/)(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:(?:(\w+\.)+)?espn\.go|(?:www\.)?espn)\.com/(?:video/clip(?:\?.*?\bid=|/_/id/)|watch/player\?.*?\bid=)(?P<id>\d+)'
     _TESTS = [{
         'url': 'http://espn.go.com/video/clip?id=10365079',
         'info_dict': {

--- a/youtube_dl/extractor/espn.py
+++ b/youtube_dl/extractor/espn.py
@@ -25,15 +25,70 @@ class ESPNIE(InfoExtractor):
             'skip_download': True,
         },
     }, {
-        # intl video, from http://www.espnfc.us/video/mls-highlights/150/video/2743663/must-see-moments-best-of-the-mls-season
-        'url': 'http://espn.go.com/video/clip?id=2743663',
+        'url': 'https://broadband.espn.go.com/video/clip?id=18910086',
         'info_dict': {
-            'id': '2743663',
+            'id': '18910086',
             'ext': 'mp4',
-            'title': 'Must-See Moments: Best of the MLS season',
-            'description': 'md5:4c2d7232beaea572632bec41004f0aeb',
-            'timestamp': 1449446454,
-            'upload_date': '20151207',
+            'title': 'Kyrie spins around defender for two',
+            'description': 'md5:2b0f5bae9616d26fba8808350f0d2b9b',
+            'timestamp': 1489539155,
+            'upload_date': '20170315',
+        },
+        'params': {
+            'skip_download': True,
+        },
+        'expected_warnings': ['Unable to download f4m manifest'],
+    }, {
+        'url': 'http://nonredline.sports.espn.go.com/video/clip?id=19744672',
+        'info_dict': {
+            'id': '19744672',
+            'ext': 'mp4',
+            'title': 'Aggies use 2016 season as motivation',
+            'description': 'md5:2fe30038633f86408a184ec676c5fdac',
+            'timestamp': 1498519201,
+            'upload_date': '20170626',
+        },
+        'params': {
+            'skip_download': True,
+        },
+        'expected_warnings': ['Unable to download f4m manifest'],
+    }, {
+        'url': 'https://cdn.espn.go.com/video/clip/_/id/19771774',
+        'info_dict': {
+            'id': '19771774',
+            'ext': 'mp4',
+            'title': 'Coach Cal to the Knicks? Not so fast',
+            'description': 'md5:a60393eaee9c203dd4184c48c308651b',
+            'timestamp': 1498806684,
+            'upload_date': '20170630',
+        },
+        'params': {
+            'skip_download': True,
+        },
+        'expected_warnings': ['Unable to download f4m manifest'],
+    }, {
+        'url': 'http://www.espn.com/watch/player?id=19141491',
+        'info_dict': {
+            'id': '19141491',
+            'ext': 'mp4',
+            'title': 'Stephen A.: Lynch was wrong for slapping phone out of fan\'s hand',
+            'description': 'md5:9b31cf7b31e85c6dfcdefd11571e6c8e',
+            'timestamp': 1492011670,
+            'upload_date': '20170412',
+        },
+        'params': {
+            'skip_download': True,
+        },
+        'expected_warnings': ['Unable to download f4m manifest'],
+    }, {
+        'url': 'http://www.espn.com/watch/player?bucketId=257&id=19505875',
+        'info_dict': {
+            'id': '19505875',
+            'ext': 'mp4',
+            'title': 'Six-year-old Fuller nails first word at Spelling Bee',
+            'description': 'md5:f90babb45b196d7c8ca1d295bb68e36a',
+            'timestamp': 1496252167,
+            'upload_date': '20170531',
         },
         'params': {
             'skip_download': True,

--- a/youtube_dl/extractor/espn.py
+++ b/youtube_dl/extractor/espn.py
@@ -10,7 +10,19 @@ from ..utils import (
 
 
 class ESPNIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:(?:(\w+\.)+)?espn\.go|(?:www\.)?espn)\.com/(?:video/clip(?:\?.*?\bid=|/_/id/)|watch/player\?.*?\bid=)(?P<id>\d+)'
+    _VALID_URL = r'''(?x)
+                    https?://
+                        (?:
+                            (?:(?:\w+\.)+)?espn\.go|
+                            (?:www\.)?espn
+                        )\.com/
+                        (?:
+                            video/clip(?:\?.*?\bid=|/_/id/)|
+                            watch/player\?.*?\bid=
+                        )
+                        (?P<id>\d+)
+                    '''
+
     _TESTS = [{
         'url': 'http://espn.go.com/video/clip?id=10365079',
         'info_dict': {
@@ -40,60 +52,16 @@ class ESPNIE(InfoExtractor):
         'expected_warnings': ['Unable to download f4m manifest'],
     }, {
         'url': 'http://nonredline.sports.espn.go.com/video/clip?id=19744672',
-        'info_dict': {
-            'id': '19744672',
-            'ext': 'mp4',
-            'title': 'Aggies use 2016 season as motivation',
-            'description': 'md5:2fe30038633f86408a184ec676c5fdac',
-            'timestamp': 1498519201,
-            'upload_date': '20170626',
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'expected_warnings': ['Unable to download f4m manifest'],
+        'only_matching': True,
     }, {
         'url': 'https://cdn.espn.go.com/video/clip/_/id/19771774',
-        'info_dict': {
-            'id': '19771774',
-            'ext': 'mp4',
-            'title': 'Coach Cal to the Knicks? Not so fast',
-            'description': 'md5:a60393eaee9c203dd4184c48c308651b',
-            'timestamp': 1498806684,
-            'upload_date': '20170630',
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'expected_warnings': ['Unable to download f4m manifest'],
+        'only_matching': True,
     }, {
         'url': 'http://www.espn.com/watch/player?id=19141491',
-        'info_dict': {
-            'id': '19141491',
-            'ext': 'mp4',
-            'title': 'Stephen A.: Lynch was wrong for slapping phone out of fan\'s hand',
-            'description': 'md5:9b31cf7b31e85c6dfcdefd11571e6c8e',
-            'timestamp': 1492011670,
-            'upload_date': '20170412',
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'expected_warnings': ['Unable to download f4m manifest'],
+        'only_matching': True,
     }, {
         'url': 'http://www.espn.com/watch/player?bucketId=257&id=19505875',
-        'info_dict': {
-            'id': '19505875',
-            'ext': 'mp4',
-            'title': 'Six-year-old Fuller nails first word at Spelling Bee',
-            'description': 'md5:f90babb45b196d7c8ca1d295bb68e36a',
-            'timestamp': 1496252167,
-            'upload_date': '20170531',
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'expected_warnings': ['Unable to download f4m manifest'],
+        'only_matching': True,
     }, {
         'url': 'http://www.espn.com/video/clip?id=10365079',
         'only_matching': True,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [ x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

Updated the regex for the [ESPN] extractor to include additional URL formats for videos featured on the site - issue #13244.

Cheers,

Parmjit V.