### PR TITLE
[brightcove] Handle 'data-brightcove-id' attr

### DIFF
--- a/youtube_dl/extractor/brightcove.py
+++ b/youtube_dl/extractor/brightcove.py
@@ -535,7 +535,7 @@ class BrightcoveNewIE(AdobePassIE):
 
             # According to examples from [4] it's unclear whether video id
             # may be optional and what to do when it is
-            video_id = attrs.get('data-video-id')
+            video_id = attrs.get('data-video-id') or attrs.get('data-brightcove-id')
             if not video_id:
                 continue
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Improve Brightcove extractor

The brightcove extractor currently can't handle http://bigthink.com/ videos.

I was going to create a custom extractor, but it turned out the only thing that was wrong with the generic extractor was that it was expecting the `<video>` tag to have a `data-video-id` attribute, while bigthink has a `data-brightcove-id` attribute.

I figured that it would be simpler to just allow the video id to come from that attribute as well.