### PR TITLE
Catch all errors when trying to run external commands

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1960,7 +1960,7 @@ def get_exe_version(exe, args=['--version'],
             [encodeArgument(exe)] + args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()
-    except OSError:
+    except:
         return False
     if isinstance(out, bytes):  # Python 2.x
         out = out.decode('ascii', 'ignore')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Trying to run a non-installed command (such as avprobe) through Popen may throw other errors than `OSError`. For example, a `ValueError` may happen on macOS 10.12.6:

```
$ ./youtube-dl -U -v
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'-U', u'-v']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2018.06.25
[debug] Python version 2.7.10 (CPython) - Darwin-16.7.0-x86_64-i386-64bit
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "./youtube-dl/__main__.py", line 19, in <module>
  File "./youtube-dl/youtube_dl/__init__.py", line 472, in main
  File "./youtube-dl/youtube_dl/__init__.py", line 439, in _real_main
  File "./youtube-dl/youtube_dl/YoutubeDL.py", line 417, in __init__
  File "./youtube-dl/youtube_dl/YoutubeDL.py", line 2260, in print_debug_header
  File "./youtube-dl/youtube_dl/postprocessor/ffmpeg.py", line 76, in get_versions
  File "./youtube-dl/youtube_dl/postprocessor/ffmpeg.py", line 60, in __init__
  File "./youtube-dl/youtube_dl/postprocessor/ffmpeg.py", line 117, in _determine_executables
  File "./youtube-dl/youtube_dl/postprocessor/ffmpeg.py", line 117, in <genexpr>
  File "./youtube-dl/youtube_dl/utils.py", line 1962, in get_exe_version
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1334, in _execute_child
    child_exception = pickle.loads(data)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 1382, in loads
    return Unpickler(file).load()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 858, in load
    dispatch[key](self)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 966, in load_string
    raise ValueError, "insecure string pickle"
ValueError: insecure string pickle
```

Catching all errors instead of only `OSError` should be safer.