### PR TITLE
[twitch:vod] Twitch passport support for login

### DIFF
--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -27,7 +27,6 @@ from ..utils import (
     try_get,
     unified_timestamp,
     update_url_query,
-    urlencode_postdata,
     url_or_none,
     urljoin,
 )

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -33,7 +33,7 @@ from ..utils import (
 
 
 class TwitchBaseIE(InfoExtractor):
-    _VALID_URL_BASE = r'https?://(?:(?:www|go|m|passport)\.)?twitch\.tv'
+    _VALID_URL_BASE = r'https?://(?:(?:www|go|m)\.)?twitch\.tv'
 
     _API_BASE = 'https://api.twitch.tv'
     _USHER_BASE = 'https://usher.ttvnw.net'
@@ -90,13 +90,13 @@ class TwitchBaseIE(InfoExtractor):
             try:
                 response = self._download_json(
                     post_url, None, note,
-                    data=json.dumps(form),
+                    data=json.dumps(form).encode(),
                     headers=headers)
             except ExtractorError as e:
                 if isinstance(e.cause, compat_HTTPError) and e.cause.code == 400:
                     response = self._parse_json(
                         e.cause.read().decode('utf-8'), None)
-                    fail(response.get('message') or response['errors'][0])
+                    fail(response.get('error_description') or response.get('error_code'))
                 raise
 
             if 'Authenticated successfully' in response.get('message', ''):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Twitch recently made changes to how their login works, involving [passport.twitch.tv](https://passport.twitch.tv/sessions/new "passport.twitch.tv"). This broke [certain VOD](https://github.com/rg3/youtube-dl/issues/17024 "certain VOD") downloads. This PR still requests the login form from `twitch.tv/login` but instead posts the information to `passport.twitch.tv`.

_Note: If hammering, a captcha requirement may pop up. This seemed to calm down for me after about 30 mins of leaving it alone_

This fixes #17024 