### PR TITLE
[YouTube] Remove YouTube Red ad from creator metadata

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1654,6 +1654,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         if m_music:
             video_alt_title = remove_quotes(unescapeHTML(m_music.group('title')))
             video_creator = clean_html(m_music.group('creator'))
+            if video_creator:
+                video_creator = video_creator.replace(' Listen ad-free with YouTube Red', '')
         else:
             video_alt_title = video_creator = None
 

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1016,6 +1016,25 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'url': 'https://www.youtube.com/watch?v=MuAGGZNfUkU&list=RDMM',
             'only_matching': True,
         },
+        {
+            'url': 'https://www.youtube.com/watch?v=ZUf6p5Inc08',
+            'note': 'Audio of Video with artist containing YouTube advert',
+            'info_dict': {
+                'id': 'ZUf6p5Inc08',
+                'ext': 'm4a',
+                'upload_date': '20140210',
+                'uploader_id': 'glitchmob',
+                'uploader_url': r're:https?://(?:www\.)?youtube\.com/user/glitchmob',
+                'creator': 'The Glitch Mob',
+                'license': 'Standard YouTube License',
+                'title': 'The Glitch Mob - Mind of a Beast'
+            },
+            'params': {
+                'skip_download': True,
+                'youtube_include_dash_manifest': True,
+                'format': '140',
+            },
+        },
     ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

When saving a YouTube video with the `--add-metadata` flag enabled, the `artist` of an audio track (e.g. `-f 140`) has ` Listen ad-free with YouTube Red` appended to it. 

This simple change removes the advertising from the artist if it is there. 