### PR TITLE
Paramountnetwork extractor #15418

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -985,7 +985,7 @@ from .spankbang import SpankBangIE
 from .spankwire import SpankwireIE
 from .spiegel import SpiegelIE, SpiegelArticleIE
 from .spiegeltv import SpiegeltvIE
-from .spike import SpikeIE
+from .paramountnetwork import ParamountNetworkIE
 from .stitcher import StitcherIE
 from .sport5 import Sport5IE
 from .sportbox import SportBoxEmbedIE

--- a/youtube_dl/extractor/paramountnetwork.py
+++ b/youtube_dl/extractor/paramountnetwork.py
@@ -5,7 +5,7 @@ import re
 from .mtv import MTVServicesInfoExtractor
 
 
-class SpikeIE(MTVServicesInfoExtractor):
+class ParamountNetworkIE(MTVServicesInfoExtractor):
     _VALID_URL = r'https?://(?:[^/]+\.)?paramountnetwork\.com/[^/]+/[\da-z]{6}(?:[/?#&]|$)'
     _TESTS = [{
         'url': 'http://www.paramountnetwork.com/video-clips/e1ktem/nobodies-gangbanged',
@@ -34,7 +34,7 @@ class SpikeIE(MTVServicesInfoExtractor):
     _GEO_COUNTRIES = ['US']
 
     def _extract_mgid(self, webpage):
-        mgid = super(SpikeIE, self)._extract_mgid(webpage)
+        mgid = super(ParamountNetworkIE, self)._extract_mgid(webpage)
         if mgid is None:
             url_parts = self._search_regex(self._CUSTOM_URL_REGEX, webpage, 'episode_id')
             video_type, episode_id = url_parts.split('/', 1)

--- a/youtube_dl/extractor/spike.py
+++ b/youtube_dl/extractor/spike.py
@@ -6,10 +6,10 @@ from .mtv import MTVServicesInfoExtractor
 
 
 class SpikeIE(MTVServicesInfoExtractor):
-    _VALID_URL = r'https?://(?:[^/]+\.)?spike\.com/[^/]+/[\da-z]{6}(?:[/?#&]|$)'
+    _VALID_URL = r'https?://(?:[^/]+\.)?paramountnetwork\.com/[^/]+/[\da-z]{6}(?:[/?#&]|$)'
     _TESTS = [{
         'url': 'http://www.paramountnetwork.com/video-clips/e1ktem/nobodies-gangbanged',
-        'md5': 'TODO: md5 sum of the first 10241 bytes of the video file (use --test)',
+        'md5': 'f53ab001b5c1c6fee01bc9f00e2859d1',
         'info_dict': {
             'id': 'e1ktem',
             'ext': 'mp4',

--- a/youtube_dl/extractor/spike.py
+++ b/youtube_dl/extractor/spike.py
@@ -8,37 +8,24 @@ from .mtv import MTVServicesInfoExtractor
 class SpikeIE(MTVServicesInfoExtractor):
     _VALID_URL = r'https?://(?:[^/]+\.)?spike\.com/[^/]+/[\da-z]{6}(?:[/?#&]|$)'
     _TESTS = [{
-        'url': 'http://www.spike.com/video-clips/lhtu8m/auction-hunters-can-allen-ride-a-hundred-year-old-motorcycle',
-        'md5': '1a9265f32b0c375793d6c4ce45255256',
+        'url': 'http://www.paramountnetwork.com/video-clips/e1ktem/nobodies-gangbanged',
+        'md5': 'TODO: md5 sum of the first 10241 bytes of the video file (use --test)',
         'info_dict': {
-            'id': 'b9c8221a-4e50-479a-b86d-3333323e38ba',
+            'id': 'e1ktem',
             'ext': 'mp4',
-            'title': 'Auction Hunters|December 27, 2013|4|414|Can Allen Ride A Hundred Year-Old Motorcycle?',
-            'description': 'md5:fbed7e82ed5fad493615b3094a9499cb',
-            'timestamp': 1388120400,
-            'upload_date': '20131227',
+            'title': 'Gangbanged - NOBODIES | Paramount Network',
+            'description': 'TODO: Add description checksum',
+            'upload_date': 'TODO: Add upload date',
         },
     }, {
-        'url': 'http://www.spike.com/full-episodes/j830qm/lip-sync-battle-joel-mchale-vs-jim-rash-season-2-ep-209',
-        'md5': 'b25c6f16418aefb9ad5a6cae2559321f',
+        'url': 'http://www.paramountnetwork.com/episodes/j830qm/lip-sync-battle-joel-mchale-vs-jim-rash-season-2-ep-13',
+        'md5': 'TODO: md5 sum of the first 10241 bytes of the video file (use --test)',
         'info_dict': {
-            'id': '37ace3a8-1df6-48be-85b8-38df8229e241',
+            'id': 'j830qm',
             'ext': 'mp4',
-            'title': 'Lip Sync Battle|April 28, 2016|2|209|Joel McHale Vs. Jim Rash|Act 1',
-            'description': 'md5:a739ca8f978a7802f67f8016d27ce114',
+            'title': 'Lip Sync Battle - Season 2, Ep. 13 - Joel McHale Vs. Jim Rash - Full Episode | Paramount Network',
+            'description': 'TODO: Add description checksum',
         },
-    }, {
-        'url': 'http://www.spike.com/video-clips/lhtu8m/',
-        'only_matching': True,
-    }, {
-        'url': 'http://www.spike.com/video-clips/lhtu8m',
-        'only_matching': True,
-    }, {
-        'url': 'http://bellator.spike.com/fight/atwr7k/bellator-158-michael-page-vs-evangelista-cyborg',
-        'only_matching': True,
-    }, {
-        'url': 'http://bellator.spike.com/video-clips/bw6k7n/bellator-158-foundations-michael-venom-page',
-        'only_matching': True,
     }]
 
     _FEED_URL = 'http://www.spike.com/feeds/mrss/'


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
[Spike](spike.com) has now become Paramount Network, as per *issue #15418*. 

This causes the extractor to raise an 'Unsupported URL Error' as the URL has changed from *spike.com* to *paramountnetwork.com*.

I have done the following:
- Change _VALID_URL to the new URL.
- Change the tests to use new URL.

There are some variables such as _FEED_URL, which I haven't found documented,  if a more experienced contributor knows what they are for. Downloaded files don't receive the correct file name.

Videos *can now be downloaded*, but for some reason the *tests fail*:
```python
[debug] Using fake IP 3.247.35.116 (US) as X-Forwarded-For.
[ParamountNetwork] nobodies-gangbanged: Downloading webpage
[ParamountNetwork] Downloading JSON metadata
[ParamountNetwork] c1978ce3-ae3c-4cd2-b0ed-3051517e5ed5: Downloading info
[ParamountNetwork] c1978ce3-ae3c-4cd2-b0ed-3051517e5ed5: Extracting information
[ParamountNetwork] c1978ce3-ae3c-4cd2-b0ed-3051517e5ed5: Downloading video urls
[ParamountNetwork] c1978ce3-ae3c-4cd2-b0ed-3051517e5ed5: Downloading m3u8 information
[download] Downloading playlist: <![CDATA[Item Unavailable]]>
[ParamountNetwork] playlist <![CDATA[Item Unavailable]]>: Collected 1 video ids (downloading 1 of them)
[download] Downloading video 1 of 1
[info] Writing video description metadata as JSON to: test_ParamountNetwork_c1978ce3-ae3c-4cd2-b0ed-3051517e5ed5.info.json
[debug] Invoking downloader on 'https://cp477482-vh.akamaihd.net/i/mtvnorigin/gsp.alias/mediabus/tvland.com/2017/03/17/04/35/41/4c334ca06ad44b7a9e00af85e62e85de/1620129/hDuIFjX15u_7208813_1620129_20170317163541955_,384x216_278,512x288_498,640x360_1028,768x432_1528,960x540_2128,1280x720_3128,1920x1080_5128,.mp4.csmil/index_6_av.m3u8?null=0&id=AgBOmMxJWN1ZRvrFaVo1LZJ58EBwVXksMFs9SX7eQbGO%2fEL0DJ96EhL32biK9tog5sHeB5JhFBgXng%3d%3d&hdntl=exp=1516967802~acl=%2fi%2fmtvnorigin%2fgsp.alias%2fmediabus%2ftvland.com%2f2017%2f03%2f17%2f04%2f35%2f41%2f4c334ca06ad44b7a9e00af85e62e85de%2f1620129%2fhDuIFjX15u_7208813_1620129_20170317163541955_,384x216_278,512x288_498,640x360_1028,768x432_1528,960x540_2128,1280x720_3128,1920x1080_5128,.mp4.csmil%2f*~data=hdntl~hmac=6a025969bc8b52e2f9ecedbb2c82b4e9bef1dbfcb8079597fcdd3e87737d225c'
[hlsnative] Downloading m3u8 manifest
ERROR: hlsnative has detected features it does not support, extraction will be delegated to ffmpeg; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 795, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 994, in process_ie_result
    extra_info=extra)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 849, in process_ie_result
    return self.process_video_result(ie_result, download=download)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 1622, in process_video_result
    self.process_info(new_info)
  File "test/test_download.py", line 56, in process_info
    return super(YoutubeDL, self).process_info(info_dict)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 1895, in process_info
    success = dl(filename, info_dict)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 1834, in dl
    return fd.download(name, info)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/downloader/common.py", line 361, in download
    return self.real_download(filename, info_dict)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/downloader/hls.py", line 71, in real_download
    'hlsnative has detected features it does not support, '
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/downloader/common.py", line 160, in report_warning
    self.ydl.report_warning(*args, **kargs)
  File "/home/arch/ozzy/clones/youtube-dl/test/helper.py", line 244, in _report_warning
    real_warning(w)
  File "test/test_download.py", line 52, in report_warning
    raise ExtractorError(message)
youtube_dl.utils.ExtractorError: hlsnative has detected features it does not support, extraction will be delegated to ffmpeg; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

E
======================================================================
ERROR: test_ParamountNetwork (__main__.TestDownload):
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 795, in extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 994, in process_ie_result
    extra_info=extra)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 849, in process_ie_result
    return self.process_video_result(ie_result, download=download)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 1622, in process_video_result
    self.process_info(new_info)
  File "test/test_download.py", line 56, in process_info
    return super(YoutubeDL, self).process_info(info_dict)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 1895, in process_info
    success = dl(filename, info_dict)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 1834, in dl
    return fd.download(name, info)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/downloader/common.py", line 361, in download
    return self.real_download(filename, info_dict)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/downloader/hls.py", line 71, in real_download
    'hlsnative has detected features it does not support, '
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/downloader/common.py", line 160, in report_warning
    self.ydl.report_warning(*args, **kargs)
  File "/home/arch/ozzy/clones/youtube-dl/test/helper.py", line 244, in _report_warning
    real_warning(w)
  File "test/test_download.py", line 52, in report_warning
    raise ExtractorError(message)
youtube_dl.utils.ExtractorError: hlsnative has detected features it does not support, extraction will be delegated to ffmpeg; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test/test_download.py", line 159, in test_template
    force_generic_extractor=params.get('force_generic_extractor', False))
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 807, in extract_info
    self.report_error(compat_str(e), e.format_traceback())
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 612, in report_error
    self.trouble(error_message, tb)
  File "/home/arch/ozzy/clones/youtube-dl/youtube_dl/YoutubeDL.py", line 582, in trouble
    raise DownloadError(message, exc_info)
youtube_dl.utils.DownloadError: ERROR: hlsnative has detected features it does not support, extraction will be delegated to ffmpeg; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

----------------------------------------------------------------------
Ran 1 test in 4.293s

FAILED (errors=1)
```