### PR TITLE
ffmpeg postprocessor use playlist_index for track metadata when track_number does not set

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -419,6 +419,8 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         add(('description', 'comment'), 'description')
         add('purl', 'webpage_url')
         add('track', 'track_number')
+        if metadata.get('track') is None:
+            add('track', 'playlist_index')
         add('artist', ('artist', 'creator', 'uploader', 'uploader_id'))
         add('genre')
         add('album')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.


When using the --add-metadata option and with regard to the ffmpeg postprocessor use playlist_index for track metadata in lieu of track_number when the latter does not exist.
This is a useful behavior to me of which I think would be of use to others. As well, there are also issues filed in regard to this - #13271 and #7393
