### PR TITLE
[PornHub] Added support for channel video collections (fixes issue #15613)

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -829,7 +829,6 @@ from .pornflip import PornFlipIE
 from .pornhd import PornHdIE
 from .pornhub import (
     PornHubIE,
-    PornHubChannelVideosIE,
     PornHubPlaylistIE,
     PornHubUserVideosIE,
 )

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -829,6 +829,7 @@ from .pornflip import PornFlipIE
 from .pornhd import PornHdIE
 from .pornhub import (
     PornHubIE,
+    PornHubChannelVideosIE,
     PornHubPlaylistIE,
     PornHubUserVideosIE,
 )

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -275,7 +275,7 @@ class PornHubPlaylistIE(PornHubPlaylistBaseIE):
 
 
 class PornHubUserVideosIE(PornHubPlaylistBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?pornhub\.com/users/(?P<id>[^/]+)/videos'
+    _VALID_URL = r'https?://(?:www\.)?pornhub\.com/(?:user|channel)s/(?P<id>[^/]+)/videos'
     _TESTS = [{
         'url': 'http://www.pornhub.com/users/zoe_ph/videos/public',
         'info_dict': {
@@ -284,6 +284,28 @@ class PornHubUserVideosIE(PornHubPlaylistBaseIE):
         'playlist_mincount': 171,
     }, {
         'url': 'http://www.pornhub.com/users/rushandlia/videos',
+        'only_matching': True,
+    }, {
+        # default sorting as Top Rated Videos
+        'url': 'https://www.pornhub.com/channels/povd/videos',
+        'info_dict': {
+            'id': 'povd',
+        },
+        'playlist_mincount': 293,
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        # Top Rated Videos
+        'url': 'https://www.pornhub.com/channels/povd/videos?o=ra',
+        'only_matching': True,
+    }, {
+        # Most Recent Videos
+        'url': 'https://www.pornhub.com/channels/povd/videos?o=da',
+        'only_matching': True,
+    }, {
+        # Most Viewed Videos
+        'url': 'https://www.pornhub.com/channels/povd/videos?o=vi',
         'only_matching': True,
     }]
 
@@ -306,23 +328,3 @@ class PornHubUserVideosIE(PornHubPlaylistBaseIE):
             entries.extend(page_entries)
 
         return self.playlist_result(entries, user_id)
-
-
-class PornHubChannelVideosIE(PornHubUserVideosIE):
-    _VALID_URL = r'https?://(?:www\.)?pornhub\.com/channels/(?P<id>[^/]+)/videos'
-    _TESTS = [{
-        # sorted as Top Rated Videos
-        'url': 'https://www.pornhub.com/channels/povd/videos?o=ra',
-        'info_dict': {
-            'id': 'povd',
-        },
-        'playlist_mincount': 293,
-    }, {
-        # Most Recent Videos
-        'url': 'https://www.pornhub.com/channels/povd/videos?o=da',
-        'only_matching': True,
-    }, {
-        # Most Viewed Videos
-        'url': 'https://www.pornhub.com/channels/povd/videos?o=vi',
-        'only_matching': True,
-    }]

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -306,3 +306,23 @@ class PornHubUserVideosIE(PornHubPlaylistBaseIE):
             entries.extend(page_entries)
 
         return self.playlist_result(entries, user_id)
+
+
+class PornHubChannelVideosIE(PornHubUserVideosIE):
+    _VALID_URL = r'https?://(?:www\.)?pornhub\.com/channels/(?P<id>[^/]+)/videos'
+    _TESTS = [{
+        # sorted as Top Rated Videos
+        'url': 'https://www.pornhub.com/channels/povd/videos?o=ra',
+        'info_dict': {
+            'id': 'povd',
+        },
+        'playlist_mincount': 293,
+    }, {
+        # Most Recent Videos
+        'url': 'https://www.pornhub.com/channels/povd/videos?o=da',
+        'only_matching': True,
+    }, {
+        # Most Viewed Videos
+        'url': 'https://www.pornhub.com/channels/povd/videos?o=vi',
+        'only_matching': True,
+    }]

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -292,9 +292,6 @@ class PornHubUserVideosIE(PornHubPlaylistBaseIE):
             'id': 'povd',
         },
         'playlist_mincount': 293,
-        'params': {
-            'skip_download': True,
-        },
     }, {
         # Top Rated Videos
         'url': 'https://www.pornhub.com/channels/povd/videos?o=ra',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

Updated the extractor for Pornhub.com to also provide support for channel videos as playlists - issue #15613.

Cheers and thank you!

Parmjit V.