### PR TITLE
[generic] Fix support for multiple HTML5 videos on one page (#14080)

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2877,13 +2877,13 @@ class GenericIE(InfoExtractor):
             if len(entries) == 1:
                 entries[0].update({
                     'id': video_id,
-                    'title': video_itle})
+                    'title': video_title})
                 self._sort_formats(entries[0]['formats'])
             else:
-                for num, entry in enumerate(entries):
+                for num, entry in enumerate(entries, start=1):
                     entry.update({
                         'id': video_id,
-                        'title': '%s (%d) ' % (video_title, num+1)})
+                        'title': '%s (%d) ' % (video_title, num)})
                     self._sort_formats(entry['formats'])
             return self.playlist_result(entries)
 

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2874,12 +2874,17 @@ class GenericIE(InfoExtractor):
         # Look for HTML5 media
         entries = self._parse_html5_media_entries(url, webpage, video_id, m3u8_id='hls')
         if entries:
-            for entry in entries:
-                entry.update({
+            if len(entries) == 1:
+                entries[0].update({
                     'id': video_id,
-                    'title': video_title,
-                })
-                self._sort_formats(entry['formats'])
+                    'title': video_itle})
+                self._sort_formats(entries[0]['formats'])
+            else:
+                for num, entry in enumerate(entries):
+                    entry.update({
+                        'id': video_id,
+                        'title': '%s (%d) ' % (video_title, num+1)})
+                    self._sort_formats(entry['formats'])
             return self.playlist_result(entries)
 
         jwplayer_data = self._find_jwplayer_data(

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -1879,6 +1879,15 @@ class GenericIE(InfoExtractor):
                 'title': 'Building A Business Online: Principal Chairs Q & A',
             },
         },
+        {
+            # multiple HTML5 videos on one page
+            'url': 'https://www.paragon-software.com/home/rk-free/keyscenarios.html',
+            'info_dict': {
+                'id': 'keyscenarios',
+                'title': 'Rescue Kit 14 Free Edition - Getting started',
+            },
+            'playlist_count': 4,
+        }
         # {
         #     # TODO: find another test
         #     # http://schema.org/VideoObject
@@ -2885,7 +2894,7 @@ class GenericIE(InfoExtractor):
                         'id': video_id,
                         'title': '%s (%d) ' % (video_title, num)})
                     self._sort_formats(entry['formats'])
-            return self.playlist_result(entries)
+            return self.playlist_result(entries, video_id, video_title)
 
         jwplayer_data = self._find_jwplayer_data(
             webpage, video_id, transform_source=js_to_json)

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2886,14 +2886,16 @@ class GenericIE(InfoExtractor):
             if len(entries) == 1:
                 entries[0].update({
                     'id': video_id,
-                    'title': video_title})
-                self._sort_formats(entries[0]['formats'])
+                    'title': video_title,
+                })
             else:
                 for num, entry in enumerate(entries, start=1):
                     entry.update({
-                        'id': video_id,
-                        'title': '%s (%d) ' % (video_title, num)})
-                    self._sort_formats(entry['formats'])
+                        'id': '%s-%s' % (video_id, num),
+                        'title': '%s (%d)' % (video_title, num),
+                    })
+            for entry in entries:
+                self._sort_formats(entry['formats'])
             return self.playlist_result(entries, video_id, video_title)
 
         jwplayer_data = self._find_jwplayer_data(


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix
Previously, multiple HTML5 videos on one page would lead to title conflicts, where every video had the same title and thereby only the first one would be downloaded ('video already downloaded').

This fixes #14080.