### PR TITLE
[wdr] New extractor "wdr:elefant" for videos of "Sendung mit dem Elefanten"

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1275,6 +1275,7 @@ from .watchbox import WatchBoxIE
 from .watchindianporn import WatchIndianPornIE
 from .wdr import (
     WDRIE,
+    WDRElefantIE,
     WDRMobileIE,
 )
 from .webcaster import (

--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -253,7 +253,10 @@ class WDRElefantIE(WDRBaseIE):
                 'id': 'mdb-1008774',
                 'ext': 'mp4',
                 'age_limit': None,
-                'upload_date': '20091119'
+                'upload_date': '20091119',
+            },
+            'params': {
+                'skip_download' : True,
             },
         },
         {
@@ -264,6 +267,9 @@ class WDRElefantIE(WDRBaseIE):
                 'ext': 'mp4',
                 'age_limit': None,
                 'upload_date': '20150406'
+            },
+            'params': {
+                'skip_download' : True,
             },
         },
     ]

--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -16,7 +16,7 @@ from ..utils import (
 
 
 class WDRBaseIE(InfoExtractor):
-    def _extract_wdr_video(self, webpage, display_id):
+    def _extract_jsonp_url(self, webpage, display_id):
         # for wdr.de the data-extension is in a tag with the class "mediaLink"
         # for wdr.de radio players, in a tag with the class "wdrrPlayerPlayBtn"
         # for wdrmaus, in a tag with the class "videoButton" (previously a link
@@ -35,8 +35,9 @@ class WDRBaseIE(InfoExtractor):
 
         media_link_obj = self._parse_json(json_metadata, display_id,
                                           transform_source=js_to_json)
-        jsonp_url = media_link_obj['mediaObj']['url']
+        return media_link_obj['mediaObj']['url']
 
+    def _extract_wdr_video(self, jsonp_url, display_id):
         metadata = self._download_json(
             jsonp_url, display_id, transform_source=strip_jsonp)
 
@@ -206,7 +207,8 @@ class WDRIE(WDRBaseIE):
         display_id = mobj.group('display_id')
         webpage = self._download_webpage(url, display_id)
 
-        info_dict = self._extract_wdr_video(webpage, display_id)
+        jsonp_url = self._extract_jsonp_url(webpage, display_id)
+        info_dict = self._extract_wdr_video(jsonp_url, display_id)
 
         if not info_dict:
             entries = [

--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -247,19 +247,6 @@ class WDRElefantIE(WDRBaseIE):
 
     _TESTS = [
         {
-            'url': 'http://www.wdrmaus.de/elefantenseite/#lieder_geburtstagslied',
-            'info_dict': {
-                'title': 'Ich bin schon 1-2-3',
-                'id': 'mdb-1008774',
-                'ext': 'mp4',
-                'age_limit': None,
-                'upload_date': '20091119',
-            },
-            'params': {
-                'skip_download' : True,
-            },
-        },
-        {
             'url': 'http://www.wdrmaus.de/elefantenseite/#folge_ostern_2015',
             'info_dict': {
                 'title': 'Folge Oster-Spezial 2015',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

New extractor "wdr:elefant" (sub-extractor of "wdr") to support videos of the "Sendung mit dem Elefanten" (a children's show) at http://www.wdrmaus.de/elefantenseite/ . See commit message for technical details.
