### PR TITLE
Youtube content disposition fix

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -272,6 +272,11 @@ class YoutubeDL(object):
                        Must only be used along with sleep_interval.
                        Actual sleep time will be a random float from range
                        [sleep_interval; max_sleep_interval].
+    youtube_prefer_get_video_info: By prefering a Youtube link extracted from
+                       get_video_info instead of the video's webpage, Youtube
+                       is likely to send a link with the
+                       'content-disposition: Attachment' header added (provided
+                       you add the '&title=....' option to the link)
     listformats:       Print an overview of available video formats and exit.
     list_thumbnails:   Print a table of all thumbnails and exit.
     match_filter:      A function that gets called with the info_dict of

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -408,6 +408,7 @@ def _real_main(argv=None):
         'call_home': opts.call_home,
         'sleep_interval': opts.sleep_interval,
         'max_sleep_interval': opts.max_sleep_interval,
+        'youtube_prefer_get_video_info': opts.youtube_prefer_get_video_info,
         'external_downloader': opts.external_downloader,
         'list_thumbnails': opts.list_thumbnails,
         'playlist_items': opts.playlist_items,

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1550,7 +1550,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 if args.get('livestream') == '1' or args.get('live_playback') == 1:
                     is_live = True
                 sts = ytplayer_config.get('sts')
-            if not video_info or self._downloader.params.get('youtube_include_dash_manifest', True):
+            if not video_info or self._downloader.params.get('youtube_include_dash_manifest', True) or self._downloader.params.get('youtube_prefer_get_video_info', True):                
                 # We also try looking in get_video_info since it may contain different dashmpd
                 # URL that points to a DASH manifest with possibly different itag set (some itags
                 # are missing from DASH manifest pointed by webpage's dashmpd, some - from DASH
@@ -1558,7 +1558,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 # The general idea is to take a union of itags of both DASH manifests (for example
                 # video with such 'manifest behavior' see https://github.com/rg3/youtube-dl/issues/6093)
                 self.report_video_info_webpage_download(video_id)
-                for el in ('info', 'embedded', 'detailpage', 'vevo', ''):
+                # el=detailpage makes the resulting extracted urls ignore the 'title' parameter, thus, omiting the content-disposition: Attachment header
+                # that's why it should be the last option:
+                for el in ('info', 'embedded', 'vevo', '', 'detailpage'):
                     query = {
                         'video_id': video_id,
                         'ps': 'default',
@@ -1593,7 +1595,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         # due to YouTube measures against IP ranges of hosting providers.
                         # Working around by preferring the first succeeded video_info containing
                         # the token if no such video_info yet was found.
-                        if 'token' not in video_info:
+                        if 'token' not in video_info  or self._downloader.params.get('youtube_prefer_get_video_info', True):
                             video_info = get_video_info
                         break
         if 'token' not in video_info:

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1558,9 +1558,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 # The general idea is to take a union of itags of both DASH manifests (for example
                 # video with such 'manifest behavior' see https://github.com/rg3/youtube-dl/issues/6093)
                 self.report_video_info_webpage_download(video_id)
-                # el=detailpage makes the resulting extracted urls ignore the 'title' parameter, thus, omiting the content-disposition: Attachment header
-                # that's why it should be the last option:
-                for el in ('info', 'embedded', 'vevo', '', 'detailpage'):
+                if self._downloader.params.get('youtube_prefer_get_video_info', True):
+                    # el=detailpage makes the resulting extracted urls ignore the 'title' parameter, thus, omiting the content-disposition: Attachment header
+                    # that's why it should be the last option:
+                    el_order = ('info', 'embedded', 'vevo', '', 'detailpage')
+                else:
+                    el_order = ('info', 'embedded', 'detailpage', 'vevo', ''):
+                for el in el_order:
                     query = {
                         'video_id': video_id,
                         'ps': 'default',

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1563,7 +1563,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     # that's why it should be the last option:
                     el_order = ('info', 'embedded', 'vevo', '', 'detailpage')
                 else:
-                    el_order = ('info', 'embedded', 'detailpage', 'vevo', ''):
+                    el_order = ('info', 'embedded', 'detailpage', 'vevo', '')
                 for el in el_order:
                     query = {
                         'video_id': video_id,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -563,7 +563,15 @@ def parseOpts(overrideArguments=None):
             'Upper bound of a range for randomized sleep before each download '
             '(maximum possible number of seconds to sleep). Must only be used '
             'along with --min-sleep-interval.'))
-
+    workarounds.add_option(
+        '--youtube-prefer-get-video-info',
+        action='store_true', dest='youtube_prefer_get_video_info', default=False,
+        help=(
+            'By prefering a Youtube link extracted from get_video_info instead '
+            'of the video\'s webpage, Youtube is likely to send a link with the '
+            '"content-disposition: Attachment" header added (provided you add the '
+            '"&title=...." option to the link)'))
+    
     verbosity = optparse.OptionGroup(parser, 'Verbosity / Simulation Options')
     verbosity.add_option(
         '-q', '--quiet',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This fix relates to the Youtube extractor. Specifically, it deals with the issue of youtube ignoring the '&title=...' URL option in some links. The '&title=...' options lets us specify a filename for when downloading the file directly from the Youtube servers, and it also sets a 'content-disposition: attachment' header which allows the file to get downloaded directly from the web browser. 
I found that by giving higher priority to the Youtube links extracted from the get_video_info page Youtube gives us links that can accept the &title= option.

In order to activate this feature I added a workaround option: "--youtube-prefer-get-video-info"

Demonstration of the feature:
If you run the following command:
`youtube-dl -f 18 --get-url https://www.youtube.com/watch?v=41ILD_pVxFo`
You will get a url that, if you append &title=myvideotitle at the end and open it in your browser, it will simply start playing the video in the browser.

However, if you run it with the --youtube-prefer-get-video-info option as:
`youtube-dl --youtube-prefer-get-video-info -f 18 --get-url https://www.youtube.com/watch?v=41ILD_pVxFo`
You will get a url that, if you append &title=myvideotitle at the end and open it in your browser, it will start downloading the video using a 'content-disposition: attachment' header and the filename "myvideotitle.mp4"
