### PR TITLE
[parliamentliveuk] Fix kaltura widget config detection

### DIFF
--- a/youtube_dl/extractor/parliamentliveuk.py
+++ b/youtube_dl/extractor/parliamentliveuk.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from re import DOTALL
+
 from .common import InfoExtractor
 
 
@@ -29,7 +31,7 @@ class ParliamentLiveUKIE(InfoExtractor):
             'http://vodplayer.parliamentlive.tv/?mid=' + video_id, video_id)
         widget_config = self._parse_json(self._search_regex(
             r'(?s)kWidgetConfig\s*=\s*({.+});',
-            webpage, 'kaltura widget config'), video_id)
+            webpage, 'kaltura widget config', flags=DOTALL), video_id)
         kaltura_url = 'kaltura:%s:%s' % (
             widget_config['wid'][1:], widget_config['entry_id'])
         event_title = self._download_json(


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The parliamentliveuk extractor currently expects to find the configuration for the Kaltura widget playing the video on a single line. This is no longer the case, and youtube-dl fails fatally upon not finding this data. This PR fixes this issue.