### PR TITLE
[Soundcloud] Also use avatar picture for thumbnail (fixes issue #12878)

### DIFF
--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -136,6 +136,38 @@ class SoundcloudIE(InfoExtractor):
                 'license': 'all-rights-reserved',
             },
         },
+        # use album art for thumbnail
+        {
+            'url': 'https://soundcloud.com/postmalone/rockstar-feat-21-savage',
+            'md5': '631b6b41bdfb5c1e466e207a7afaf3ed',
+            'info_dict': {
+                'id': '341546259',
+                'ext': 'mp3',
+                'title': 'rockstar (feat. 21 Savage)',
+                'description': None,
+                'uploader': 'Post Malone',
+                'upload_date': '20170908',
+                'duration': 218,
+                'thumbnail': 'https://i1.sndcdn.com/artworks-JbxEN7x8VfRc-0-t500x500.jpg',
+                'license': 'all-rights-reserved',
+            },
+        },
+        # no album art, use avatar pic for thumbnail
+        {
+            'url': 'https://soundcloud.com/garyvee/sideways-prod-mad-real',
+            'md5': '59c7872bc44e5d99b7211891664760c2',
+            'info_dict': {
+                'id': '309699954',
+                'ext': 'mp3',
+                'title': 'Sideways (Prod. Mad Real)',
+                'description': 'md5:d41d8cd98f00b204e9800998ecf8427e',
+                'uploader': 'garyvee',
+                'upload_date': '20170226',
+                'duration': 207,
+                'thumbnail': 'https://i1.sndcdn.com/avatars-000298106657-ogrgmg-t500x500.jpg',
+                'license': 'all-rights-reserved',
+            },
+        },
     ]
 
     _CLIENT_ID = 'c6CU49JDMapyrQo06UxU9xouB9ZVzqCn'

--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -160,7 +160,7 @@ class SoundcloudIE(InfoExtractor):
         name = full_title or track_id
         if quiet:
             self.report_extraction(name)
-        thumbnail = info.get('artwork_url')
+        thumbnail = info.get('artwork_url') or info.get('user', {}).get('avatar_url')
         if isinstance(thumbnail, compat_str):
             thumbnail = thumbnail.replace('-large', '-t500x500')
         ext = 'mp3'

--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -136,22 +136,6 @@ class SoundcloudIE(InfoExtractor):
                 'license': 'all-rights-reserved',
             },
         },
-        # use album art for thumbnail
-        {
-            'url': 'https://soundcloud.com/postmalone/rockstar-feat-21-savage',
-            'md5': '631b6b41bdfb5c1e466e207a7afaf3ed',
-            'info_dict': {
-                'id': '341546259',
-                'ext': 'mp3',
-                'title': 'rockstar (feat. 21 Savage)',
-                'description': None,
-                'uploader': 'Post Malone',
-                'upload_date': '20170908',
-                'duration': 218,
-                'thumbnail': 'https://i1.sndcdn.com/artworks-JbxEN7x8VfRc-0-t500x500.jpg',
-                'license': 'all-rights-reserved',
-            },
-        },
         # no album art, use avatar pic for thumbnail
         {
             'url': 'https://soundcloud.com/garyvee/sideways-prod-mad-real',
@@ -164,8 +148,11 @@ class SoundcloudIE(InfoExtractor):
                 'uploader': 'garyvee',
                 'upload_date': '20170226',
                 'duration': 207,
-                'thumbnail': 'https://i1.sndcdn.com/avatars-000298106657-ogrgmg-t500x500.jpg',
+                'thumbnail': r're:https?://.*\.jpg',
                 'license': 'all-rights-reserved',
+            },
+            'params': {
+                'skip_download': True,
             },
         },
     ]


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

Updated the extractor for the Soundcloud.com website to use the avatar picture when the album artwork is not available - issue #12878.  Apparently a number of tracks on this site do not feature any album art.

Cheers,

Parmjit V.