### PR TITLE
[openload] Add option for phantomjs executable path (fixes #15146)

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2259,7 +2259,9 @@ class YoutubeDL(object):
 
         exe_versions = FFmpegPostProcessor.get_versions(self)
         exe_versions['rtmpdump'] = rtmpdump_version()
-        exe_versions['phantomjs'] = PhantomJSwrapper._version()
+        exe_versions['phantomjs'] = PhantomJSwrapper._version(
+            exe_path=self.params.get('phantomjs_location')
+        )
         exe_str = ', '.join(
             '%s %s' % (exe, v)
             for exe, v in sorted(exe_versions.items())

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -421,6 +421,7 @@ def _real_main(argv=None):
         'match_filter': match_filter,
         'no_color': opts.no_color,
         'ffmpeg_location': opts.ffmpeg_location,
+        'phantomjs_location': opts.phantomjs_location,
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
         'external_downloader_args': external_downloader_args,

--- a/youtube_dl/extractor/openload.py
+++ b/youtube_dl/extractor/openload.py
@@ -107,14 +107,16 @@ class PhantomJSwrapper(object):
 
     _TMP_FILE_NAMES = ['script', 'html', 'cookies']
 
-    @staticmethod
-    def _version():
-        return get_exe_version('phantomjs', version_re=r'([0-9.]+)')
+    _DEFAULT_EXE_PATH = 'phantomjs'
 
-    def __init__(self, extractor, required_version=None, timeout=10000):
+    @classmethod
+    def _version(cls, exe_path=None):
+        return get_exe_version(exe_path or cls._DEFAULT_EXE_PATH, version_re=r'([0-9.]+)')
+
+    def __init__(self, extractor, required_version=None, timeout=10000, exe_path=None):
         self._TMP_FILES = {}
 
-        self.exe = check_executable('phantomjs', ['-v'])
+        self.exe = check_executable(exe_path or self._DEFAULT_EXE_PATH, ['-v'])
         if not self.exe:
             raise ExtractorError('PhantomJS executable not found in PATH, '
                                  'download it from http://phantomjs.org',
@@ -342,7 +344,8 @@ class OpenloadIE(InfoExtractor):
                 raise ExtractorError('File not found', expected=True, video_id=video_id)
             break
 
-        phantom = PhantomJSwrapper(self, required_version='2.0')
+        phantomjs_location = self._downloader.params.get('phantomjs_location')
+        phantom = PhantomJSwrapper(self, required_version='2.0', exe_path=phantomjs_location)
         webpage, _ = phantom.get(page_url, html=webpage, video_id=video_id, headers=headers)
 
         decoded_id = (get_element_by_id('streamurl', webpage) or

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -853,7 +853,7 @@ def parseOpts(overrideArguments=None):
     postproc.add_option(
         '--phantomjs-location', metavar='PATH',
         dest='phantomjs_location',
-        help='Location of the phantomjs binary; either the path to the binary or its containing directory.')
+        help='Location of the phantomjs binary.')
     postproc.add_option(
         '--exec',
         metavar='CMD', dest='exec_cmd',

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -851,6 +851,10 @@ def parseOpts(overrideArguments=None):
         dest='ffmpeg_location',
         help='Location of the ffmpeg/avconv binary; either the path to the binary or its containing directory.')
     postproc.add_option(
+        '--phantomjs-location', metavar='PATH',
+        dest='phantomjs_location',
+        help='Location of the phantomjs binary; either the path to the binary or its containing directory.')
+    postproc.add_option(
         '--exec',
         metavar='CMD', dest='exec_cmd',
         help='Execute a command on the file after downloading, similar to find\'s -exec syntax. Example: --exec \'adb push {} /sdcard/Music/ && rm {}\'')


### PR DESCRIPTION

[#15146](https://github.com/rg3/youtube-dl/issues/15146)
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Addition of the `--phantom-location` option.
`youtube-dl (url) --phantomjs-location /usr/local/bin/phantomjs`

The `--phantomjs-location` flag can be used to configure the executable to use for PhantomJS. This is useful for when the executable is not in PATH, or if the user wants to use a specific executable file defined elsewhere.
