### PR TITLE
[daum] Fix clipID-based downloads

### DIFF
--- a/youtube_dl/extractor/daum.py
+++ b/youtube_dl/extractor/daum.py
@@ -40,11 +40,11 @@ class DaumIE(InfoExtractor):
     }, {
         'url': 'http://m.tvpot.daum.net/v/65139429',
         'info_dict': {
-            'id': '65139429',
+            'id': 'v4e99Kd61HUKxI18xR87xRb',
             'ext': 'mp4',
             'title': '1297회, \'아빠 아들로 태어나길 잘 했어\' 민수, 감동의 눈물[아빠 어디가] 20150118',
-            'description': 'md5:79794514261164ff27e36a21ad229fc5',
-            'upload_date': '20150604',
+            'description': 'md5:4c1f30a96780bb3cb739f8878d623998',
+            'upload_date': '20150118',
             'thumbnail': r're:^https?://.*\.(?:jpg|png)',
             'duration': 154,
             'view_count': int,
@@ -73,9 +73,9 @@ class DaumIE(InfoExtractor):
         'info_dict': {
             'id': 's3794Uf1NZeZ1qMpGpeqeRU',
             'ext': 'mp4',
-            'title': '러블리즈 - Destiny (나의 지구) (Lovelyz - Destiny) [쇼! 음악중심] 508회 20160611',
+            'title': '러블리즈 - Destiny (나의 지구) (Lovelyz - Destiny)',
             'description': '러블리즈 - Destiny (나의 지구) (Lovelyz - Destiny)\n\n[쇼! 음악중심] 20160611, 507회',
-            'upload_date': '20160611',
+            'upload_date': '20170129',
         },
     }]
 
@@ -134,7 +134,7 @@ class DaumClipIE(InfoExtractor):
     _TESTS = [{
         'url': 'http://tvpot.daum.net/clip/ClipView.do?clipid=52554690',
         'info_dict': {
-            'id': '52554690',
+            'id': 'v3280SFuC8mSOVu4S8uKV6O',
             'ext': 'mp4',
             'title': 'DOTA 2GETHER 시즌2 6회 - 2부',
             'description': 'DOTA 2GETHER 시즌2 6회 - 2부',
@@ -154,6 +154,15 @@ class DaumClipIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
+
+        # Try to use vid-based URL if found
+        webpage = self._download_webpage(url, video_id, 'Requesting webpage', fatal=False)
+        if webpage:
+            canonical = self._html_search_regex(
+                r'<link rel="canonical" href="(http://tvpot\.daum\.net/v/[a-zA-Z0-9]+)">', webpage, 'Canonical link', fatal=False)
+            if canonical:
+                return self.url_result(canonical)
+
         clip_info = self._download_json(
             'http://tvpot.daum.net/mypot/json/GetClipInfo.do?clipid=%s' % video_id,
             video_id, 'Downloading clip info')['clip_bean']
@@ -224,7 +233,7 @@ class DaumPlaylistIE(DaumListIE):
         'note': 'Playlist url with clipid - noplaylist',
         'url': 'http://tvpot.daum.net/mypot/View.do?playlistid=6213966&clipid=73806844',
         'info_dict': {
-            'id': '73806844',
+            'id': 'vd7b2Qo00SCVoY7Y9oVFVPV',
             'ext': 'mp4',
             'title': '151017 Airport',
             'upload_date': '20160117',
@@ -265,11 +274,11 @@ class DaumUserIE(DaumListIE):
     }, {
         'url': 'http://tvpot.daum.net/mypot/View.do?ownerid=o2scDLIVbHc0&clipid=73801156',
         'info_dict': {
-            'id': '73801156',
+            'id': 'v421acTB5c2UTMaMET2E2h2',
             'ext': 'mp4',
             'title': '[미공개] 김구라, 오만석이 부릅니다 \'오케피\' - 마이 리틀 텔레비전 20160116',
-            'upload_date': '20160117',
-            'description': 'md5:5e91d2d6747f53575badd24bd62b9f36'
+            'upload_date': '20160116',
+            'description': 'md5:0c56847079326aed96892d52db0399cc'
         },
         'params': {
             'noplaylist': True,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some daum.net URLs have a alphanumeric **video ID** called `vid`, which looks like `v2b9eCxzw1EzE6swwSS4Okz`. An example URL is `http://tvpot.daum.net/v/v2b9eCxzw1EzE6swwSS4Okz`

Some other URLs have a numeric **clip ID** called `clipid`, which looks like `66008403`. An example URL is `http://tvpot.daum.net/v/66008403`

Currently, download for URLs with clip IDs is broken. This commit fixes it, and also updates the expected test data.

It achieves it by redirecting it to the `vid`-based URL. The URL can be found from the canonical `link` tag, which is explained later. I'm not sure if the `vid` is always present in this manner in clip ID-based pages. But 10 pages of 10 I saw had them, and I don't think there could be a reason other pages won't have it.

TODO: Some other features of `daum.net`, such as playlists, are still broken. Those should be fixed later.
In fact, TVPot has disabled almost all of its features, so playlists might not work from now on. Some old API endpoints are still alive and current extractor is using them, like in [daum.py#L85](https://github.com/rg3/youtube-dl/blob/6d0630d8801fd3278a05fa7e55a73bd454403e5a/youtube_dl/extractor/daum.py#L85). 

##### Explanation of the canonical `link` tag
`<link rel="canonical" href="http://example.com">`
This kind of tag, presented in `<head>`, is originally meant for search engines to correctly discern and group URLs. Often is the case where the same page can be accessed via a few different URLs. This tag tells the search engine that it can consider this page **as** the page given in the `href` attribute, making the search results faster and more accurate.