### PR TITLE
[heise] delegate to KalturaIE when necessary (#14961)

### DIFF
--- a/youtube_dl/extractor/heise.py
+++ b/youtube_dl/extractor/heise.py
@@ -2,15 +2,14 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
-from .youtube import YoutubeIE
 from .kaltura import KalturaIE
+from .youtube import YoutubeIE
 from ..utils import (
     determine_ext,
     int_or_none,
     parse_iso8601,
-    xpath_text,
     smuggle_url,
-    ExtractorError,
+    xpath_text,
 )
 
 
@@ -55,6 +54,9 @@ class HeiseIE(InfoExtractor):
             'ext': 'mp4',
             'title': 'ct10 nachgehakt hos restrictor',
         },
+        'params': {
+            'skip_download': True,
+        },
     }, {
         'url': 'http://www.heise.de/ct/artikel/c-t-uplink-3-3-Owncloud-Tastaturen-Peilsender-Smartphone-2403911.html',
         'only_matching': True,
@@ -80,15 +82,13 @@ class HeiseIE(InfoExtractor):
         if yt_urls:
             return self.playlist_from_matches(yt_urls, video_id, title, ie=YoutubeIE.ie_key())
 
-        try:
-            container_id = self._search_regex(
-                r'<div class="videoplayerjw"[^>]+data-container="([0-9]+)"',
-                webpage, 'container ID')
+        kaltura_url = KalturaIE._extract_url(webpage)
+        if kaltura_url:
+            return self.url_result(smuggle_url(kaltura_url, {'source_url': url}), KalturaIE.ie_key())
 
-        except ExtractorError:
-            kaltura_url = KalturaIE._extract_url(webpage)
-            if kaltura_url:
-                return self.url_result(smuggle_url(kaltura_url, {'source_url': url}), KalturaIE.ie_key())
+        container_id = self._search_regex(
+            r'<div class="videoplayerjw"[^>]+data-container="([0-9]+)"',
+            webpage, 'container ID')
 
         sequenz_id = self._search_regex(
             r'<div class="videoplayerjw"[^>]+data-sequenz="([0-9]+)"',

--- a/youtube_dl/extractor/heise.py
+++ b/youtube_dl/extractor/heise.py
@@ -3,11 +3,14 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 from .youtube import YoutubeIE
+from .kaltura import KalturaIE
 from ..utils import (
     determine_ext,
     int_or_none,
     parse_iso8601,
     xpath_text,
+    smuggle_url,
+    ExtractorError,
 )
 
 
@@ -43,6 +46,16 @@ class HeiseIE(InfoExtractor):
             'skip_download': True,
         },
     }, {
+        'url': 'https://www.heise.de/video/artikel/nachgehakt-Wie-sichert-das-c-t-Tool-Restric-tor-Windows-10-ab-3700244.html',
+        'md5': '4b58058b46625bdbd841fc2804df95fc',
+        'info_dict': {
+            'id': '1_ntrmio2s',
+            'timestamp': 1512470717,
+            'upload_date': '20171205',
+            'ext': 'mp4',
+            'title': 'ct10 nachgehakt hos restrictor',
+        },
+    }, {
         'url': 'http://www.heise.de/ct/artikel/c-t-uplink-3-3-Owncloud-Tastaturen-Peilsender-Smartphone-2403911.html',
         'only_matching': True,
     }, {
@@ -67,9 +80,16 @@ class HeiseIE(InfoExtractor):
         if yt_urls:
             return self.playlist_from_matches(yt_urls, video_id, title, ie=YoutubeIE.ie_key())
 
-        container_id = self._search_regex(
-            r'<div class="videoplayerjw"[^>]+data-container="([0-9]+)"',
-            webpage, 'container ID')
+        try:
+            container_id = self._search_regex(
+                r'<div class="videoplayerjw"[^>]+data-container="([0-9]+)"',
+                webpage, 'container ID')
+
+        except ExtractorError:
+            kaltura_url = KalturaIE._extract_url(webpage)
+            if kaltura_url:
+                return self.url_result(smuggle_url(kaltura_url, {'source_url': url}), KalturaIE.ie_key())
+
         sequenz_id = self._search_regex(
             r'<div class="videoplayerjw"[^>]+data-sequenz="([0-9]+)"',
             webpage, 'sequenz ID')


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
---

### Description of your *pull request* and other information

Fixes #14961.
The fix delegates the webpage to KalturaIE, when no jwplayer container ID was found.
I also added a test.