### PR TITLE
[VTM.be] fix long video_id

### DIFF
--- a/youtube_dl/extractor/medialaan.py
+++ b/youtube_dl/extractor/medialaan.py
@@ -140,7 +140,7 @@ class MedialaanIE(GigyaBaseIE):
                 '\\\\', '\\').replace(r'\"', '"').replace(r"\'", "'"))
 
         vod_id = config.get('vodId') or self._search_regex(
-            (r'\\"vodId\\"\s*:\s*\\"(.+?)\\"',
+            (r'\"vodId\"\s*:\s*\"(.+?)\"',
              r'<[^>]+id=["\']vod-(\d+)'),
             webpage, 'video_id', default=None)
 

--- a/youtube_dl/extractor/medialaan.py
+++ b/youtube_dl/extractor/medialaan.py
@@ -140,7 +140,8 @@ class MedialaanIE(GigyaBaseIE):
                 '\\\\', '\\').replace(r'\"', '"').replace(r"\'", "'"))
 
         vod_id = config.get('vodId') or self._search_regex(
-            (r'\"vodId\"\s*:\s*\"(.+?)\"',
+            (r'\\"vodId\\"\s*:\s*\\"(.+?)\\"',
+             r'"vodId"\s*:\s*"(.+?)"',
              r'<[^>]+id=["\']vod-(\d+)'),
             webpage, 'video_id', default=None)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Long video id's like ```vtm_20180328_VM067D2E9_vtmwatch``` do not work.

Example of such links are `https://vtm.be/video/volledige-afleveringen/id/vtm_20180328_VM067D2E9_vtmwatch` and `https://vtm.be/video?f%5B0%5D=sm_field_program_active%3ABoxing%20Stars&aid=194365`

Should fix #14702 and #14871, although the videos used to report are no longer online.