### PR TITLE
Added info extractor for www.tele5.de, a German TV station.

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1086,6 +1086,7 @@ from .teachingchannel import TeachingChannelIE
 from .teamcoco import TeamcocoIE
 from .techtalks import TechTalksIE
 from .ted import TEDIE
+from .tele5 import Tele5IE
 from .tele13 import Tele13IE
 from .telebruxelles import TeleBruxellesIE
 from .telecinco import TelecincoIE

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -1,0 +1,58 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from .nexx import NexxIE
+
+
+class Tele5IE(InfoExtractor):
+    _VALID_URL = r'https://www.tele5.de/(mediathek/filme-online/videos|tv/).*'
+
+    _TESTS = [{
+        'url': 'https://www.tele5.de/mediathek/filme-online/videos?vid=1550589',
+        'info_dict': {
+            'id': '1550589',
+            'ext': 'mp4',
+            'upload_date': '20180822',
+            'timestamp': 1534927316,
+            'title': 'SchleFaZ: Atomic Shark'
+        }
+    }, {
+        'url': 'https://www.tele5.de/tv/dark-matter/videos',
+        'info_dict': {
+            'id': '1548206',
+            'ext': 'mp4',
+            'title': 'Folge Sechsundzwanzig',
+            'timestamp': 1533664358,
+            'upload_date': '20180807'
+        }
+    }, {
+        'url': 'https://www.tele5.de/tv/relic-hunter/videos',
+        'info_dict': {
+            'id': '1548034',
+            'ext': 'mp4',
+            'timestamp': 1533577964,
+            'upload_date': '20180806',
+            'title': 'Mr. Right'
+        }
+    }, {
+        'url': 'https://www.tele5.de/tv/buffy-im-bann-der-daemonen/videos',
+        'info_dict': {
+            'id': '1547129',
+            'ext': 'mp4',
+            'upload_date': '20180730',
+            'timestamp': 1532967491,
+            'title': 'Der Höllenhund'
+        }
+    }]
+
+    def _real_extract(self, url):
+        webpage = self._download_webpage(url, 'N/A')
+
+        id = self._html_search_regex(
+            r'class="ce_videoelementnexx-video__player"\sid="video-player"\sdata-id="(?P<id>[0-9]+)"',
+            webpage, 'id')
+
+        return self.url_result(
+            'https://api.nexx.cloud/v3/759/videos/byid/%s'
+            % id, ie=NexxIE.ie_key())

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import re
+
 from .common import InfoExtractor
 from .nexx import NexxIE
 
 
 class Tele5IE(InfoExtractor):
-    _VALID_URL = r'https://www.tele5.de/[mediathek/filme-online/videos|tv/]'
+    _VALID_URL = r'https://www\.tele5\.de/(?:mediathek/filme-online/videos\?vid=|tv/)(?P<display_id>[\w-]+)'
 
     _TESTS = [{
         'url': 'https://www.tele5.de/mediathek/filme-online/videos?vid=1550589',
@@ -15,26 +17,23 @@ class Tele5IE(InfoExtractor):
             'ext': 'mp4',
             'upload_date': '20180822',
             'timestamp': 1534927316,
-            'title': 'SchleFaZ: Atomic Shark'
+            'title': 'SchleFaZ: Atomic Shark',
         }
     }, {
         'url': 'https://www.tele5.de/tv/dark-matter/videos',
-        'info_dict': {
-            'id': '1548206',
-            'ext': 'mp4',
-            'title': 'Folge Sechsundzwanzig',
-            'timestamp': 1533664358,
-            'upload_date': '20180807'
-        }
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):
-        webpage = self._download_webpage(url, 'N/A')
+        mobj = re.match(self._VALID_URL, url)
+        display_id = mobj.group('display_id')
+
+        webpage = self._download_webpage(url, display_id)
 
         video_id = self._html_search_regex(
-            r'id="video-player"\sdata-id="(?P<id>[0-9]+)"',
-            webpage, 'id')
+            r'id\s*=\s*["\']video-player["\']\s*data-id\s*=\s*["\']([0-9]+)["\']',
+            webpage, 'video_id')
 
         return self.url_result(
-            'https://api.nexx.cloud/v3/759/videos/byid/%s'
-            % video_id, ie=NexxIE.ie_key())
+            'https://api.nexx.cloud/v3/759/videos/byid/%s' % video_id,
+            ie=NexxIE.ie_key(), video_id=video_id)

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -6,7 +6,7 @@ from .nexx import NexxIE
 
 
 class Tele5IE(InfoExtractor):
-    _VALID_URL = r'https://www.tele5.de/(mediathek/filme-online/videos|tv/).*'
+    _VALID_URL = r'https://www.tele5.de/[mediathek/filme-online/videos|tv/]'
 
     _TESTS = [{
         'url': 'https://www.tele5.de/mediathek/filme-online/videos?vid=1550589',
@@ -26,33 +26,15 @@ class Tele5IE(InfoExtractor):
             'timestamp': 1533664358,
             'upload_date': '20180807'
         }
-    }, {
-        'url': 'https://www.tele5.de/tv/relic-hunter/videos',
-        'info_dict': {
-            'id': '1548034',
-            'ext': 'mp4',
-            'timestamp': 1533577964,
-            'upload_date': '20180806',
-            'title': 'Mr. Right'
-        }
-    }, {
-        'url': 'https://www.tele5.de/tv/buffy-im-bann-der-daemonen/videos',
-        'info_dict': {
-            'id': '1547129',
-            'ext': 'mp4',
-            'upload_date': '20180730',
-            'timestamp': 1532967491,
-            'title': 'Der Höllenhund'
-        }
     }]
 
     def _real_extract(self, url):
         webpage = self._download_webpage(url, 'N/A')
 
-        id = self._html_search_regex(
-            r'class="ce_videoelementnexx-video__player"\sid="video-player"\sdata-id="(?P<id>[0-9]+)"',
+        video_id = self._html_search_regex(
+            r'id="video-player"\sdata-id="(?P<id>[0-9]+)"',
             webpage, 'id')
 
         return self.url_result(
             'https://api.nexx.cloud/v3/759/videos/byid/%s'
-            % id, ie=NexxIE.ie_key())
+            % video_id, ie=NexxIE.ie_key())


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
This adds support for www.tele5.de, which is a German TV station providing temporary online access to movies and TV shows after broadcast.

I have added tests, but since the referenced videos will only be available for limited time, these tests will fail in the future. They all were successful at the time this PR has been created, though. Unfortunately the site does not provide videos that are available for a longer time.
