### PR TITLE
[20min] Fix extractions for 20min embeds.

### DIFF
--- a/youtube_dl/extractor/twentymin.py
+++ b/youtube_dl/extractor/twentymin.py
@@ -50,7 +50,7 @@ class TwentyMinutenIE(InfoExtractor):
     @staticmethod
     def _extract_urls(webpage):
         return [m.group('url') for m in re.finditer(
-            r'<iframe[^>]+src=(["\'])(?P<url>(?:https?://)?(?:www\.)?20min\.ch/videoplayer/videoplayer.html\?.*?\bvideoId@\d+.*?)\1',
+            r'<iframe[^>]+src=(["\'])(?P<url>(?:https?://|//)?(?:www\.)?20min\.ch/videoplayer/videoplayer.html\?.*?\bvideoId@\d+.*?)\1',
             webpage)]
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/twentymin.py
+++ b/youtube_dl/extractor/twentymin.py
@@ -50,7 +50,7 @@ class TwentyMinutenIE(InfoExtractor):
     @staticmethod
     def _extract_urls(webpage):
         return [m.group('url') for m in re.finditer(
-            r'<iframe[^>]+src=(["\'])(?P<url>(?:https?://|//)?(?:www\.)?20min\.ch/videoplayer/videoplayer.html\?.*?\bvideoId@\d+.*?)\1',
+            r'<iframe[^>]+src=(["\'])(?P<url>(?:(?:https?:)?//)?(?:www\.)?20min\.ch/videoplayer/videoplayer.html\?.*?\bvideoId@\d+.*?)\1',
             webpage)]
 
     def _real_extract(self, url):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Embedded videos for 20min.ch stopped working, because a change on their site:
```
youtube-dl -F "http://www.20min.ch/sport/dossier/superleague/story/-Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018"
[generic] -Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018: Requesting header
WARNING: Falling back on generic information extractor.
[generic] -Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018: Downloading webpage
[generic] -Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018: Extracting information
ERROR: Unsupported URL: http://www.20min.ch/sport/dossier/superleague/story/-Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018
```
With this commit it works again as expected:
```
python -m youtube_dl -F "http://www.20min.ch/sport/dossier/superleague/story/-Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018"
[generic] -Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018: Requesting header
WARNING: Falling back on generic information extractor.
[generic] -Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018: Downloading webpage
[generic] -Was-hat-Pickel-dort-ueberhaupt-zu-suchen---23224018: Extracting information
[download] Downloading playlist: «Was hat Pickel dort überhaupt zu suchen?»
[generic] playlist «Was hat Pickel dort überhaupt zu suchen?»: Collected 3 video ids (downloading 3 of them)
[download] Downloading video 1 of 3
[20min] 560221: Downloading JSON metadata
[info] Available formats for 560221:
format code  extension  resolution note
sd           mp4        unknown
hd           mp4        unknown    (best)
[download] Downloading video 2 of 3
[20min] 560227: Downloading JSON metadata
[info] Available formats for 560227:
format code  extension  resolution note
sd           mp4        unknown
hd           mp4        unknown    (best)
[download] Downloading video 3 of 3
[20min] 560223: Downloading JSON metadata
[info] Available formats for 560223:
format code  extension  resolution note
sd           mp4        unknown
hd           mp4        unknown    (best)
[download] Finished downloading playlist: «Was hat Pickel dort überhaupt zu suchen?»
```

The corresponding test in the generic information extractor will pass again:
```
python test/test_download.py TestDownload.test_Generic_116[generic] So-kommen-Sie-bei-Eis-und-Schnee-sicher-an-27032552: Requesting header
[generic] So-kommen-Sie-bei-Eis-und-Schnee-sicher-an-27032552: Downloading webpage
[generic] So-kommen-Sie-bei-Eis-und-Schnee-sicher-an-27032552: Extracting information
[download] Downloading playlist: So kommen Sie bei Eis und Schnee sicher an
[generic] playlist So kommen Sie bei Eis und Schnee sicher an: Collected 1 video ids (downloading 1 of them)
[download] Downloading video 1 of 1
[20min] 523629: Downloading JSON metadata
[info] Writing video description metadata as JSON to: test_Generic_116_523629.info.json
[download] Finished downloading playlist: So kommen Sie bei Eis und Schnee sicher an
.
----------------------------------------------------------------------
Ran 1 test in 0.991s

OK
```


