### PR TITLE
[twitch] Determine ids from URLs when extracting playlist

### DIFF
--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -358,8 +358,16 @@ class TwitchPlaylistBaseIE(TwitchBaseIE):
                 break
             offset += limit
         return self.playlist_result(
-            [self.url_result(entry) for entry in orderedSet(entries)],
+            [self._make_url_result(entry) for entry in orderedSet(entries)],
             channel_id, channel_name)
+
+    def _make_url_result(self, url):
+        try:
+            video_id = 'v%s' % TwitchVodIE._match_id(url)
+            return self.url_result(url, TwitchVodIE.ie_key(), video_id=video_id)
+        except AssertionError:
+            self.to_screen('Unable to match video ID from URL: %s' % url)
+        return self.url_result(url)
 
     def _extract_playlist_page(self, response):
         videos = response.get('videos')

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -366,8 +366,7 @@ class TwitchPlaylistBaseIE(TwitchBaseIE):
             video_id = 'v%s' % TwitchVodIE._match_id(url)
             return self.url_result(url, TwitchVodIE.ie_key(), video_id=video_id)
         except AssertionError:
-            self.to_screen('Unable to match video ID from URL: %s' % url)
-        return self.url_result(url)
+            return self.url_result(url)
 
     def _extract_playlist_page(self, response):
         videos = response.get('videos')


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Using the `--download-archive` parameter, youtube-dl can skip videos that it has already downloaded, as soon as it determines that the extractor and video ID match an existing video. For Twitch, the video ID for a VOD is determined as part of a JSON request in `_real_extract(...)`. However, the video ID can also be reliably determined from the URL; the ID is part of the URL, with a leading `v`. The Twitch extractor already relies on this behaviour for downloading rechat subtitles.

With this pull request, when extracting a playlist, the URL is checked against `_match_id(...)` for the VOD extractor. If it matches, we now return the video ID alongside the URL, so that the video can be skipped if desired without needing to make a JSON request. This makes it significantly faster to check for new videos on a channel, and reduces the number of API calls. If it turns out that a URL in the playlist does not match our expectations, we fall back to the old behaviour of simply returning the URL.

An excerpt from a download *without* this pull request (several seconds between each video):
```
...
[download] Downloading video 80 of 84
[twitch:vod] 204792451: Downloading vod info JSON
[twitch:vod] 204792451: Downloading vod access token
[twitch:vod] 204792451: Downloading m3u8 information
[download] Building the new Editing/Streaming/Gaming PC has already been recorded in archive
[download] Downloading video 81 of 84
[twitch:vod] 204821085: Downloading vod info JSON
[twitch:vod] 204821085: Downloading vod access token
[twitch:vod] 204821085: Downloading m3u8 information
[download] PC build, the final solution has already been recorded in archive
[download] Downloading video 82 of 84
[twitch:vod] 204850361: Downloading vod info JSON
[twitch:vod] 204850361: Downloading vod access token
[twitch:vod] 204850361: Downloading m3u8 information
[download] PC build, COMPLETE! (testing) has already been recorded in archive
[download] Downloading video 83 of 84
[twitch:vod] 207644374: Downloading vod info JSON
[twitch:vod] 207644374: Downloading vod access token
[twitch:vod] 207644374: Downloading m3u8 information
[download] pubg sQUADS has already been recorded in archive
[download] Downloading video 84 of 84
[twitch:vod] 212555204: Downloading vod info JSON
[twitch:vod] 212555204: Downloading vod access token
[twitch:vod] 212555204: Downloading m3u8 information
[download] PUBG XMAS has already been recorded in archive
```

And now, from a similar download *with* this pull request (near-instant):
```
...
[download] Downloading video 60 of 100
[download] v205683181 has already been recorded in archive
[download] Downloading video 61 of 100
[download] v207626842 has already been recorded in archive
[download] Downloading video 62 of 100
[download] v203168347 has already been recorded in archive
[download] Downloading video 63 of 100
[download] v205130464 has already been recorded in archive
[download] Downloading video 64 of 100
```

Finally, to demonstrate sane fallback to the old behaviour, if we simulate an error extracting the video ID by altering the code to pass a bad URL to `_match_id`, we get an excerpt like the following:
```
...
[twitch:videos:past-broadcasts] Unable to match video ID from URL: https://www.twitch.tv/videos/188047675
[twitch:videos:past-broadcasts] Unable to match video ID from URL: https://www.twitch.tv/videos/187769206
[twitch:videos:past-broadcasts] Unable to match video ID from URL: https://www.twitch.tv/videos/187452839
[twitch:videos:past-broadcasts] Unable to match video ID from URL: https://www.twitch.tv/videos/187354420
[twitch:videos:past-broadcasts] Unable to match video ID from URL: https://www.twitch.tv/videos/187171654
[download] Downloading playlist: Coestar
[twitch:videos:past-broadcasts] playlist Coestar: Collected 100 video ids (downloading 100 of them)
[download] Downloading video 1 of 100
[twitch:vod] 213467862: Downloading vod info JSON
[twitch:vod] 213467862: Downloading vod access token
[twitch:vod] 213467862: Downloading m3u8 information
[download] Retro stuff: Jaguar, OSSC/Framemeister, and more (#StreamADay 1486) has already been recorded in archive
[download] Downloading video 2 of 100
[twitch:vod] 207973514: Downloading vod info JSON
[twitch:vod] 207973514: Downloading vod access token
[twitch:vod] 207973514: Downloading m3u8 information
[download] Checking out that NEW MAP (REAL) (#StreamADay 1466) has already been recorded in archive
...
```