### PR TITLE
CBS extractor download fix (Fixes Issue #13490)

### DIFF
--- a/youtube_dl/extractor/cbs.py
+++ b/youtube_dl/extractor/cbs.py
@@ -79,10 +79,13 @@ class CBSIE(CBSBaseIE):
                 tp_formats, tp_subtitles = self._extract_theplatform_smil(
                     update_url_query(tp_release_url, query), content_id,
                     'Downloading %s SMIL data' % asset_type)
+                formats.extend(tp_formats)
+                subtitles = self._merge_subtitles(subtitles, tp_subtitles)
             except ExtractorError:
+                print("WARNING: Failed to download %s SMTL data" % asset_type)
                 continue
-            formats.extend(tp_formats)
-            subtitles = self._merge_subtitles(subtitles, tp_subtitles)
+
+
         self._sort_formats(formats)
 
         info = self._extract_theplatform_metadata(tp_path, content_id)

--- a/youtube_dl/extractor/cbs.py
+++ b/youtube_dl/extractor/cbs.py
@@ -85,7 +85,6 @@ class CBSIE(CBSBaseIE):
                 print("WARNING: Failed to download %s SMTL data" % asset_type)
                 continue
 
-
         self._sort_formats(formats)
 
         info = self._extract_theplatform_metadata(tp_path, content_id)

--- a/youtube_dl/extractor/cbs.py
+++ b/youtube_dl/extractor/cbs.py
@@ -7,6 +7,7 @@ from ..utils import (
     xpath_element,
     xpath_text,
     update_url_query,
+    ExtractorError
 )
 
 
@@ -74,9 +75,12 @@ class CBSIE(CBSBaseIE):
                 query['formats'] = 'MPEG4,M3U'
             elif asset_type in ('RTMP', 'WIFI', '3G'):
                 query['formats'] = 'MPEG4,FLV'
-            tp_formats, tp_subtitles = self._extract_theplatform_smil(
-                update_url_query(tp_release_url, query), content_id,
-                'Downloading %s SMIL data' % asset_type)
+            try:
+                tp_formats, tp_subtitles = self._extract_theplatform_smil(
+                    update_url_query(tp_release_url, query), content_id,
+                    'Downloading %s SMIL data' % asset_type)
+            except ExtractorError:
+                continue
             formats.extend(tp_formats)
             subtitles = self._merge_subtitles(subtitles, tp_subtitles)
         self._sort_formats(formats)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

This pull request simple puts the following code in `cbs.py`
```
tp_formats, tp_subtitles = self._extract_theplatform_smil(
update_url_query(tp_release_url, query), content_id,
'Downloading %s SMIL data' % asset_type)
subtitles = self._merge_subtitles(subtitles, tp_subtitles)
```

This allows it to continue attempting a download on certain files which otherwise fail, even on a -F. as seen in Issue #13490. This fix does _not_ necessarily allow a previously failing download to complete from CBS at what youtube-dl believes to be the highest quality (in these cases, an ramp stream with an flv) because of ffmpeg's lack of support for SAMPLE-AES encryption, but will allow you to run -F and find a format you can properly download, which was not possible before.

A pull request, #13506, was created to seemingly fix this issue, but it hasn't seemed to go anywhere. This simple fix I propose seems to do the job for me.