### PR TITLE
[sevenplus] add series title extraction (#15862)

### DIFF
--- a/youtube_dl/extractor/sevenplus.py
+++ b/youtube_dl/extractor/sevenplus.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import re
 
-from .common import InfoExtractor
 from .brightcove import BrightcoveNewIE
 from ..utils import update_url_query
 
@@ -82,6 +81,6 @@ class SevenPlusIE(BrightcoveNewIE):
                         info[dst_key] = value
 
         webpage = self._download_webpage(url, episode_id)
-        info['series'] = self._search_regex(r'<title>([^>|]+) | 7plus</title>', webpage, 'title')
+        info['series'] = self._search_regex(r'<title>(.+?) +\| +7 ?[pP]lus ?</title>', webpage, 'title', fatal=False)
 
         return info

--- a/youtube_dl/extractor/sevenplus.py
+++ b/youtube_dl/extractor/sevenplus.py
@@ -27,6 +27,22 @@ class SevenPlusIE(BrightcoveNewIE):
             'skip_download': True,
         }
     }, {
+        'url': 'https://7plus.com.au/MDAY?episode-id=MDAY5-001',
+        'info_dict': {
+            'id': 'MDAY5-001',
+            'ext': 'mp4',
+            'title': 'S5 E1 - Invisible Killer',
+            'description': 'md5:bea06aef0fe4bdefb2dce2e6af873fab',
+            'uploader_id': '5303576322001',
+            'upload_date': '20180219',
+            'timestamp': 1519012651,
+            'series': 'Air Crash Investigations',
+        },
+        'params': {
+            'format': 'bestvideo',
+            'skip_download': True,
+        }
+    }, {
         'url': 'https://7plus.com.au/UUUU?episode-id=AUMS43-001',
         'only_matching': True,
     }]
@@ -65,8 +81,7 @@ class SevenPlusIE(BrightcoveNewIE):
                     if value:
                         info[dst_key] = value
 
-        if info['title'] is None:
-            webpage = self._download_webpage(url, episode_id)
-            info['title'] = self._search_regex(r'<title>([^>]+)</title>', webpage, 'title')
+        webpage = self._download_webpage(url, episode_id)
+        info['series'] = self._search_regex(r'<title>([^>|]+) | 7plus</title>', webpage, 'title')
 
         return info

--- a/youtube_dl/extractor/sevenplus.py
+++ b/youtube_dl/extractor/sevenplus.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import re
 
+from .common import InfoExtractor
 from .brightcove import BrightcoveNewIE
 from ..utils import update_url_query
 
@@ -63,5 +64,9 @@ class SevenPlusIE(BrightcoveNewIE):
                     value = item.get(src_key)
                     if value:
                         info[dst_key] = value
+
+        if info['title'] is None:
+            webpage = self._download_webpage(url, episode_id)
+            info['title'] = self._search_regex(r'<title>([^>]+)</title>', webpage, 'title')
 
         return info


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] New feature

---

### Description of your *pull request* and other information
According to issue #15862 I added non-fatal season title extraction for 7plus and a test. I can't run the first test (has been there before), not sure whether that's because of geo-restriction. But mine works fine. @section83 verified it works as expected.

Regards