### PR TITLE
[YoutubeDL] Display video titles in formats list output (fixes issue #17357)

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2177,9 +2177,12 @@ class YoutubeDL(object):
             table[-1][-1] += (' ' if table[-1][-1] else '') + '(best)'
 
         header_line = ['format code', 'extension', 'resolution', 'note']
+        video_descriptor = info_dict['id']
+        if info_dict['title'] is not None:
+            video_descriptor = info_dict['title'] + '-' + video_descriptor
         self.to_screen(
             '[info] Available formats for %s:\n%s' %
-            (info_dict['id'], render_table(header_line, table)))
+            (video_descriptor, render_table(header_line, table)))
 
     def list_thumbnails(self, info_dict):
         thumbnails = info_dict.get('thumbnails')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

Also display all video titles in the formats list output, using the standard dash notation - issue #17357.

This is effectively a redux of outdated PR #11296 with some additional checks in place.

Cheers and thank you!

Parmjit V.