### PR TITLE
[XVideos] Correctly set thumbnail image (fixes issue #15978)

### DIFF
--- a/youtube_dl/extractor/xvideos.py
+++ b/youtube_dl/extractor/xvideos.py
@@ -58,7 +58,10 @@ class XVideosIE(InfoExtractor):
             group='title') or self._og_search_title(webpage)
 
         thumbnail = self._search_regex(
-            r'url_bigthumb=(.+?)&amp|html5player\.setThumbUrl\(\'(.+?)\'\);', webpage, 'thumbnail', fatal=False)
+            (r'url_bigthumb=(.+?)&amp',
+             r'html5player\.setThumbUrl\(\'(.+?)\'\);'),
+            webpage, 'thumbnail', fatal=False)
+
         duration = int_or_none(self._og_search_property(
             'duration', webpage, default=None)) or parse_duration(
             self._search_regex(

--- a/youtube_dl/extractor/xvideos.py
+++ b/youtube_dl/extractor/xvideos.py
@@ -39,6 +39,20 @@ class XVideosIE(InfoExtractor):
     }, {
         'url': 'http://static-hw.xvideos.com/swf/xv-player.swf?id_video=4588838',
         'only_matching': True,
+    }, {
+        'url': 'https://www.xvideos.com/video299069/diesel_sfw_xxx_video',
+        'md5': 'c0cec3673a7b74a0ed871945c03ab935',
+        'info_dict': {
+            'id': '299069',
+            'ext': 'mp4',
+            'title': 'DIESEL SFW XXX Video',
+            'thumbnail': r're:https?://.*\.jpg',
+            'duration': 80,
+            'age_limit': 18,
+        },
+        'params': {
+            'skip_download': True,
+        }
     }]
 
     def _real_extract(self, url):
@@ -58,7 +72,8 @@ class XVideosIE(InfoExtractor):
             group='title') or self._og_search_title(webpage)
 
         thumbnail = self._search_regex(
-            r'url_bigthumb=(.+?)&amp', webpage, 'thumbnail', fatal=False)
+            r'url_bigthumb=(.+?)&amp', webpage, 'thumbnail', default=None) or self._search_regex(
+            r'html5player\.setThumbUrl\(\'(.+?)\'\);', webpage, 'thumbnail', fatal=False)
         duration = int_or_none(self._og_search_property(
             'duration', webpage, default=None)) or parse_duration(
             self._search_regex(

--- a/youtube_dl/extractor/xvideos.py
+++ b/youtube_dl/extractor/xvideos.py
@@ -58,10 +58,9 @@ class XVideosIE(InfoExtractor):
             group='title') or self._og_search_title(webpage)
 
         thumbnail = self._search_regex(
-            (r'url_bigthumb=(.+?)&amp',
-             r'html5player\.setThumbUrl\(\'(.+?)\'\);'),
-            webpage, 'thumbnail', fatal=False)
-
+            (r'setThumbUrl\(\s*(["\'])(?P<thumbnail>(?:(?!\1).)+)\1',
+             r'url_bigthumb=(?P<thumbnail>.+?)&amp'),
+            webpage, 'thumbnail', fatal=False, group='thumbnail')
         duration = int_or_none(self._og_search_property(
             'duration', webpage, default=None)) or parse_duration(
             self._search_regex(

--- a/youtube_dl/extractor/xvideos.py
+++ b/youtube_dl/extractor/xvideos.py
@@ -39,20 +39,6 @@ class XVideosIE(InfoExtractor):
     }, {
         'url': 'http://static-hw.xvideos.com/swf/xv-player.swf?id_video=4588838',
         'only_matching': True,
-    }, {
-        'url': 'https://www.xvideos.com/video299069/diesel_sfw_xxx_video',
-        'md5': 'c0cec3673a7b74a0ed871945c03ab935',
-        'info_dict': {
-            'id': '299069',
-            'ext': 'mp4',
-            'title': 'DIESEL SFW XXX Video',
-            'thumbnail': r're:https?://.*\.jpg',
-            'duration': 80,
-            'age_limit': 18,
-        },
-        'params': {
-            'skip_download': True,
-        }
     }]
 
     def _real_extract(self, url):
@@ -72,8 +58,7 @@ class XVideosIE(InfoExtractor):
             group='title') or self._og_search_title(webpage)
 
         thumbnail = self._search_regex(
-            r'url_bigthumb=(.+?)&amp', webpage, 'thumbnail', default=None) or self._search_regex(
-            r'html5player\.setThumbUrl\(\'(.+?)\'\);', webpage, 'thumbnail', fatal=False)
+            r'url_bigthumb=(.+?)&amp|html5player\.setThumbUrl\(\'(.+?)\'\);', webpage, 'thumbnail', fatal=False)
         duration = int_or_none(self._og_search_property(
             'duration', webpage, default=None)) or parse_duration(
             self._search_regex(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

Updated the extractor for the XVideos.com website to set the thumbnail image using the embedded html5player data - issue #15978.

Cheers,

Parmjit V.