### PR TITLE
[ARD:mediathek] Fix title and description extraction

### DIFF
--- a/youtube_dl/extractor/ard.py
+++ b/youtube_dl/extractor/ard.py
@@ -173,13 +173,17 @@ class ARDMediathekIE(InfoExtractor):
         title = self._html_search_regex(
             [r'<h1(?:\s+class="boxTopHeadline")?>(.*?)</h1>',
              r'<meta name="dcterms\.title" content="(.*?)"/>',
-             r'<h4 class="headline">(.*?)</h4>'],
+             r'<h4 class="headline">(.*?)</h4>',
+             r'<title[^>]*>(.*?)</title>'],
             webpage, 'title')
         description = self._html_search_meta(
             'dcterms.abstract', webpage, 'description', default=None)
         if description is None:
             description = self._html_search_meta(
-                'description', webpage, 'meta description')
+                'description', webpage, 'meta description', default=None)
+        if description is None:
+            description = self._html_search_regex(
+                r'<p\s+class="teasertext">(.*?)</p>', webpage, 'teaser text')
 
         # Thumbnail is sometimes not present.
         # It is in the mobile version, but that seems to use a different URL

--- a/youtube_dl/extractor/ard.py
+++ b/youtube_dl/extractor/ard.py
@@ -183,7 +183,8 @@ class ARDMediathekIE(InfoExtractor):
                 'description', webpage, 'meta description', default=None)
         if description is None:
             description = self._html_search_regex(
-                r'<p\s+class="teasertext">(.*?)</p>', webpage, 'teaser text')
+                r'<p\s+class="teasertext">(.+?)</p>',
+                webpage, 'teaser text', default=None)
 
         # Thumbnail is sometimes not present.
         # It is in the mobile version, but that seems to use a different URL


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

[ARD:mediathek] recently fails for certain videos, because youtube-dl cannot extract the title. This PR adds a new regex for the title extraction and a new regex for the description extraction, which is used e.g. in this (https://www.ardmediathek.de/tv/Dokumentarfilm/Das-Salz-der-Erde-Sebasti%C3%A3o-Salgado-im/SWR-Fernsehen/Video?bcastId=1105036&documentId=57927466) video.

It should close #18349, but I cannot explain that strange behavior which I described there: https://github.com/rg3/youtube-dl/issues/18349#issuecomment-443526330