### PR TITLE
[extractor/openload] Closes #14665

### DIFF
--- a/youtube_dl/extractor/openload.py
+++ b/youtube_dl/extractor/openload.py
@@ -302,6 +302,7 @@ class OpenloadIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         url = 'https://openload.co/embed/%s/' % video_id
+        url2 = 'https://openload.co/f/%s/' % video_id
         headers = {
             'User-Agent': self._USER_AGENT,
         }
@@ -309,7 +310,10 @@ class OpenloadIE(InfoExtractor):
         webpage = self._download_webpage(url, video_id, headers=headers)
 
         if 'File not found' in webpage or 'deleted by the owner' in webpage:
-            raise ExtractorError('File not found', expected=True, video_id=video_id)
+            url = url2
+            webpage = self._download_webpage(url, video_id, headers=headers)
+            if 'File not found' in webpage or 'deleted by the owner' in webpage:
+                raise ExtractorError('File not found', expected=True, video_id=video_id)
 
         phantom = PhantomJSwrapper(self, required_version='2.0')
         webpage, _ = phantom.get(url, html=webpage, video_id=video_id, headers=headers)


### PR DESCRIPTION
Fixes issue with OpenLoad where /embed/ link shows file as deleted but /f/ does not

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

In #14665 the user is unable to download the file located at https://openload.co/f/e-Ixz9ZR5L0/ The reason for this seems to be because the openload extractor is searching for the file /embed/ link specifically in the source: url = 'https://openload.co/embed/%s/' % video_id

This should be fine but there seems to be a bug with openload.co itself in that the video file on the original link (https://openload.co/f/e-Ixz9ZR5L0/) exists and is fine, but the embed link (https://openload.co/embed/e-Ixz9ZR5L0/) is dead for some reason. This pull requests handles that case adding a fallback to a second webpage parse using the /f/ url.

If the file truly doesn't exist the extractor still throws the same exception, this pull request only adds a second attempt for the strange corner case.
