### PR TITLE
[iprima] Fix extraction, add new valid URLs, update videos in tests

### DIFF
--- a/youtube_dl/extractor/iprima.py
+++ b/youtube_dl/extractor/iprima.py
@@ -16,7 +16,7 @@ class IPrimaIE(InfoExtractor):
     _GEO_BYPASS = False
 
     _TESTS = [{
-        'url': 'http://play.iprima.cz/gondici-s-r-o-33',
+        'url': 'http://play.iprima.cz/gondici-s-r-o/gondici-s-r-o-34',
         'info_dict': {
             'id': 'p136534',
             'ext': 'mp4',
@@ -31,7 +31,8 @@ class IPrimaIE(InfoExtractor):
         'only_matching': True,
     }, {
         # geo restricted
-        'url': 'http://play.iprima.cz/closer-nove-pripady/closer-nove-pripady-iv-1',
+        'url': 'http://play.iprima.cz/closer-nove-pripady/closer-nove-pripady/closer-nove-pripady-'
+               'iv-1/closer-nove-pripady-iv-1-upoutavka',
         'only_matching': True,
     }]
 

--- a/youtube_dl/extractor/iprima.py
+++ b/youtube_dl/extractor/iprima.py
@@ -34,6 +34,28 @@ class IPrimaIE(InfoExtractor):
         'url': 'http://play.iprima.cz/closer-nove-pripady/closer-nove-pripady/closer-nove-pripady-'
                'iv-1/closer-nove-pripady-iv-1-upoutavka',
         'only_matching': True,
+    }, {
+        'url': 'http://prima.iprima.cz/zpravodajstvi/10122017-0',
+        'info_dict': {
+            'id': 'p407787',
+            'ext': 'mp4',
+            'title': 'Zpravodajství FTV Prima, Zpravodajství FTV Prima 10.12.2017 | Prima',
+            'description': 'md5:d3640eaccd3a66423c86f8942d79d5ce',
+        },
+        'params': {
+            'skip_download': True,  # m3u8 download
+        },
+    }, {
+        'url': 'http://cool.iprima.cz/porady/tezka-drina/pila-0',
+        'info_dict': {
+            'id': 'p32629',
+            'ext': 'mp4',
+            'title': 'Těžká dřina, 5. epizoda - Pila | Prima Cool',
+            'description': 'md5:ab9ad7b8af739fed79185c4e58bc599d',
+        },
+        'params': {
+            'skip_download': True,  # m3u8 download
+        },
     }]
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/iprima.py
+++ b/youtube_dl/extractor/iprima.py
@@ -12,7 +12,7 @@ from ..utils import (
 
 
 class IPrimaIE(InfoExtractor):
-    _VALID_URL = r'https?://play\.iprima\.cz/(?:.+/)?(?P<id>[^?#]+)'
+    _VALID_URL = r'https?://(?:prima|cool|max|zoom|love|play)\.iprima\.cz/(?:.+/)?(?P<id>[^?#]+)'
     _GEO_BYPASS = False
 
     _TESTS = [{
@@ -40,15 +40,16 @@ class IPrimaIE(InfoExtractor):
 
         webpage = self._download_webpage(url, video_id)
 
-        video_id = self._search_regex(r'data-product="([^"]+)">', webpage, 'real id')
+        video_id = self._search_regex(r'(?:prehravac/embedded\?id=|productId: \')(p[0-9]+)', webpage, 'real id')
 
         playerpage = self._download_webpage(
-            'http://play.iprima.cz/prehravac/init',
+            'http://api.play-backend.iprima.cz/prehravac/init-embed',
             video_id, note='Downloading player', query={
                 '_infuse': 1,
                 '_ts': round(time.time()),
                 'productId': video_id,
-            }, headers={'Referer': url})
+                'embed': 'true',
+            }, headers={'Referer': 'http://api.play-backend.iprima.cz/prehravac/embedded?id=' + video_id})
 
         formats = []
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

IPrima.cz changed their URLs, they now have a subdomain for each of their TV Channels (`prima.iprima.cz`, `cool.iprima.cz` etc.). But the old `play.iprima.cz` is still in use, too, maybe temporarily (not sure about that). Anyway, this extractor now supports both old and new URLs.

I've also replaced URLs in `_TESTS` that were returning 404 with working ones (well, for now, iprima seems to move/delete stuff a lot), and added two additional tests with the new scheme URLs.

Should fix:

Fixes #14504 (the original URL is `410 Gone`, but the one in the second comment works).
Most likely fixes #14654, too, but the URL 404ed and i don't have an account anyway… i've left a comment for the reporter.
