### PR TITLE
MPD manifests: improve errmsg for missing duration

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -1920,7 +1920,7 @@ class InfoExtractor(object):
                             # can't be used at the same time
                             if '%(Number' in media_template and 's' not in representation_ms_info:
                                 segment_duration = None
-                                if 'total_number' not in representation_ms_info and 'segment_duration':
+                                if 'total_number' not in representation_ms_info and 'segment_duration' in representation_ms_info:
                                     segment_duration = float_or_none(representation_ms_info['segment_duration'], representation_ms_info['timescale'])
                                     representation_ms_info['total_number'] = int(math.ceil(float(period_duration) / segment_duration))
                                 representation_ms_info['fragments'] = [{


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This patch checks for missing data for the segment duration calculation, and if it's missing, raises a more specific error than just the generic type conversion failure.

Example of original error message from #14388:

```text
  File "/…/ytdl-rg3/youtube_dl/extractor/common.py", line 1753, in _extract_mpd_formats
    formats_dict=formats_dict, mpd_url=mpd_url)
  File "/…/ytdl-rg3/youtube_dl/extractor/common.py", line 1925, in _parse_mpd_formats
    representation_ms_info['total_number'] = int(math.ceil(float(period_duration) / segment_duration))
TypeError: float() argument must be a string or a number
```

NB [line 1923 of the old `youtube_dl/extractor/common.py`](https://github.com/rg3/youtube-dl/blob/bfd484ccff4ea9d16af9515416d4f35d14d5b41d/youtube_dl/extractor/common.py#L1923):

As far as I can tell, the 2nd part of the if condition
`and 'segment_duration'` is useless because it will always
pass, so I made a guess at what could have been meant.
We should try and get a linter program to warn about useless
expressions. If we have one, we should put a better hint in
the coding guidelines.