### PR TITLE
[bilibili] Fix extraction (#16638)

### DIFF
--- a/youtube_dl/extractor/bilibili.py
+++ b/youtube_dl/extractor/bilibili.py
@@ -114,7 +114,7 @@ class BiliBiliIE(InfoExtractor):
 
         if 'anime/' not in url:
             cid = self._search_regex(
-                r'cid(?:["\']:|=)(\d+)', webpage, 'cid',
+                r'(?:["\'{\s])cid(?:["\']:|=)(\d+)', webpage, 'cid',
                 default=None
             ) or compat_parse_qs(self._search_regex(
                 [r'EmbedPlayer\([^)]+,\s*"([^"]+)"\)',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

[bilibili] Refine the regex for finding `cid` value on the page. The old expression would hit `"video_codecid":7` in the first place and ignore the real `"cid":123456`. As a result, extractor will trying to fetch an ancient video record (cid=7) which is not available now (status: video is hidden).

```
"accept_description":["高清 1080P","高清 720P","清晰 480P","流畅 360P"],"accept_quality":[80,48,32,16],"video_codecid":7,"video_project":false,
```
...omit...
```
"pages":[{"cid":14125937,"page":1,"from":"vupload","part":"0001-6900","duration":288,"vid":"","weblink":"","dimension":{"width":0,"height":0,"rotate":0}}]
```