### PR TITLE
[RadioCanada] Added support for TV shows without titles like evening news

### DIFF
--- a/youtube_dl/extractor/radiocanada.py
+++ b/youtube_dl/extractor/radiocanada.py
@@ -20,20 +20,36 @@ from ..utils import (
 class RadioCanadaIE(InfoExtractor):
     IE_NAME = 'radiocanada'
     _VALID_URL = r'(?:radiocanada:|https?://ici\.radio-canada\.ca/widgets/mediaconsole/)(?P<app_code>[^:/]+)[:/](?P<id>[0-9]+)'
-    _TEST = {
-        'url': 'http://ici.radio-canada.ca/widgets/mediaconsole/medianet/7184272',
-        'info_dict': {
-            'id': '7184272',
-            'ext': 'mp4',
-            'title': 'Le parcours du tireur capté sur vidéo',
-            'description': 'Images des caméras de surveillance fournies par la GRC montrant le parcours du tireur d\'Ottawa',
-            'upload_date': '20141023',
+    _TESTS = [
+        {
+            'url': 'http://ici.radio-canada.ca/widgets/mediaconsole/medianet/7184272',
+            'info_dict': {
+                'id': '7184272',
+                'ext': 'mp4',
+                'title': 'Le parcours du tireur capté sur vidéo',
+                'description': 'Images des caméras de surveillance fournies par la GRC montrant le parcours du tireur d\'Ottawa',
+                'upload_date': '20141023',
+            },
+            'params': {
+                # m3u8 download
+                'skip_download': True,
+            }
         },
-        'params': {
-            # m3u8 download
-            'skip_download': True,
-        },
-    }
+        {
+            'url': 'http://ici.radio-canada.ca/widgets/mediaconsole/medianet/7754998/',
+            'info_dict': {
+                'id': '7754998',
+                'ext': 'mp4',
+                'title': 'letelejournal22h',
+                'description': 'INTEGRALE WEB 22H-TJ',
+                'upload_date': '20170720',
+            },
+            'params': {
+                # m3u8 download
+                'skip_download': True,
+            },
+        }
+    ]
 
     def _real_extract(self, url):
         url, smuggled_data = unsmuggle_url(url, {})
@@ -145,7 +161,7 @@ class RadioCanadaIE(InfoExtractor):
 
         return {
             'id': video_id,
-            'title': get_meta('Title'),
+            'title': get_meta('Title') or get_meta('AV-nomEmission'),
             'description': get_meta('Description') or get_meta('ShortDescription'),
             'thumbnail': get_meta('imageHR') or get_meta('imageMR') or get_meta('imageBR'),
             'duration': int_or_none(get_meta('length')),

--- a/youtube_dl/extractor/radiocanada.py
+++ b/youtube_dl/extractor/radiocanada.py
@@ -36,6 +36,7 @@ class RadioCanadaIE(InfoExtractor):
             }
         },
         {
+            # empty Title
             'url': 'http://ici.radio-canada.ca/widgets/mediaconsole/medianet/7754998/',
             'info_dict': {
                 'id': '7754998',


### PR DESCRIPTION

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description

RadioCanada extractor wasn't able to download videos from shows that had no titles in the metadata. A `len()` on a `NoneType` would be called raising an exception. I added a test. See it fail:

```
$ python test/test_download.py TestDownload.test_RadioCanada_1[radiocanada] 7754998: Downloading metadata XML
[radiocanada] 7754998: Downloading ipad XML
[radiocanada] 7754998: Downloading m3u8 information
[radiocanada] 7754998: Downloading flash XML
[radiocanada] 7754998: Downloading android XML
[radiocanada] 7754998: Downloading m3u8 information
[radiocanada] 7754998: Downloading f4m manifest
[radiocanada] 7754998: Downloading m3u8 information
[radiocanada] 7754998: Downloading f4m manifest
[radiocanada] 7754998: Downloading m3u8 information
[radiocanada] 7754998: Downloading f4m manifest
E
======================================================================
ERROR: test_RadioCanada_1 (__main__.TestDownload):
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_download.py", line 159, in test_template
    force_generic_extractor=params.get('force_generic_extractor', False))
  File "/home/olivier/src/youtube-dl/youtube_dl/YoutubeDL.py", line 787, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/home/olivier/src/youtube-dl/youtube_dl/YoutubeDL.py", line 841, in process_ie_result
    return self.process_video_result(ie_result, download=download)
  File "/home/olivier/src/youtube-dl/youtube_dl/YoutubeDL.py", line 1601, in process_video_result
    self.process_info(new_info)
  File "test/test_download.py", line 56, in process_info
    return super(YoutubeDL, self).process_info(info_dict)
  File "/home/olivier/src/youtube-dl/youtube_dl/YoutubeDL.py", line 1666, in process_info
    if len(info_dict['title']) > 200:
TypeError: object of type 'NoneType' has no len()

----------------------------------------------------------------------
Ran 1 test in 2.478s

FAILED (errors=1)
```

This PR allows the Title to fallback to the `AV-nomEmission` metadata which contains the generic name for the show. Tests now pass:

```
$ python test/test_download.py TestDownload.test_RadioCanada_1[radiocanada] 7754998: Downloading metadata XML
[radiocanada] 7754998: Downloading ipad XML
[radiocanada] 7754998: Downloading m3u8 information
[radiocanada] 7754998: Downloading flash XML
[radiocanada] 7754998: Downloading android XML
[radiocanada] 7754998: Downloading m3u8 information
[radiocanada] 7754998: Downloading f4m manifest
[radiocanada] 7754998: Downloading m3u8 information
[radiocanada] 7754998: Downloading f4m manifest
[radiocanada] 7754998: Downloading m3u8 information
[radiocanada] 7754998: Downloading f4m manifest
[info] Writing video description metadata as JSON to: test_RadioCanada_1_7754998.info.json
.
----------------------------------------------------------------------
Ran 1 test in 2.049s

OK
```