### PR TITLE
Indavideo token

### DIFF
--- a/youtube_dl/extractor/indavideo.py
+++ b/youtube_dl/extractor/indavideo.py
@@ -61,7 +61,9 @@ class IndavideoEmbedIE(InfoExtractor):
                 video_urls.append(flv_url)
 
         filesh = video.get('filesh')
-        formats = [self.video_url_to_format(video_url, filesh) for video_url in video_urls]
+        formats = [
+            self.video_url_to_format(video_url, filesh)
+            for video_url in video_urls]
         self._sort_formats(formats)
 
         timestamp = video.get('date')

--- a/youtube_dl/extractor/indavideo.py
+++ b/youtube_dl/extractor/indavideo.py
@@ -10,6 +10,7 @@ except ImportError:
     from urllib import urlencode
 
 from .common import InfoExtractor
+from ..compat import compat_str
 from ..utils import (
     int_or_none,
     parse_age_limit,
@@ -99,7 +100,7 @@ class IndavideoEmbedIE(InfoExtractor):
         height = int_or_none(self._search_regex(
             r'\.(\d{3,4})\.mp4(?:\?|$)', video_url, 'height', default=None))
         if height and filesh:
-            token = filesh.get(str(height))
+            token = filesh.get(compat_str(height))
             if token is not None:
                 us = urlsplit(video_url)
                 query = urlencode(parse_qsl(us.query) + [('token', token)])

--- a/youtube_dl/extractor/indavideo.py
+++ b/youtube_dl/extractor/indavideo.py
@@ -1,7 +1,13 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from urllib.parse import urlsplit, urlunsplit, urlencode, parse_qsl
+try:
+    # Python 3
+    from urllib.parse import urlsplit, urlunsplit, urlencode, parse_qsl
+except ImportError:
+    # Python 2
+    from urlparse import urlsplit, urlunsplit, parse_qsl
+    from urllib import urlencode
 
 from .common import InfoExtractor
 from ..utils import (

--- a/youtube_dl/extractor/indavideo.py
+++ b/youtube_dl/extractor/indavideo.py
@@ -58,11 +58,7 @@ class IndavideoEmbedIE(InfoExtractor):
             if flv_url not in video_urls:
                 video_urls.append(flv_url)
 
-        formats = [{
-            'url': video_url,
-            'height': int_or_none(self._search_regex(
-                r'\.(\d{3,4})\.mp4(?:\?|$)', video_url, 'height', default=None)),
-        } for video_url in video_urls]
+        formats = [self.video_url_to_format(video_url) for video_url in video_urls]
         self._sort_formats(formats)
 
         timestamp = video.get('date')
@@ -88,6 +84,13 @@ class IndavideoEmbedIE(InfoExtractor):
             'age_limit': parse_age_limit(video.get('age_limit')),
             'tags': tags,
             'formats': formats,
+        }
+
+    def video_url_to_format(self, video_url):
+        return {
+            'url': video_url,
+            'height': int_or_none(self._search_regex(
+                r'\.(\d{3,4})\.mp4(?:\?|$)', video_url, 'height', default=None)),
         }
 
 

--- a/youtube_dl/extractor/indavideo.py
+++ b/youtube_dl/extractor/indavideo.py
@@ -98,7 +98,7 @@ class IndavideoEmbedIE(InfoExtractor):
     def video_url_to_format(self, video_url, filesh):
         height = int_or_none(self._search_regex(
             r'\.(\d{3,4})\.mp4(?:\?|$)', video_url, 'height', default=None))
-        if height is not None and filesh is not None:
+        if height and filesh:
             token = filesh.get(str(height))
             if token is not None:
                 us = urlsplit(video_url)

--- a/youtube_dl/extractor/indavideo.py
+++ b/youtube_dl/extractor/indavideo.py
@@ -1,20 +1,13 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-try:
-    # Python 3
-    from urllib.parse import urlsplit, urlunsplit, urlencode, parse_qsl
-except ImportError:
-    # Python 2
-    from urlparse import urlsplit, urlunsplit, parse_qsl
-    from urllib import urlencode
-
 from .common import InfoExtractor
 from ..compat import compat_str
 from ..utils import (
     int_or_none,
     parse_age_limit,
     parse_iso8601,
+    update_url_query,
 )
 
 
@@ -102,9 +95,7 @@ class IndavideoEmbedIE(InfoExtractor):
         if height and filesh:
             token = filesh.get(compat_str(height))
             if token is not None:
-                us = urlsplit(video_url)
-                query = urlencode(parse_qsl(us.query) + [('token', token)])
-                video_url = urlunsplit((us.scheme, us.netloc, us.path, query, us.fragment))
+                video_url = update_url_query(video_url, {'token': token})
         return {
             'url': video_url,
             'height': height,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

It seems that Indavideo has added an extra token to their JSON metadata, and if the token is not used as a URL parameter when requesting the actual video file, the request is denied with a 403 Forbidden response. This pull request extracts the token and appends it to the video URL transparently, using the standard Python 2/3 URL parsing tools to be as future-proof as possible.