### PR TITLE
fix for null "ie_key" value for soundcloud when dumping as json

### DIFF
--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -400,7 +400,7 @@ class SoundcloudPagedPlaylistBaseIE(SoundcloudPlaylistBaseIE):
             for e in collection:
                 permalink_url, entry_id = resolve_permalink_url((e, e.get('track'), e.get('playlist')))
                 if permalink_url:
-                    entries.append(self.url_result(permalink_url, video_id=entry_id))
+                    entries.append(self.url_result(permalink_url, self.ie_key(), entry_id))
 
             next_href = response.get('next_href')
             if not next_href:


### PR DESCRIPTION
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull fixes a bug occuring when you try to dump a soundcloud playlist/user. If you use the following command the value "ie_key" to determine the service/website is null:

command: `youtube-dl -j --flat-playlist https://soundcloud.com/jayeem_music/sets`
part of output: 
`{"_type": "url", "url": "https://soundcloud.com/jayeem_music/sets/distant", "ie_key": null, "id": "452707167"}`
