### PR TITLE
[Metube] Add a new extractor for metube.id

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -596,6 +596,7 @@ from .melonvod import MelonVODIE
 from .meta import METAIE
 from .metacafe import MetacafeIE
 from .metacritic import MetacriticIE
+from .metube import MetubeIE
 from .mgoon import MgoonIE
 from .mgtv import MGTVIE
 from .miaopai import MiaoPaiIE

--- a/youtube_dl/extractor/metube.py
+++ b/youtube_dl/extractor/metube.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+
+from .common import InfoExtractor
+
+
+class MetubeIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?metube\.id/videos/(?P<id>\d+)/(?P<slug>[^/?#&]+)'
+    _TEST = {
+        'url': 'https://www.metube.id/videos/15090866/dragon-ball-super-eps-131',
+        'info_dict': {
+            'id': '15090866',
+            'slug': 'dragon-ball-super-eps-131',
+            'ext': 'm3u8',
+            'title': 'Dragon Ball Super Eps.131',
+            'description': 'md5:dc4bfa9274e3db15392bfce045964331',
+            'thumbnail': r're:^https?://.*\.jpg$',
+        },
+    }
+
+    def _real_extract(self, url):
+        mobj = re.match(self._VALID_URL, url)
+        video_id, slug = mobj.group('id', 'slug')
+
+        webpage = self._download_webpage(url, video_id)
+        title = self._og_search_title(webpage)
+        description = self._og_search_description(webpage)
+        thumbnail = self._og_search_property('image', webpage)
+        m3u8_url = self._html_search_regex(
+            r'''jwplayer\s*\(\s*["'][^'"]+["']\s*\)\s*\.setup.*?['"]?file['"]?\s*:\s*["\'](.*?)["\']''',
+            webpage, 'm3u8_url', default='{}', fatal=False)
+        formats = self._extract_m3u8_formats(
+            m3u8_url, video_id, 'm3u8', entry_protocol='m3u8_native')
+        self._sort_formats(formats)
+
+        return {
+            'id': video_id,
+            'slug': slug,
+            'title': title,
+            'description': description,
+            'thumbnail': thumbnail,
+            'formats': formats
+        }


### PR DESCRIPTION
### Before submitting this *pull request*, I have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of this *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of this *pull request* and other information

This PR adds support for extracting (and downloading) videos from [Metube](https://metube.id/)
