### PR TITLE
[Tumblr] Add login support

### DIFF
--- a/youtube_dl/extractor/tumblr.py
+++ b/youtube_dl/extractor/tumblr.py
@@ -4,11 +4,19 @@ from __future__ import unicode_literals
 import re
 
 from .common import InfoExtractor
-from ..utils import int_or_none
+from ..utils import (
+    ExtractorError,
+    int_or_none,
+    sanitized_Request,
+    urlencode_postdata
+)
 
 
 class TumblrIE(InfoExtractor):
     _VALID_URL = r'https?://(?P<blog_name>[^/?#&]+)\.tumblr\.com/(?:post|video)/(?P<id>[0-9]+)(?:$|[/?#])'
+    _NETRC_MACHINE = 'tumblr'
+    _LOGIN_REQUIRED = False
+    _LOGIN_URL = 'https://www.tumblr.com/login'
     _TESTS = [{
         'url': 'http://tatianamaslanydaily.tumblr.com/post/54196191430/orphan-black-dvd-extra-behind-the-scenes',
         'md5': '479bb068e5b16462f5176a6828829767',
@@ -96,6 +104,31 @@ class TumblrIE(InfoExtractor):
         },
         'add_ie': ['Instagram'],
     }]
+
+    def _real_initialize(self):
+        self._login()
+
+    def _login(self):
+        (username, password) = self._get_login_info()
+        if username is None:
+            return
+        self.report_login()
+        webpage = self._download_webpage(self._LOGIN_URL, None, False)
+        form = self._hidden_inputs(webpage)
+        form.update({
+            'user[email]': username,
+            'user[password]': password
+        })
+        post_data = urlencode_postdata(form)
+        login_request = sanitized_Request(self._LOGIN_URL, post_data)
+        login_request.add_header('Content-Type', 'application/x-www-form-urlencoded')
+        login_request.add_header('Referer', self._LOGIN_URL)
+        login_response = self._download_webpage(login_request, None, False, 'Wrong login info')
+
+        # Check the login response from Tumblr for an error message and fail the extraction if we find one.
+        login_errors = self._search_regex(r'Tumblr\.RegistrationForm\.errors = \[(.*)\]', login_response, 'login errors', False, False)
+        if login_errors:
+            raise ExtractorError("Error logging in: %s" % login_errors)
 
     def _real_extract(self, url):
         m_url = re.match(self._VALID_URL, url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I've added login support for Tumblr. Some time in the last year, Tumblr has made it impossible to download explicit content without logging in. When you try to view explicit content without being logged in, you're redirected to a splash screen (https://www.tumblr.com/safe-mode?url=...) which youtube-dl then passes to the generic downloader. This results in HTML pages being downloaded with weird names, such as "safe-mode-168487385934.unknown_video"

The addition of login support allows these URLs to be downloaded without issue. I've tested this locally with both the regular `--username` and `--password` flags and the ~/.netrc file and `-n` flag.

I'm not a Python developer by trade, so please excuse the code if it's a bit off. I believe the code passes flake8 - I ran `flake8 tumblr.py` locally and there wasn't any output.

Please let me know if there's anything else I can do to improve the code. Thanks for your work in maintaining youtube-dl!