### PR TITLE
[Orfium] Add new extractor (Fixes #16025)

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -796,6 +796,9 @@ from .orf import (
     ORFOE1IE,
     ORFIPTVIE,
 )
+from .orfium import (
+    OrfiumTrackIE,
+)
 from .packtpub import (
     PacktPubIE,
     PacktPubCourseIE,

--- a/youtube_dl/extractor/orfium.py
+++ b/youtube_dl/extractor/orfium.py
@@ -1,0 +1,41 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+
+from .common import InfoExtractor
+from ..utils import ExtractorError
+
+
+class OrfiumTrackIE(InfoExtractor):
+    _VALID_URL = r'https?://(www\.)?orfium\.com/track/(?P<id>\d+)'
+    IE_NAME = 'orfium'
+    _TESTS = [{
+        'url': 'https://www.orfium.com/track/694466/misery-aciou/',
+        'md5': 'ceae78f12a22b05d7f796e04de5f6cae',
+        'info_dict': {
+            'id': '694466',
+            'title': 'misery',
+            'artist': 'aciou',
+            'thumbnail': 'https://g3w6qqdmbl.execute-api.us-west-1.amazonaws.com/prod/thumb/temp?url=https://s3-us-west-2.amazonaws.com/orfium-public/tracks/artwork/9f493b6e01d8416ca4b0417437b1709c.png&w=360&h=380',
+            'url': 'https://cdn.orfium.com/tracks%2Fa281276f-8126-48aa-98ad-9121c282e6eb-1522252307.mp3',
+            'ext': 'mp3'
+        }
+    }]
+
+    def _real_extract(self, url):
+        mobj = re.match(self._VALID_URL, url)
+        track_id = mobj.group('id')
+        info_url = 'https://www.orfium.com/api/track/%s/info/' % track_id
+        info_json = self._download_json(info_url, track_id, fatal=False)
+        if info_json is None:
+            raise ExtractorError('Track not found')
+        track_file = info_json.get('file')
+
+        return {
+            'id': track_id,
+            'title': info_json.get('title'),
+            'artist': info_json.get('artist'),
+            'thumbnail': info_json.get('image'),
+            'url': track_file
+        }


### PR DESCRIPTION
### Before submitting a *pull request*, I have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of this *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of this *pull request* and other information

This PR adds support for Orfium.com to extract the full track which is not covered in generic extractor. This fixes #16025.