### PR TITLE
Better min/max-filesize checking

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -299,7 +299,7 @@ class YoutubeDL(object):
 
     The following parameters are not used by YoutubeDL itself, they are used by
     the downloader (see youtube_dl/downloader/common.py):
-    nopart, updatetime, buffersize, ratelimit, min_filesize, max_filesize, test,
+    nopart, updatetime, buffersize, ratelimit, test,
     noresizebuffer, retries, continuedl, noprogress, consoletitle,
     xattr_set_filesize, external_downloader_args, hls_use_mpegts,
     http_chunk_size.
@@ -749,6 +749,14 @@ class YoutubeDL(object):
             return '%s has already been recorded in archive' % video_title
 
         if not incomplete:
+            filesize = info_dict.get('filesize')
+            if filesize is not None and filesize > 0:
+                min_filesize = self.params.get('min_filesize')
+                if min_filesize is not None and filesize < min_filesize:
+                    return 'Skipping %s, filesize is smaller than min-filesize (%d bytes < %d bytes)' % (video_title, filesize, min_filesize)
+                max_filesize = self.params.get('max_filesize')
+                if max_filesize is not None and filesize > max_filesize:
+                    return 'Skipping %s, filesize is larger than max-filesize (%d bytes > %d bytes)' % (video_title, filesize, max_filesize)
             match_filter = self.params.get('match_filter')
             if match_filter is not None:
                 ret = match_filter(info_dict)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When using --min-filesize OR --max-filesize, youtube-dl first invokes downloader (i.e sends http download request) and then checks "Content-length".

This may not be necessary always. In most cases we already know filesize from meta information.

This PR improves the filesize checking.

If "filesize" is available via info_dict then it uses that and avoids invoking downloader unnecessarily.