### PR TITLE
[CBC] Fix title extraction (fixes issue #16502)

### DIFF
--- a/youtube_dl/extractor/cbc.py
+++ b/youtube_dl/extractor/cbc.py
@@ -20,6 +20,7 @@ from ..utils import (
     parse_duration,
     parse_iso8601,
     parse_age_limit,
+    strip_or_none,
     int_or_none,
     ExtractorError,
 )
@@ -131,7 +132,7 @@ class CBCIE(InfoExtractor):
         webpage = self._download_webpage(url, display_id)
         title = self._og_search_title(webpage, default=None) or self._html_search_meta(
             'twitter:title', webpage, 'title', default=None) or self._html_search_regex(
-                r'<title>(.*?)\s*</title>', webpage, 'title', fatal=False)
+                r'<title>([^<]+)</title>', webpage, 'title', fatal=False)
         entries = [
             self._extract_player_init(player_init, display_id)
             for player_init in re.findall(r'CBC\.APP\.Caffeine\.initInstance\(({.+?})\);', webpage)]
@@ -139,7 +140,7 @@ class CBCIE(InfoExtractor):
             self.url_result('cbcplayer:%s' % media_id, 'CBCPlayer', media_id)
             for media_id in re.findall(r'<iframe[^>]+src="[^"]+?mediaId=(\d+)"', webpage)])
         return self.playlist_result(
-            entries, display_id, title,
+            entries, display_id, strip_or_none(title),
             self._og_search_description(webpage))
 
 

--- a/youtube_dl/extractor/cbc.py
+++ b/youtube_dl/extractor/cbc.py
@@ -129,6 +129,9 @@ class CBCIE(InfoExtractor):
     def _real_extract(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
+        title = self._og_search_title(webpage, default=None) or self._html_search_meta(
+            'twitter:title', webpage, 'title', default=None) or self._html_search_regex(
+                r'<title>(.*?)</title>', webpage, 'title', fatal=True)
         entries = [
             self._extract_player_init(player_init, display_id)
             for player_init in re.findall(r'CBC\.APP\.Caffeine\.initInstance\(({.+?})\);', webpage)]
@@ -136,8 +139,7 @@ class CBCIE(InfoExtractor):
             self.url_result('cbcplayer:%s' % media_id, 'CBCPlayer', media_id)
             for media_id in re.findall(r'<iframe[^>]+src="[^"]+?mediaId=(\d+)"', webpage)])
         return self.playlist_result(
-            entries, display_id,
-            self._og_search_title(webpage, fatal=False),
+            entries, display_id, title.strip(),
             self._og_search_description(webpage))
 
 

--- a/youtube_dl/extractor/cbc.py
+++ b/youtube_dl/extractor/cbc.py
@@ -131,7 +131,7 @@ class CBCIE(InfoExtractor):
         webpage = self._download_webpage(url, display_id)
         title = self._og_search_title(webpage, default=None) or self._html_search_meta(
             'twitter:title', webpage, 'title', default=None) or self._html_search_regex(
-                r'<title>(.*?)</title>', webpage, 'title', fatal=True)
+                r'<title>(.*?)\s*</title>', webpage, 'title', fatal=False)
         entries = [
             self._extract_player_init(player_init, display_id)
             for player_init in re.findall(r'CBC\.APP\.Caffeine\.initInstance\(({.+?})\);', webpage)]
@@ -139,7 +139,7 @@ class CBCIE(InfoExtractor):
             self.url_result('cbcplayer:%s' % media_id, 'CBCPlayer', media_id)
             for media_id in re.findall(r'<iframe[^>]+src="[^"]+?mediaId=(\d+)"', webpage)])
         return self.playlist_result(
-            entries, display_id, title.strip(),
+            entries, display_id, title,
             self._og_search_description(webpage))
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

Updated the extractor for the cbc.ca website to properly fetch the video title - issue #16502.

From the page source, the order of extraction should be: 1) OpenGraph title if available, 2) Twitter title if available, 3) Document title otherwise.

Cheers,

Parmjit V.