### PR TITLE
 [Twitch] Support redirect_path and redirect to fix downloads of subscriber-only videos.

### DIFF
--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -88,7 +88,10 @@ class TwitchBaseIE(InfoExtractor):
                     fail(response['message'])
                 raise
 
-            redirect_url = urljoin(post_url, response['redirect'])
+            redirect_url = urljoin(post_url, response.get('redirect'))
+            if redirect_url is None:
+                redirect_url = urljoin(post_url, response.get('redirect_path'))
+
             return self._download_webpage_handle(
                 redirect_url, None, 'Downloading login redirect page',
                 headers=headers)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fix for issue 14090: redirecting to the video after login fails without this change.
Current release:
$ youtube-dl --verbose --netrc https://www.twitch.tv/videos/214735984
[debug] System config: []
[debug] User config: [u'--netrc']
[debug] Custom config: []
[debug] Command-line args: [u'--verbose', u'--netrc', u'https://www.twitch.tv/videos/214735984']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2018.01.14
[debug] Python version 2.7.10 (CPython) - Darwin-17.3.0-x86_64-i386-64bit
[debug] exe versions: none
[debug] Proxy map: {}
[twitch:vod] Downloading login page
[twitch:vod] Logging in
ERROR: An extractor error has occurred. (caused by KeyError(u'redirect',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/Users/johntobin/homebrew/bin/youtube-dl/youtube_dl/extractor/common.py", line 437, in extract
    self.initialize()
  File "/Users/johntobin/homebrew/bin/youtube-dl/youtube_dl/extractor/common.py", line 395, in initialize
    self._real_initialize()
  File "/Users/johntobin/homebrew/bin/youtube-dl/youtube_dl/extractor/twitch.py", line 56, in _real_initialize
    self._login()
  File "/Users/johntobin/homebrew/bin/youtube-dl/youtube_dl/extractor/twitch.py", line 106, in _login
    'password': password,
  File "/Users/johntobin/homebrew/bin/youtube-dl/youtube_dl/extractor/twitch.py", line 91, in login_step
    redirect_url = urljoin(post_url, response['redirect'])
KeyError: u'redirect'
Traceback (most recent call last):
  File "/Users/johntobin/homebrew/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 784, in extract_info
    ie_result = ie.extract(url)
  File "/Users/johntobin/homebrew/bin/youtube-dl/youtube_dl/extractor/common.py", line 451, in extract
    raise ExtractorError('An extractor error has occurred.', cause=e)
ExtractorError: An extractor error has occurred. (caused by KeyError(u'redirect',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.


With this patch:
$ python -m youtube_dl --verbose https://www.twitch.tv/videos/214735984
[debug] System config: []
[debug] User config: [u'--netrc']
[debug] Custom config: []
[debug] Command-line args: [u'--verbose', u'https://www.twitch.tv/videos/214735984']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2018.01.14
[debug] Git HEAD: 46aa9f2b4
[debug] Python version 2.7.10 (CPython) - Darwin-17.3.0-x86_64-i386-64bit
[debug] exe versions: none
[debug] Proxy map: {}
[twitch:vod] Downloading login page
[twitch:vod] Logging in
[twitch:vod] Downloading login redirect page
[twitch:vod] 214735984: Downloading vod info JSON
[twitch:vod] 214735984: Downloading vod access token
[twitch:vod] 214735984: Downloading m3u8 information
[debug] Default format spec: best/bestvideo+bestaudio
[debug] Invoking downloader on u'https://vod.edgecast.hls.ttvnw.net/c17598a9e57f404d4c70_warhammer_27148934832_765478597/chunked/index-dvr.m3u8'
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 890
[download] Destination: HANG OUT and PAINT with Peachy and Duncan _w Ceri and Joe-v214735984.mp4
[download]   0.1% of ~7.13GiB at 672.29KiB/s ETA 03:09:09^C
ERROR: Interrupted by user
