### PR TITLE
[generic] prefer enclosures over following links in rss feeds

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2016,7 +2016,7 @@ class GenericIE(InfoExtractor):
                 if next_url:
                     break
 
-            if not enclosure_nodes:
+            if not next_url:
                 next_url = xpath_text(it, 'link', fatal=False)
 
             if not next_url:

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -190,7 +190,7 @@ class GenericIE(InfoExtractor):
                 'title': 'pdv_maddow_netcast_m4v-02-27-2015-201624',
             }
         },
-        # RSS feed with enclosures and unsupported rss urls
+        # RSS feed with enclosures and unsupported link URLs
         {
             'url': 'http://www.hellointernet.fm/podcast?format=rss',
             'info_dict': {
@@ -198,18 +198,7 @@ class GenericIE(InfoExtractor):
                 'description': 'CGP Grey and Brady Haran talk about YouTube, life, work, whatever.',
                 'title': 'Hello Internet',
             },
-            'playlist': [{
-                'info_dict': {
-                    'id': '101',
-                    'ext': 'mp3',
-                    'upload_date': '20180426',
-                    'title': '    \u200d      \u200d      ',
-                },
-            }],
-            'playlist_mincount': 99,
-            'params': {
-                'skip_download': True,
-            },
+            'playlist_mincount': 100,
         },
         # SMIL from http://videolectures.net/promogram_igor_mekjavic_eng
         {

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2009,13 +2009,14 @@ class GenericIE(InfoExtractor):
 
         entries = []
         for it in doc.findall('./channel/item'):
-            next_url = xpath_text(it, 'link', fatal=False)
-            if not next_url:
-                enclosure_nodes = it.findall('./enclosure')
-                for e in enclosure_nodes:
-                    next_url = e.attrib.get('url')
-                    if next_url:
-                        break
+            enclosure_nodes = it.findall('./enclosure')
+            for e in enclosure_nodes:
+                next_url = e.attrib.get('url')
+                if next_url:
+                    break
+
+            if not enclosure_nodes:
+                next_url = xpath_text(it, 'link', fatal=False)
 
             if not next_url:
                 continue

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -190,6 +190,27 @@ class GenericIE(InfoExtractor):
                 'title': 'pdv_maddow_netcast_m4v-02-27-2015-201624',
             }
         },
+        # RSS feed with enclosures and unsupported rss urls
+        {
+            'url': 'http://www.hellointernet.fm/podcast?format=rss',
+            'info_dict': {
+                'id': 'http://www.hellointernet.fm/podcast?format=rss',
+                'description': 'CGP Grey and Brady Haran talk about YouTube, life, work, whatever.',
+                'title': 'Hello Internet',
+            },
+            'playlist': [{
+                'info_dict': {
+                    'id': '101',
+                    'ext': 'mp3',
+                    'upload_date': '20180426',
+                    'title': u'    \u200d      \u200d      ',
+                },
+            }],
+            'playlist_mincount': 99,
+            'params': {
+                'skip_download': True,
+            },
+        },
         # SMIL from http://videolectures.net/promogram_igor_mekjavic_eng
         {
             'url': 'http://videolectures.net/promogram_igor_mekjavic_eng/video/1/smil.xml',

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2019,7 +2019,7 @@ class GenericIE(InfoExtractor):
             if not enclosure_nodes:
                 next_url = xpath_text(it, 'link', fatal=False)
 
-            if next_url is None:
+            if not next_url:
                 continue
 
             entries.append({

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2009,6 +2009,7 @@ class GenericIE(InfoExtractor):
 
         entries = []
         for it in doc.findall('./channel/item'):
+            next_url = None
             enclosure_nodes = it.findall('./enclosure')
             for e in enclosure_nodes:
                 next_url = e.attrib.get('url')
@@ -2018,7 +2019,7 @@ class GenericIE(InfoExtractor):
             if not enclosure_nodes:
                 next_url = xpath_text(it, 'link', fatal=False)
 
-            if not next_url:
+            if next_url is None:
                 continue
 
             entries.append({

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -203,7 +203,7 @@ class GenericIE(InfoExtractor):
                     'id': '101',
                     'ext': 'mp3',
                     'upload_date': '20180426',
-                    'title': u'    \u200d      \u200d      ',
+                    'title': '    \u200d      \u200d      ',
                 },
             }],
             'playlist_mincount': 99,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When downloading from rss feeds, the generic extractor follows the rss links first. This leads to "ERROR: Unsupported URL" messages in a lot of cases. Even though there are enclosures present.

```
$ youtube-dl --playlist-end 1 http://www.hellointernet.fm/podcast?format=rss
[generic] podcast?format=rss: Requesting header
WARNING: Falling back on generic information extractor.
[generic] podcast?format=rss: Downloading webpage
[generic] podcast?format=rss: Extracting information
[download] Downloading playlist: Hello Internet
[generic] playlist Hello Internet: Collected 100 video ids (downloading 1 of them)
[download] Downloading video 1 of 1
[generic] onehundred: Requesting header
WARNING: Falling back on generic information extractor.
[generic] onehundred: Downloading webpage
[generic] onehundred: Extracting information
ERROR: Unsupported URL: http://www.hellointernet.fm/podcast/onehundred
```

With this pull request downloading enclosures is preferred over following the rss links.

```
$ python -m youtube_dl --playlist-end 1 http://www.hellointernet.fm/podcast?format=rss
[generic] podcast?format=rss: Requesting header
WARNING: Falling back on generic information extractor.
[generic] podcast?format=rss: Downloading webpage
[generic] podcast?format=rss: Extracting information
[download] Downloading playlist: Hello Internet
[generic] playlist Hello Internet: Collected 100 video ids (downloading 1 of them)
[download] Downloading video 1 of 1
[generic] Hello_Internet_Episode_One_Hundred: Requesting header
[redirect] Following redirect to http://hwcdn.libsyn.com/p/e/5/c/e5ca0f579a9f12b4/Hello_Internet_Episode_One_Hundred.mp3?c_id=20078576&expiration=1523726590&hwt=d00666280d294aea41062d82e934b6f0
[generic] Hello_Internet_Episode_One_Hundred: Requesting header
[download] Destination: Hello Internet Episode One Hundred-Hello_Internet_Episode_One_Hundred.mp3
[download] 100% of 96.39MiB in 00:09
[download] Finished downloading playlist: Hello Internet
```