### PR TITLE
Add support for minimum and maximum duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
     --reject-title REGEX             Skip download for matching titles (regex or
                                      caseless sub-string)
     --max-downloads NUMBER           Abort after downloading NUMBER files
+    --min-duration SECONDS           Do not download any videos smaller than
+                                     duration, in seconds
+    --max-duration SECONDS           Do not download any videos larger than
+                                     duration, in seconds
     --min-filesize SIZE              Do not download any videos smaller than
                                      SIZE (e.g. 50k or 44.6m)
     --max-filesize SIZE              Do not download any videos larger than SIZE

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -749,6 +749,19 @@ class YoutubeDL(object):
             return '%s has already been recorded in archive' % video_title
 
         if not incomplete:
+            duration = info_dict.get('duration')
+            min_duration = self.params.get('min_duration')
+            if min_duration is not None:
+                if duration is None:
+                    return 'Skipping %s, because its duration is unknown and min_duration is specified' % (video_title)
+                if duration < min_duration:
+                    return 'Skipping %s, because its duration (%ds) is less than %ds' % (video_title, duration, min_duration)
+            max_duration = self.params.get('max_duration')
+            if max_duration is not None:
+                if duration is None:
+                    return 'Skipping %s, because its duration is unknown and max_duration is specified' % (video_title)
+                if duration > max_duration:
+                    return 'Skipping %s, because its duration (%ds) is more than %ds' % (video_title, duration, max_duration)
             match_filter = self.params.get('match_filter')
             if match_filter is not None:
                 ret = match_filter(info_dict)

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -150,6 +150,12 @@ def _real_main(argv=None):
         if numeric_limit is None:
             parser.error('invalid rate limit specified')
         opts.ratelimit = numeric_limit
+    if opts.min_duration is not None:
+        if opts.min_duration <= 0:
+            parser.error('invalid min_duration specified')
+    if opts.max_duration is not None:
+        if opts.max_duration <= 0:
+            parser.error('invalid max_duration specified')
     if opts.min_filesize is not None:
         numeric_limit = FileDownloader.parse_bytes(opts.min_filesize)
         if numeric_limit is None:
@@ -384,6 +390,8 @@ def _real_main(argv=None):
         'write_pages': opts.write_pages,
         'test': opts.test,
         'keepvideo': opts.keepvideo,
+        'min_duration': opts.min_duration,
+        'max_duration': opts.max_duration,
         'min_filesize': opts.min_filesize,
         'max_filesize': opts.max_filesize,
         'min_views': opts.min_views,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -280,6 +280,14 @@ def parseOpts(overrideArguments=None):
         dest='max_downloads', metavar='NUMBER', type=int, default=None,
         help='Abort after downloading NUMBER files')
     selection.add_option(
+        '--min-duration',
+        metavar='SECONDS', dest='min_duration', type=int, default=None,
+        help='Do not download any videos smaller than duration, in seconds')
+    selection.add_option(
+        '--max-duration',
+        metavar='SECONDS', dest='max_duration', type=int, default=None,
+        help='Do not download any videos larger than duration, in seconds')
+    selection.add_option(
         '--min-filesize',
         metavar='SIZE', dest='min_filesize', default=None,
         help='Do not download any videos smaller than SIZE (e.g. 50k or 44.6m)')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This adds the option of minimum and maximum duration for a video. (Similar to min and max filesize)

Often filesize is not an indicator of video duration but video selection by exact duration may be what is desired.

There are multiple reason why I am adding this:

1. For my youtube subscription - I see small videos (< 5 mins) directly on youtube without downloading. So downloading them makes no sense. (hence --min-duration)
2. Most of the times I am not interested in long duration videos (> 45 mins). Hence --max-duration.
3. See issue #17051. If this feature is passed - we could also add "-fs" (max filesize) and "-t" (max duration) option to ffmpeg processor. So that "recently" streamed video which is "no more live" but still under process by youtube (hence does not have file size and duration available) will not run away downloading 2-3 hour video and occupy GBs of space. In short --max-filesize and --max-duration would be respected even by ffmpeg.

Please consider.