### PR TITLE
[abc.net.au:iview] use metered hls urls #14711

### DIFF
--- a/youtube_dl/extractor/abc.py
+++ b/youtube_dl/extractor/abc.py
@@ -133,8 +133,8 @@ class ABCIViewIE(InfoExtractor):
         time_str = str(int(time.time()))
         house_number = video_params.get('episodeHouseNumber')
         path = '/auth/hls/sign?ts={0}&hn={1}&d=android-mobile'.format(
-            time_str, house_number).encode('utf-8')
-        sig = hmac.new(key, path, hashlib.sha256).hexdigest()
+            time_str, house_number)
+        sig = hmac.new(key, path.encode('utf-8'), hashlib.sha256).hexdigest()
         auth_url = 'http://iview.abc.net.au{0}&sig={1}'.format(path, sig)
         token = self._download_webpage(auth_url, video_id)
 

--- a/youtube_dl/extractor/abc.py
+++ b/youtube_dl/extractor/abc.py
@@ -157,7 +157,7 @@ class ABCIViewIE(InfoExtractor):
         for format_url in format_urls:
             if format_url:
                 formats.extend(
-                    self._extract_akamai_formats(format_url, video_id))
+                    self._extract_m3u8_formats(format_url, video_id, 'mp4'))
         self._sort_formats(formats)
 
         subtitles = {}

--- a/youtube_dl/extractor/abc.py
+++ b/youtube_dl/extractor/abc.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
+import hashlib
+import hmac
 import re
+import time
 
 from .common import InfoExtractor
 from ..compat import compat_str
@@ -126,14 +129,29 @@ class ABCIViewIE(InfoExtractor):
         title = video_params.get('title') or video_params['seriesTitle']
         stream = next(s for s in video_params['playlist'] if s.get('type') == 'program')
 
-        format_urls = [
-            try_get(stream, lambda x: x['hds-unmetered'], compat_str)]
+        key = 'android.content.res.Resources'.encode('utf-8')
+        time_str = str(int(time.time()))
+        house_number = video_params.get('episodeHouseNumber')
+        path = '/auth/hls/sign?ts={0}&hn={1}&d=android-mobile'.format(
+            time_str, house_number).encode('utf-8')
+        sig = hmac.new(key, path, hashlib.sha256).hexdigest()
+        auth_url = 'http://iview.abc.net.au{0}&sig={1}'.format(path, sig)
+        token = self._download_webpage(auth_url, video_id)
+
+        format_urls = []
+
+        def tokenize_url(url, token):
+            return ''.join([url, '?hdnea=', token])
 
         # May have higher quality video
         sd_url = try_get(
-            stream, lambda x: x['streams']['hds']['sd'], compat_str)
+            stream, lambda x: x['streams']['hls']['sd'], compat_str)
         if sd_url:
-            format_urls.append(sd_url.replace('metered', 'um'))
+            format_urls.append(tokenize_url(sd_url, token))
+        else:
+            sd_low_url = try_get(
+                stream, lambda x: x['streams']['hls']['sd-low'], compat_str)
+            format_urls.append(tokenize_url(sd_low_url, token))
 
         formats = []
         for format_url in format_urls:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

ABC dropped unmetering so the 'hds-unmetered' stream points to the metered server which requires an auth step. The 'sd' stream still works and the same workaround would work, but it may go at any time so I've done the auth step to use the unmetered hls streams.