### PR TITLE
[vlive:playlist] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1203,6 +1203,7 @@ from .vk import (
     VKWallPostIE,
 )
 from .vlive import (
+    VLivePlaylistIE,
     VLiveIE,
     VLiveChannelIE
 )

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1203,9 +1203,9 @@ from .vk import (
     VKWallPostIE,
 )
 from .vlive import (
-    VLivePlaylistIE,
     VLiveIE,
-    VLiveChannelIE
+    VLiveChannelIE,
+    VLivePlaylistIE
 )
 from .vodlocker import VodlockerIE
 from .vodpl import VODPlIE

--- a/youtube_dl/extractor/vlive.py
+++ b/youtube_dl/extractor/vlive.py
@@ -292,16 +292,16 @@ class VLivePlaylistIE(InfoExtractor):
         assert video_id_match
         video_id = compat_str(video_id_match.group('video_id'))
 
-        video_url_format = 'http://www.vlive.tv/video/%s'
+        VIDEO_URL_TEMPLATE = 'http://www.vlive.tv/video/%s'
         if self._downloader.params.get('noplaylist'):
             self.to_screen(
                 'Downloading just video %s because of --no-playlist' % video_id)
             return self.url_result(
-                video_url_format % video_id,
+                VIDEO_URL_TEMPLATE % video_id,
                 ie=VLiveIE.ie_key(), video_id=video_id)
-        else:
-            self.to_screen(
-                'Downloading playlist %s - add --no-playlist to just download video' % playlist_id)
+
+        self.to_screen(
+            'Downloading playlist %s - add --no-playlist to just download video' % playlist_id)
 
         webpage = self._download_webpage(
             'http://www.vlive.tv/video/%s/playlist/%s' % (video_id, playlist_id), video_id)
@@ -319,7 +319,7 @@ class VLivePlaylistIE(InfoExtractor):
             item_id = compat_str(item_id)
             entries.append(
                 self.url_result(
-                    video_url_format % item_id,
+                    VIDEO_URL_TEMPLATE % item_id,
                     ie=VLiveIE.ie_key(), video_id=item_id))
 
         return self.playlist_result(

--- a/youtube_dl/extractor/vlive.py
+++ b/youtube_dl/extractor/vlive.py
@@ -270,21 +270,14 @@ class VLiveChannelIE(InfoExtractor):
 class VLivePlaylistIE(InfoExtractor):
     IE_NAME = 'vlive:playlist'
     _VALID_URL = r'https?://(?:(?:www|m)\.)?vlive\.tv/video/(?P<video_id>[0-9]+)/playlist/(?P<id>[0-9]+)'
-    _TESTS = [{
-        'url': 'http://www.vlive.tv/video/30824/playlist/30826',
-        'info_dict': {
-            'id': '30826',
-            'title': 'TWICE TV5 - TWICE in SWITZERLAND'
-        },
-        'playlist_mincount': 20
-    }, {
+    _TEST = {
         'url': 'http://www.vlive.tv/video/22867/playlist/22912',
         'info_dict': {
             'id': '22912',
             'title': 'Valentine Day Message from TWICE'
         },
         'playlist_mincount': 9
-    }]
+    }
 
     def _real_extract(self, url):
         playlist_id = self._match_id(url)

--- a/youtube_dl/extractor/vlive.py
+++ b/youtube_dl/extractor/vlive.py
@@ -311,11 +311,11 @@ class VLivePlaylistIE(InfoExtractor):
             webpage, 'playlist name', fatal=False)
 
         item_ids = self._search_regex(
-            r'\bvar\s+playlistVideoSeqs\s*=\s*\[([^]]+)\]',
+            r'\bvar\s+playlistVideoSeqs\s*=\s*(\[[^]]+\])',
             webpage, 'playlist item ids')
 
         entries = []
-        for item_id in self._parse_json('[%s]' % item_ids, playlist_id):
+        for item_id in self._parse_json(item_ids, playlist_id):
             item_id = compat_str(item_id)
             entries.append(
                 self.url_result(

--- a/youtube_dl/extractor/vlive.py
+++ b/youtube_dl/extractor/vlive.py
@@ -49,6 +49,10 @@ class VLiveIE(InfoExtractor):
         },
     }]
 
+    @classmethod
+    def suitable(cls, url):
+        return False if VLivePlaylistIE.suitable(url) else super(VLiveIE, cls).suitable(url)
+
     def _real_extract(self, url):
         video_id = self._match_id(url)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

A couple more examples of vlive playlists:
```
http://www.vlive.tv/video/24371/playlist/24384
http://www.vlive.tv/video/20928/playlist/20933
http://www.vlive.tv/video/16181/playlist/17079
```

The reason why there are two tests is because the webpages for the two are slightly different. The webpage for the video in the first test contains playlist information even if you remove the 'playlist' and playlist id segments of the URL. Whereas the second video doesn't contain playlist information if you remove the 'playlist' and playlist id segments of the URL therefore the playlist extractor would not work.

I've put this extractor before the regular video extractor in the extractors file because the playlist URLs match the regular video pattern. This way they both work.