### PR TITLE
[openload] Generic IP v4 & v6 stream URL parsing (fixes #16137)

### DIFF
--- a/youtube_dl/extractor/openload.py
+++ b/youtube_dl/extractor/openload.py
@@ -340,7 +340,9 @@ class OpenloadIE(InfoExtractor):
                       get_element_by_id('streamurj', webpage) or
                       self._search_regex(
                           (r'>\s*([\w-]+~\d{10,}~\d+\.\d+\.0\.0~[\w-]+)\s*<',
-                           r'>\s*([\w~-]+~\d+\.\d+\.\d+\.\d+~[\w~-]+)'), webpage,
+                           r'>\s*([\w~-]+~\d+\.\d+\.\d+\.\d+~[\w~-]+)',
+                           # someId~someIPv6~someId
+                           r'>\s*([\w~-]+?~[a-f0-9:]+~[\w~-]+)\s*<'), webpage,
                           'stream URL'))
 
         video_url = 'https://openload.co/stream/%s?mime=true' % decoded_id

--- a/youtube_dl/extractor/openload.py
+++ b/youtube_dl/extractor/openload.py
@@ -341,8 +341,9 @@ class OpenloadIE(InfoExtractor):
                       self._search_regex(
                           (r'>\s*([\w-]+~\d{10,}~\d+\.\d+\.0\.0~[\w-]+)\s*<',
                            r'>\s*([\w~-]+~\d+\.\d+\.\d+\.\d+~[\w~-]+)',
-                           # someId~someIPv6~someId
-                           r'>\s*([\w~-]+?~[a-f0-9:]+~[\w~-]+)\s*<'), webpage,
+                           r'>\s*([\w-]+~\d{10,}~(?:[a-f\d]+:){2}:~[\w-]+)\s*<',
+                           r'>\s*([\w~-]+~[a-f0-9:]+~[\w~-]+)\s*<',
+                           r'>\s*([\w~-]+~[a-f0-9:]+~[\w~-]+)'), webpage,
                           'stream URL'))
 
         video_url = 'https://openload.co/stream/%s?mime=true' % decoded_id


### PR DESCRIPTION
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] Bug fix

---

This is a fix for #16137. The previous regexps were doing painful parsing of what is actually an IP network. Thing is, the original author (and Travis CI!) has no IPv6 connectivity, hence forgot to include IPv6 patterns in regexps (hex and `:` eg. `2a01:cb15::`). This breaks URL parsing for people on a IPv6-enabled network.

This PR replaces the two similar regexps with a more generic one, that includes both IPv4 and IPv6.

flake8 reports warnings around my fix, dunno if I am supposed to fix these in the PR, as it is unrelated. Please tell me if that's a requirement.