### PR TITLE
[kakao] [All issues fixed] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -481,6 +481,7 @@ from .jove import JoveIE
 from .joj import JojIE
 from .jwplatform import JWPlatformIE
 from .jpopsukitv import JpopsukiIE
+from .kakao import KakaoIE
 from .kaltura import KalturaIE
 from .kamcord import KamcordIE
 from .kanalplay import KanalPlayIE

--- a/youtube_dl/extractor/kakao.py
+++ b/youtube_dl/extractor/kakao.py
@@ -22,6 +22,7 @@ class KakaoIE(InfoExtractor):
             'title': '乃木坂46 バナナマン 「3期生紹介コーナーが始動！顔高低差GPも！」 『乃木坂工事中』',
             'uploader_id': 2671005,
             'uploader': '그랑그랑이',
+            'upload_date': '20170227'
         }
     }, {
         'url': 'http://tv.kakao.com/channel/2653210/cliplink/300103180',
@@ -33,6 +34,7 @@ class KakaoIE(InfoExtractor):
             'title': '러블리즈 - Destiny (나의 지구) (Lovelyz - Destiny)',
             'uploader_id': 2653210,
             'uploader': '쇼 음악중심',
+            'upload_date': '20170129'
         }
     }]
 

--- a/youtube_dl/extractor/kakao.py
+++ b/youtube_dl/extractor/kakao.py
@@ -1,0 +1,138 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import (
+    int_or_none,
+)
+import datetime
+
+
+class KakaoIE(InfoExtractor):
+    _VALID_URL = r'https?://tv.kakao.com/channel/(?P<channel>\d+)/cliplink/(?P<id>\d+)'
+    IE_NAME = 'kakao.com'
+
+    _TESTS = [{
+        'url': 'http://tv.kakao.com/channel/2671005/cliplink/301965083',
+        'md5': '702b2fbdeb51ad82f5c904e8c0766340',
+        'info_dict': {
+            'id': '301965083',
+            'ext': 'mp4',
+            'title': '乃木坂46 バナナマン 「3期生紹介コーナーが始動！顔高低差GPも！」 『乃木坂工事中』',
+            'uploader_id': 2671005,
+            'uploader': '그랑그랑이',
+        }
+    }, {
+        'url': 'http://tv.kakao.com/channel/2653210/cliplink/300103180',
+        'md5': 'a8917742069a4dd442516b86e7d66529',
+        'info_dict': {
+            'id': '300103180',
+            'ext': 'mp4',
+            'description': '러블리즈 - Destiny (나의 지구) (Lovelyz - Destiny)\r\n\r\n[쇼! 음악중심] 20160611, 507회',
+            'title': '러블리즈 - Destiny (나의 지구) (Lovelyz - Destiny)',
+            'uploader_id': 2653210,
+            'uploader': '쇼 음악중심',
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        # Player URL, to be used in Referer header
+        player_url = 'http://tv.kakao.com/embed/player/cliplink/' + video_id + \
+            '?service=kakao_tv&autoplay=1&profile=HIGH&wmode=transparent'
+        player_header = {'Referer': player_url}
+
+        # Request Impress, which contains video information
+        impress = self._download_json(
+            'http://tv.kakao.com/api/v1/ft/cliplinks/%s/impress' % video_id,
+            video_id, 'Downloading video info',
+            query={
+                'player': 'monet_html5',
+                'referer': url,
+                'uuid': '',
+                'service': 'kakao_tv',
+                'section': '',
+                'dteType': 'PC',
+                'fields': 'clipLink,clip,channel,hasPlusFriend,-service,-tagList'
+            }, headers=player_header)
+
+        clipLink = impress['clipLink']
+
+        # Now we request Raw, which contains infos about video files.
+        tid = impress.get('tid', '')
+        raw = self._download_json(
+            'http://tv.kakao.com/api/v1/ft/cliplinks/%s/raw' % video_id,
+            video_id, 'Downloading video formats info',
+            query={
+                'player': 'monet_html5',
+                'referer': url,
+                'uuid': '',
+                'service': 'kakao_tv',
+                'section': '',
+                'tid': tid,
+                'profile': 'HIGH',
+                'dteType': 'PC',
+            }, headers=player_header)
+
+        formats = []
+        for fmt in raw['outputList']:
+            profile_name = fmt['profile']
+            # The following request is called when user changes the video quality.
+            # We simulate it here.
+            fmt_url_json = self._download_json(
+                'http://tv.kakao.com/api/v1/ft/cliplinks/%s/raw/videolocation' % video_id,
+                video_id, 'Downloading video URL for profile %s' % profile_name,
+                query={
+                    'service': 'kakao_tv',
+                    'section': '',
+                    'tid': tid,
+                    'profile': profile_name
+                }, headers=player_header)
+            fmt_url = fmt_url_json['url']
+
+            formats.append({
+                'url': fmt_url,
+                'format_id': profile_name,
+                'width': int_or_none(fmt.get('width')),
+                'height': int_or_none(fmt.get('height')),
+                'format_note': fmt.get('label', None),
+                'filesize': int_or_none(fmt.get('filesize'))
+            })
+
+        self._sort_formats(formats)
+
+        clip = clipLink['clip']
+        # Parse thumbnails.
+        top_thumbnail = clip.get('thumbnailUrl', None)
+        thumbs = []
+        for thumb in clip.get('clipChapterThumbnailList', []):
+            thumbs.append({
+                'url': thumb['thumbnailUrl'],
+                'id': str(thumb['timeInSec']),
+                'preference': -1 if thumb['isDefault'] else 0
+            })
+        # Parse upload date.
+        upload_date = None
+        try:
+            upload_date = datetime.datetime.strptime(clipLink['create_time'], '%Y-%m-%d %H:%M:%S')
+            upload_date = upload_date.strftime('%Y%m%d')
+        except (ValueError, KeyError):
+            pass
+
+        return {
+            'id': video_id,
+            'title': clip['title'],
+            'formats': formats,
+            'thumbnail': top_thumbnail,
+            'thumbnails': thumbs,
+            'description': clip.get('description'),
+            'uploader': clipLink['channel'].get('name'),
+            'upload_date': upload_date,
+            'uploader_id': clipLink.get('channelId'),
+            'duration': int_or_none(clip.get('duration')),
+            'view_count': int_or_none(clip.get('playCount')),
+            'like_count': int_or_none(clip.get('likeCount')),
+            'comment_count': int_or_none(clip.get('commentCount')),
+        }

--- a/youtube_dl/extractor/kakao.py
+++ b/youtube_dl/extractor/kakao.py
@@ -116,7 +116,7 @@ class KakaoIE(InfoExtractor):
         # Parse upload date.
         upload_date = None
         try:
-            upload_date = datetime.datetime.strptime(clipLink['create_time'], '%Y-%m-%d %H:%M:%S')
+            upload_date = datetime.datetime.strptime(clipLink['createTime'], '%Y-%m-%d %H:%M:%S')
             upload_date = upload_date.strftime('%Y%m%d')
         except (ValueError, KeyError):
             pass


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

#### Background story

Two Korean companies, [Daum](https://www.daum.net) and [Kakao](http://www.kakaocorp.com), was merged in October 1st, 2014.
Since then, some services of Daum have been closed or changed.

'tvpot'(TV팟), a video sharing service previously served by Daum, is no longer allowing any other activities than watching a video. Instead, Kakao has launched a (Beta) service named 'Kakao TV'(카카오TV).

Now, users can migrate their videos that were previously uploaded in tvpot to Kakao TV. For example, [this video in tvpot](http://tvpot.daum.net/v/v4eeefwPzwww1OHvUzPGvzw) has its corresponding one in [Kakao TV](http://tv.kakao.com/channel/2671005/cliplink/301965083). This means that the owner of the video agreed on migrating the videos.

The reason why they don't migrate it themselves, is that Kakao accounts are different from Daum account (remember that they were two different companies). I feel like they're not trying to just bomb up the old service; thye're encouraging users to keep their videos alive. It has been announced in Feb, 2017 that tvpot is going to be closed someday, but the exact date is not announced yet -- and 6 months have passed. Well... who knows?

#### About this pull request

I've implemented an extractor for Kakao TV videos. This can download videos of the form `tv.kakao.com/channel/(numbers)/cliplink/(numbers)`. Some URLs have the form `tv.kakao.com/v/s2c98ruQGIkQpupf33RGpRl`, but the server appropriately redirects with 302 to the URL in the former form. I've tested that the generic(redirect) extractor works well.

Currently, the JavaScript is not much obfuscated, and it was quite easy to look through how it works:

1. The HTML5 player requests an *impress* of the video. The *impress* contains various informations about the video, including the uploader(here called *channel*), video duration, thumbnails, and a parameter called `tid`.
2. Then, the player requests an *raw* of the video. The *raw* contains the URL of the video file, and a list of video qualities.

`flake8` passed.

Please let me know of any problems in the PR. Thank you.