### PR TITLE
[CamModels] Add extractor

### DIFF
--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from .common import InfoExtractor
 
+
 class CamModelsIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?cammodels\.com/cam/(?P<id>\w+)'
     _MANIFEST_URL_ROOT_REGEX = r'manifestUrlRoot=(?P<id>https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))'

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -61,7 +61,7 @@ class CamModelsIE(InfoExtractor):
         manifest = self._download_json(url_or_request=manifest_url, video_id=video_id, headers=self._HEADERS, fatal=False)
         if not manifest:
             raise ExtractorError(
-                msg='Link to stream info was found, but we couldn\'t access it. This stream may require login.',
+                msg='Link to stream URLs was found, but we couldn\'t access it.',
                 expected=False,
                 video_id=video_id)
         return manifest

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -1,49 +1,81 @@
 from __future__ import unicode_literals
 from .common import InfoExtractor
+from .common import ExtractorError
+import json
 
 
 class CamModelsIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?cammodels\.com/cam/(?P<id>\w+)'
-    _MANIFEST_URL_ROOT_REGEX = r'manifestUrlRoot=(?P<id>https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))'
-    _USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36'
-    # _TEST = {
-    #     'url': 'https://www.cammodels.com/cam/AutumnKnight',
-    #     'params': {
-    #         'skip_download': True,
-    #     },
-    #     'skip': _ROOM_OFFLINE,
-    #     'info_dict': {
-    #         'id': 'AutumnKnight',
-    #         'ext': 'flv'
-    #     }
-    # }
+    _MANIFEST_URL = r'manifestUrlRoot=(?P<id>https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))'
+    _MANIFEST_URL_CONSOLE_ERROR = 'Unable to find link to stream info on webpage. Room is not offline, so something else is wrong.'
+    _OFFLINE = r'(?P<id>I\'m offline, but let\'s stay connected!)'
+    _OFFLINE_CONSOLE_ERROR = 'This user is currently offline, so nothing can be downloaded.'
+    _PRIVATE = r'(?P<id>I’m in a private show right now)'
+    _PRIVATE_CONSOLE_ERROR = 'This user is doing a private show, which requires payment. This extractor currently does not support private streams.'
+    _MANIFEST_CONSOLE_ERROR = 'Link to stream info was found, but we couldn\'t access it. This stream may require login.'
+    _RTMP_URL_FALLBACK = r'(?P<id>rtmp?:\/\/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#&//=]*))'
+    _RTMP_URL_FALLBACK_CONSOLE_ERROR = 'Link to stream info was found, but we couldn\'t read the response. This is probably a bug.'
+    _HEADERS = {
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36'
+    }
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        headers = {
-            'User-Agent': self._USER_AGENT
-        }
-        webpage = self._download_webpage(url_or_request=url, video_id=video_id, headers=headers)
-        manifest_url_root = self._html_search_regex(self._MANIFEST_URL_ROOT_REGEX, webpage, 'manifest')
-        manifest_url = manifest_url_root + video_id + '.json'
-        manifest = self._download_json(manifest_url, video_id=video_id, headers=headers)
-        rtmp_formats = manifest['formats']['mp4-rtmp']['encodings']
-        formats = []
-        for format in rtmp_formats:
-            formats.append({
-                'ext': 'flv',
-                'url': format.get('location'),
-                'width': format.get('videoWidth'),
-                'height': format.get('videoHeight'),
-                'vbr': format.get('videoKbps'),
-                'abr': format.get('audioKbps'),
-                'format_id': str(format.get('videoWidth'))
-            })
-        self._sort_formats(formats)
+        webpage = self._download_webpage(url_or_request=url, video_id=video_id, headers=self._HEADERS)
+        manifest_url = self._get_manifest_url_from_webpage(video_id=video_id, webpage=webpage)
+        manifest = self._get_manifest_from_manifest_url(manifest_url=manifest_url, video_id=video_id, webpage=webpage)
+        formats = self._get_formats_from_manifest(manifest=manifest, video_id=video_id)
         return {
             'id': video_id,
             'title': self._live_title(video_id),
-            'age_limit': self._rta_search(webpage),
-            'ext': 'flv',
             'formats': formats
         }
+
+    def _get_manifest_url_from_webpage(self, video_id, webpage):
+        manifest_url_root = self._html_search_regex(pattern=self._MANIFEST_URL, string=webpage, name='manifest', fatal=False)
+        if not manifest_url_root:
+            offline = self._html_search_regex(pattern=self._OFFLINE, string=webpage, name='offline indicator', fatal=False)
+            if offline:
+                raise ExtractorError(msg=self._OFFLINE_CONSOLE_ERROR, expected=True, video_id=video_id)
+            private = self._html_search_regex(pattern=self._PRIVATE, string=webpage, name='private show indicator', fatal=False)
+            if private:
+                raise ExtractorError(msg=self._PRIVATE_CONSOLE_ERROR, expected=True, video_id=video_id)
+            raise ExtractorError(msg=self._MANIFEST_URL_CONSOLE_ERROR, expected=False, video_id=video_id)
+        manifest_url = manifest_url_root + video_id + '.json'
+        return manifest_url
+
+    def _get_manifest_from_manifest_url(self, manifest_url, video_id, webpage):
+        manifest = self._download_json(url_or_request=manifest_url, video_id=video_id, headers=self._HEADERS, fatal=False)
+        if not manifest:
+            raise ExtractorError(msg=self._MANIFEST_CONSOLE_ERROR, expected=False, video_id=video_id)
+        return manifest
+
+    def _get_formats_from_manifest(self, manifest, video_id):
+        try:
+            rtmp_formats = manifest['formats']['mp4-rtmp']['encodings']
+            formats = []
+            for format in rtmp_formats:
+                formats.append({
+                    'ext': 'flv',
+                    'url': format.get('location'),
+                    'width': format.get('videoWidth'),
+                    'height': format.get('videoHeight'),
+                    'vbr': format.get('videoKbps'),
+                    'abr': format.get('audioKbps'),
+                    'format_id': str(format.get('videoWidth'))
+                })
+        # If they change the JSON format, then fallback to parsing out RTMP links via regex.
+        except:
+            manifest_json = json.dumps(manifest)
+            manifest_links = self._search_regex(pattern=self._RTMP_URL_FALLBACK, string=manifest_json, name='RTMP URLs', fatal=False)
+            if not manifest_links:
+                raise ExtractorError(msg=self._RTMP_URL_FALLBACK_CONSOLE_ERROR, expected=False, video_id=video_id)
+            formats = []
+            for manifest_link in manifest_links:
+                formats.append({
+                    'ext': 'flv',
+                    'url': manifest_link,
+                    'format_id': manifest_link.split(sep='/')[-1]
+                })
+        self._sort_formats(formats)
+        return formats

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -64,7 +64,7 @@ class CamModelsIE(InfoExtractor):
                 for encoding in encodings:
                     formats.append({
                         'ext': 'mp4',
-                        'url': encoding.get('location'),
+                        'url': encoding['location'],
                         'width': int_or_none(encoding.get('videoWidth')),
                         'height': int_or_none(encoding.get('videoHeight')),
                         'vbr': int_or_none(encoding.get('videoKbps')),

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -18,23 +18,6 @@ class CamModelsIE(InfoExtractor):
             url,
             video_id,
             headers=self._HEADERS)
-        manifest_url = self._get_manifest_url_from_webpage(
-            webpage,
-            video_id)
-        manifest = self._get_manifest_from_manifest_url(
-            manifest_url,
-            video_id,
-            webpage)
-        formats = self._get_formats_from_manifest(
-            manifest,
-            video_id)
-        return {
-            'id': video_id,
-            'title': self._live_title(video_id),
-            'formats': formats
-        }
-
-    def _get_manifest_url_from_webpage(self, webpage, video_id):
         manifest_url_root = self._html_search_regex(
             r'manifestUrlRoot=(?P<id>https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))',
             webpage,
@@ -66,9 +49,6 @@ class CamModelsIE(InfoExtractor):
                 expected=False,
                 video_id=video_id)
         manifest_url = manifest_url_root + video_id + '.json'
-        return manifest_url
-
-    def _get_manifest_from_manifest_url(self, manifest_url, video_id, webpage):
         manifest = self._download_json(
             manifest_url,
             video_id,
@@ -79,9 +59,6 @@ class CamModelsIE(InfoExtractor):
                 'Link to stream URLs was found, but we couldn\'t access it.',
                 expected=False,
                 video_id=video_id)
-        return manifest
-
-    def _get_formats_from_manifest(self, manifest, video_id):
         try:
             rtmp_formats = manifest['formats']['mp4-rtmp']['encodings']
             formats = []
@@ -115,4 +92,8 @@ class CamModelsIE(InfoExtractor):
                     'format_id': url.split(sep='/')[-1]
                 })
         self._sort_formats(formats)
-        return formats
+        return {
+            'id': video_id,
+            'title': self._live_title(video_id),
+            'formats': formats
+        }

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -1,0 +1,48 @@
+from __future__ import unicode_literals
+from .common import InfoExtractor
+
+class CamModelsIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?cammodels\.com/cam/(?P<id>\w+)'
+    _MANIFEST_URL_ROOT_REGEX = r'manifestUrlRoot=(?P<id>https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))'
+    _USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36'
+    # _TEST = {
+    #     'url': 'https://www.cammodels.com/cam/AutumnKnight',
+    #     'params': {
+    #         'skip_download': True,
+    #     },
+    #     'skip': _ROOM_OFFLINE,
+    #     'info_dict': {
+    #         'id': 'AutumnKnight',
+    #         'ext': 'flv'
+    #     }
+    # }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        headers = {
+            'User-Agent': self._USER_AGENT
+        }
+        webpage = self._download_webpage(url_or_request=url, video_id=video_id, headers=headers)
+        manifest_url_root = self._html_search_regex(self._MANIFEST_URL_ROOT_REGEX, webpage, 'manifest')
+        manifest_url = manifest_url_root + video_id + '.json'
+        manifest = self._download_json(manifest_url, video_id=video_id, headers=headers)
+        rtmp_formats = manifest['formats']['mp4-rtmp']['encodings']
+        formats = []
+        for format in rtmp_formats:
+            formats.append({
+                'ext': 'flv',
+                'url': format.get('location'),
+                'width': format.get('videoWidth'),
+                'height': format.get('videoHeight'),
+                'vbr': format.get('videoKbps'),
+                'abr': format.get('audioKbps'),
+                'format_id': str(format.get('videoWidth'))
+            })
+        self._sort_formats(formats)
+        return {
+            'id': video_id,
+            'title': self._live_title(video_id),
+            'age_limit': self._rta_search(webpage),
+            'ext': 'flv',
+            'formats': formats
+        }

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -55,13 +55,8 @@ class CamModelsIE(InfoExtractor):
             headers=self._HEADERS)
         try:
             formats = []
-            all_formats = manifest['formats']
-            for fmtName in all_formats:
-                fmt = all_formats[fmtName]
-                encodings = fmt.get('encodings')
-                if not encodings:
-                    continue
-                for encoding in encodings:
+            for fmtName in ['mp4-rtmp', 'mp4-hls']:
+                for encoding in manifest['formats'][fmtName]['encodings']:
                     formats.append({
                         'ext': 'mp4',
                         'url': encoding['location'],
@@ -86,7 +81,7 @@ class CamModelsIE(InfoExtractor):
             for manifest_link in manifest_links:
                 url = manifest_link.group('id')
                 formats.append({
-                    'ext': 'flv',
+                    'ext': 'mp4',
                     'url': url,
                     'format_id': url.split(sep='/')[-1]
                 })

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -28,7 +28,8 @@ class CamModelsIE(InfoExtractor):
                 r'(?P<id>I\'m offline, but let\'s stay connected!)',
                 webpage,
                 'offline indicator',
-                fatal=False)
+                None,
+                False)
             if offline:
                 raise ExtractorError(
                     'This user is currently offline, so nothing can be downloaded.',
@@ -38,7 +39,8 @@ class CamModelsIE(InfoExtractor):
                 r'(?P<id>I’m in a private show right now)',
                 webpage,
                 'private show indicator',
-                fatal=False)
+                None,
+                False)
             if private:
                 raise ExtractorError(
                     'This user is doing a private show, which requires payment. This extractor currently does not support private streams.',

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -6,7 +6,6 @@ import re
 from ..utils import int_or_none
 
 
-
 class CamModelsIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?cammodels\.com/cam/(?P<id>\w+)'
     _HEADERS = {
@@ -33,26 +32,20 @@ class CamModelsIE(InfoExtractor):
                 'offline indicator',
                 None,
                 False)
-            if offline:
-                raise ExtractorError(
-                    'This user is currently offline, so nothing can be downloaded.',
-                    expected=True,
-                    video_id=video_id)
             private = self._html_search_regex(
                 r'(?P<id>I’m in a private show right now)',
                 webpage,
                 'private show indicator',
                 None,
                 False)
-            if private:
-                raise ExtractorError(
-                    'This user is doing a private show, which requires payment. This extractor currently does not support private streams.',
-                    expected=True,
-                    video_id=video_id)
+            err = 'This user is currently offline, so nothing can be downloaded.' if offline \
+                else 'This user is doing a private show, which requires payment. This extractor currently does not support private streams.' if private \
+                else 'Unable to find link to stream info on webpage. Room is not offline, so something else is wrong.'
             raise ExtractorError(
-                'Unable to find link to stream info on webpage. Room is not offline, so something else is wrong.',
-                expected=False,
-                video_id=video_id)
+                err,
+                expected=True if offline or private else False,
+                video_id=video_id
+            )
         manifest_url = manifest_url_root + video_id + '.json'
         manifest = self._download_json(
             manifest_url,

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -9,59 +9,74 @@ class CamModelsIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?cammodels\.com/cam/(?P<id>\w+)'
     _HEADERS = {
         'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36'
+        # Needed because server doesn't return links to video URLs if a browser-like User-Agent is not used
     }
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        webpage = self._download_webpage(url_or_request=url, video_id=video_id, headers=self._HEADERS)
-        manifest_url = self._get_manifest_url_from_webpage(video_id=video_id, webpage=webpage)
-        manifest = self._get_manifest_from_manifest_url(manifest_url=manifest_url, video_id=video_id, webpage=webpage)
-        formats = self._get_formats_from_manifest(manifest=manifest, video_id=video_id)
+        webpage = self._download_webpage(
+            url,
+            video_id,
+            headers=self._HEADERS)
+        manifest_url = self._get_manifest_url_from_webpage(
+            webpage,
+            video_id)
+        manifest = self._get_manifest_from_manifest_url(
+            manifest_url,
+            video_id,
+            webpage)
+        formats = self._get_formats_from_manifest(
+            manifest,
+            video_id)
         return {
             'id': video_id,
             'title': self._live_title(video_id),
             'formats': formats
         }
 
-    def _get_manifest_url_from_webpage(self, video_id, webpage):
+    def _get_manifest_url_from_webpage(self, webpage, video_id):
         manifest_url_root = self._html_search_regex(
-            pattern=r'manifestUrlRoot=(?P<id>https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))',
-            string=webpage,
-            name='manifest',
+            r'manifestUrlRoot=(?P<id>https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))',
+            webpage,
+            'manifest',
             fatal=False)
         if not manifest_url_root:
             offline = self._html_search_regex(
-                pattern=r'(?P<id>I\'m offline, but let\'s stay connected!)',
-                string=webpage,
-                name='offline indicator',
+                r'(?P<id>I\'m offline, but let\'s stay connected!)',
+                webpage,
+                'offline indicator',
                 fatal=False)
             if offline:
                 raise ExtractorError(
-                    msg='This user is currently offline, so nothing can be downloaded.',
+                    'This user is currently offline, so nothing can be downloaded.',
                     expected=True,
                     video_id=video_id)
             private = self._html_search_regex(
-                pattern=r'(?P<id>I’m in a private show right now)',
-                string=webpage,
-                name='private show indicator',
+                r'(?P<id>I’m in a private show right now)',
+                webpage,
+                'private show indicator',
                 fatal=False)
             if private:
                 raise ExtractorError(
-                    msg='This user is doing a private show, which requires payment. This extractor currently does not support private streams.',
+                    'This user is doing a private show, which requires payment. This extractor currently does not support private streams.',
                     expected=True,
                     video_id=video_id)
             raise ExtractorError(
-                msg='Unable to find link to stream info on webpage. Room is not offline, so something else is wrong.',
+                'Unable to find link to stream info on webpage. Room is not offline, so something else is wrong.',
                 expected=False,
                 video_id=video_id)
         manifest_url = manifest_url_root + video_id + '.json'
         return manifest_url
 
     def _get_manifest_from_manifest_url(self, manifest_url, video_id, webpage):
-        manifest = self._download_json(url_or_request=manifest_url, video_id=video_id, headers=self._HEADERS, fatal=False)
+        manifest = self._download_json(
+            manifest_url,
+            video_id,
+            headers=self._HEADERS,
+            fatal=False)
         if not manifest:
             raise ExtractorError(
-                msg='Link to stream URLs was found, but we couldn\'t access it.',
+                'Link to stream URLs was found, but we couldn\'t access it.',
                 expected=False,
                 video_id=video_id)
         return manifest
@@ -84,11 +99,11 @@ class CamModelsIE(InfoExtractor):
         except:
             manifest_json = json.dumps(manifest)
             manifest_links = re.finditer(
-                pattern=r'(?P<id>rtmp?:\/\/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#&//=]*))',
-                string=manifest_json)
+                r'(?P<id>rtmp?:\/\/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#&//=]*))',
+                manifest_json)
             if not manifest_links:
                 raise ExtractorError(
-                    msg='Link to stream info was found, but we couldn\'t read the response. This is probably a bug.',
+                    'Link to stream info was found, but we couldn\'t read the response. This is probably a bug.',
                     expected=False,
                     video_id=video_id)
             formats = []

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from .common import InfoExtractor
 from .common import ExtractorError
 import json
+import re
 
 
 class CamModelsIE(InfoExtractor):
@@ -67,15 +68,16 @@ class CamModelsIE(InfoExtractor):
         # If they change the JSON format, then fallback to parsing out RTMP links via regex.
         except:
             manifest_json = json.dumps(manifest)
-            manifest_links = self._search_regex(pattern=self._RTMP_URL_FALLBACK, string=manifest_json, name='RTMP URLs', fatal=False)
+            manifest_links = re.finditer(pattern=self._RTMP_URL_FALLBACK, string=manifest_json)
             if not manifest_links:
                 raise ExtractorError(msg=self._RTMP_URL_FALLBACK_CONSOLE_ERROR, expected=False, video_id=video_id)
             formats = []
             for manifest_link in manifest_links:
+                url = manifest_link.group('id')
                 formats.append({
                     'ext': 'flv',
-                    'url': manifest_link,
-                    'format_id': manifest_link.split(sep='/')[-1]
+                    'url': url,
+                    'format_id': url.split(sep='/')[-1]
                 })
         self._sort_formats(formats)
         return formats

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -71,7 +71,7 @@ class CamModelsIE(InfoExtractor):
                     'format_id': str(format.get('videoWidth'))
                 })
         # If they change the JSON format, then fallback to parsing out RTMP links via regex.
-        except:
+        except KeyError:
             manifest_json = json.dumps(manifest)
             manifest_links = re.finditer(
                 r'(?P<id>rtmp?:\/\/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#&//=]*))',

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -3,6 +3,8 @@ from .common import InfoExtractor
 from .common import ExtractorError
 import json
 import re
+from ..utils import int_or_none
+
 
 
 class CamModelsIE(InfoExtractor):
@@ -70,10 +72,10 @@ class CamModelsIE(InfoExtractor):
                     formats.append({
                         'ext': 'mp4',
                         'url': encoding.get('location'),
-                        'width': encoding.get('videoWidth'),
-                        'height': encoding.get('videoHeight'),
-                        'vbr': encoding.get('videoKbps'),
-                        'abr': encoding.get('audioKbps'),
+                        'width': int_or_none(encoding.get('videoWidth')),
+                        'height': int_or_none(encoding.get('videoHeight')),
+                        'vbr': int_or_none(encoding.get('videoKbps')),
+                        'abr': int_or_none(encoding.get('audioKbps')),
                         'format_id': fmtName + str(encoding.get('videoWidth'))
                     })
         # If they change the JSON format, then fallback to parsing out RTMP links via regex.

--- a/youtube_dl/extractor/cammodels.py
+++ b/youtube_dl/extractor/cammodels.py
@@ -54,13 +54,9 @@ class CamModelsIE(InfoExtractor):
         manifest = self._download_json(
             manifest_url,
             video_id,
-            headers=self._HEADERS,
-            fatal=False)
-        if not manifest:
-            raise ExtractorError(
-                'Link to stream URLs was found, but we couldn\'t access it.',
-                expected=False,
-                video_id=video_id)
+            'Downloading links to streams.',
+            'Link to stream URLs was found, but we couldn\'t access it.',
+            headers=self._HEADERS)
         try:
             rtmp_formats = manifest['formats']['mp4-rtmp']['encodings']
             formats = []

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -144,6 +144,7 @@ from .camdemy import (
     CamdemyIE,
     CamdemyFolderIE
 )
+from .cammodels import CamModelsIE
 from .camwithher import CamWithHerIE
 from .canalplus import CanalplusIE
 from .canalc2 import Canalc2IE


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests: _Searching for "cammodels" repo-wide yielded no code or issue results_
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8): _Yes, on Python 3.6. Do I need to run it on other versions too?_

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

#### Extractor Info

Adds a new extractor for CamModels.com streaming video. Golden path example for a live stream: 

```
$ python3 -m youtube_dl -F https://www.cammodels.com/cam/AutumnKnight/
[CamModels] AutumnKnight: Downloading webpage
[CamModels] AutumnKnight: Downloading JSON metadata
[info] Available formats for AutumnKnight:
format code  extension  resolution note
256          flv        256x144     160k video@ 111k, audio@ 49k
654          flv        654x368     782k video@ 700k, audio@ 82k
1280         flv        1280x720   1736k video@1657k, audio@ 79k (best)
```

#### Current Limitations

I left the test case `_TEST` commented out. If you uncomment it and run `python3 test/test_download.py TestDownload.test_CamModels`, it passes vacuously, similar to the (useless) test code in `chaturbate.py`. 

Suggestions on how to meaningfully end-to-end test a streaming service where streams may or may not exist at a given time would be appreciated!