### PR TITLE
Continue trying after _parse_jwplayer_data fails

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2069,6 +2069,20 @@ class GenericIE(InfoExtractor):
             },
             'skip': 'TODO: fix nested playlists processing in tests',
         },
+        {
+            # Test for fallback after _parse_jwplayer_data fails
+            # See https://github.com/rg3/youtube-dl/pull/16735
+            'url': 'http://www.anime1.com/watch/nichijou/episode-1',
+            'info_dict': {
+                'id': '[HorribleSubs] Nichijou - 01 [480p]_a1_BRK',
+                'title': 'Nichijou - Episode 1',
+                'ext': 'mp4',
+                'uploader': 'www.anime1.com',
+            },
+            'params': {
+                'skip_download': True,
+            }
+        },
         # {
         #     # TODO: find another test
         #     # http://schema.org/VideoObject

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -3137,9 +3137,9 @@ class GenericIE(InfoExtractor):
                 info = self._parse_jwplayer_data(
                     jwplayer_data, video_id, require_title=False, base_url=url)
                 return merge_dicts(info, info_dict)
-            except ExtractorError as e:
-                self.to_screen(e.msg_without_bug_report)
-                self.to_screen("Trying different extractor")
+            except ExtractorError:
+                # If there is an error, try a different extractor
+                pass
 
         # Video.js embed
         mobj = re.search(

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -3123,7 +3123,7 @@ class GenericIE(InfoExtractor):
                 info = self._parse_jwplayer_data(
                     jwplayer_data, video_id, require_title=False, base_url=url)
                 return merge_dicts(info, info_dict)
-            except ExtractorError, e:
+            except ExtractorError as e:
                 self.to_screen(e.msg_without_bug_report)
                 self.to_screen("Trying different extractor")
 

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -3119,9 +3119,13 @@ class GenericIE(InfoExtractor):
         jwplayer_data = self._find_jwplayer_data(
             webpage, video_id, transform_source=js_to_json)
         if jwplayer_data:
-            info = self._parse_jwplayer_data(
-                jwplayer_data, video_id, require_title=False, base_url=url)
-            return merge_dicts(info, info_dict)
+            try:
+                info = self._parse_jwplayer_data(
+                    jwplayer_data, video_id, require_title=False, base_url=url)
+                return merge_dicts(info, info_dict)
+            except ExtractorError, e:
+                self.to_screen(e.msg_without_bug_report)
+                self.to_screen("Trying different extractor")
 
         # Video.js embed
         mobj = re.search(

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -748,7 +748,6 @@ class ExtractorError(YoutubeDLError):
             msg = video_id + ': ' + msg
         if cause:
             msg += ' (caused by %r)' % cause
-        self.msg_without_bug_report = msg
         if not expected:
             msg += bug_reports_message()
         super(ExtractorError, self).__init__(msg)

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -748,6 +748,7 @@ class ExtractorError(YoutubeDLError):
             msg = video_id + ': ' + msg
         if cause:
             msg += ' (caused by %r)' % cause
+        self.msg_without_bug_report = msg
         if not expected:
             msg += bug_reports_message()
         super(ExtractorError, self).__init__(msg)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request supersedes #12516. Essentially the problem is that `_parse_jwplayer_data` fails when the "JSON" structure it extracts contains variable references. However it seems an extractor further down in generic.py still works.

This pull requests makes it so that if  `_parse_jwplayer_data` fails instead of giving up youtube-dl continues trying different extractors.