### PR TITLE
Always truncate files to 10241 bytes with --test

### DIFF
--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -358,7 +358,14 @@ class FileDownloader(object):
                     else '%.2f' % sleep_interval))
             time.sleep(sleep_interval)
 
-        return self.real_download(filename, info_dict)
+        real_download_result = self.real_download(filename, info_dict)
+
+        if real_download_result and self.params.get('test', False):
+            f = open(filename, 'ab')
+            f.truncate(self._TEST_FILE_SIZE)
+            f.close()
+
+        return real_download_result
 
     def real_download(self, filename, info_dict):
         """Real download process. Redefine in subclasses."""


### PR DESCRIPTION
This should prevent issues like that in #13449 where the FFmpeg
downloader was not reliably trimming to the correct length.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Always truncate files to 10241 bytes with --test. This should prevent issues like that in #13449 where the FFmpeg downloader was not reliably trimming to the correct length.
