### PR TITLE
Don't raise "requested format not available" when just dumping JSON

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1571,7 +1571,7 @@ class YoutubeDL(object):
         }
 
         formats_to_download = list(format_selector(ctx))
-        if not formats_to_download:
+        if download and not formats_to_download:
             raise ExtractorError('requested format not available',
                                  expected=True)
 
@@ -1583,7 +1583,8 @@ class YoutubeDL(object):
                 new_info.update(format)
                 self.process_info(new_info)
         # We update the info dict with the best quality format (backwards compatibility)
-        info_dict.update(formats_to_download[-1])
+        if formats_to_download:
+            info_dict.update(formats_to_download[-1])
         return info_dict
 
     def process_subtitles(self, video_id, normal_subtitles, automatic_captions):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---
I got `ERROR: requested format not available` when **dump json** of a video (see my log), I think `youtube-dl` should ignore this error instead.
```
$ youtube-dl -v -j --skip-download CSV_BiJ17MU
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-v', '-j', '--skip-download', 'CSV_BiJ17MU']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2017.07.15
[debug] Git HEAD: 3c1d586d8
[debug] Python version 3.5.2 - Darwin-16.6.0-x86_64-i386-64bit
[debug] exe versions: none
[debug] Proxy map: {}
ERROR: requested format not available
Traceback (most recent call last):
  File "/Users/khangnt/Desktop/youtube-dl/venv/lib/python3.5/site-packages/youtube_dl/YoutubeDL.py", line 787, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/Users/khangnt/Desktop/youtube-dl/venv/lib/python3.5/site-packages/youtube_dl/YoutubeDL.py", line 841, in process_ie_result
    return self.process_video_result(ie_result, download=download)
  File "/Users/khangnt/Desktop/youtube-dl/venv/lib/python3.5/site-packages/youtube_dl/YoutubeDL.py", line 1576, in process_video_result
    expected=True)
youtube_dl.utils.ExtractorError: requested format not available
```