### PR TITLE
added option --with-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                      TEMPLATE" for all the info
     --autonumber-start NUMBER        Specify the start value for %(autonumber)s
                                      (default is 1)
+    --with-index                     Add playlist index before filenames
     --restrict-filenames             Restrict filenames to only ASCII
                                      characters, and avoid "&" and spaces in
                                      filenames

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -231,6 +231,10 @@ def _real_main(argv=None):
                (opts.useid and '%(id)s.%(ext)s') or
                (opts.autonumber and '%(autonumber)s-%(id)s.%(ext)s') or
                DEFAULT_OUTTMPL)
+
+    if opts.withindex:
+        outtmpl = '%(playlist_index)s. '+outtmpl
+
     if not os.path.splitext(outtmpl)[1] and opts.extractaudio:
         parser.error('Cannot download a video and extract audio into the same'
                      ' file! Use "{0}.%(ext)s" instead of "{0}" as the output'
@@ -333,6 +337,7 @@ def _real_main(argv=None):
         'format': opts.format,
         'listformats': opts.listformats,
         'outtmpl': outtmpl,
+        'withindex': opts.withindex,
         'autonumber_size': opts.autonumber_size,
         'autonumber_start': opts.autonumber_start,
         'restrictfilenames': opts.restrictfilenames,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -690,6 +690,9 @@ def parseOpts(overrideArguments=None):
         dest='autonumber_start', metavar='NUMBER', default=1, type=int,
         help='Specify the start value for %(autonumber)s (default is %default)')
     filesystem.add_option(
+        '--with-index', default=False,
+        action='store_true', dest='withindex', help='Add playlist index before filenames')
+    filesystem.add_option(
         '--restrict-filenames',
         action='store_true', dest='restrictfilenames', default=False,
         help='Restrict filenames to only ASCII characters, and avoid "&" and spaces in filenames')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [ x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ x] New feature

---

### Description of your *pull request* and other information

Manually sorting and renaming files after downloading a playlist is a pain.
Using the flexible -o (output format) option is too much for people who hates reading documentation.
For this purpose it should have a friendly option to download videos with index number in their file name.