### PR TITLE
Disable download tests for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 sudo: false
 env:
   - YTDL_TEST_SET=core
-  - YTDL_TEST_SET=download
+# - YTDL_TEST_SET=download
 script: ./devscripts/run_tests.sh
 notifications:
   email:


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The download tests for Travis CI currently never succeed.  This noise
is distracting and can also be demotivating because, without fault on
the contributor's side, every pull request will be labelled: "All
checks have failed".

There is latent interest in fixing those tests, but these constant
failures do not seem to encourage action.  With the sheer amount of
between 15 % and 25 % of tests failing, this also effectively
precludes scenarios where someone will "just fix them" before
committing a change or merging a pull request.

This change therefore disables the download tests for Travis CI.
Developers wanting to work on fixing them can easily (temporarily)
reenable them.