### PR TITLE
Added support to Gaana.com

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -418,6 +418,11 @@ from .gameone import (
 )
 from .gamespot import GameSpotIE
 from .gamestar import GameStarIE
+from .gaana import (
+    GaanaIE,
+    GaanaAlbumIE,
+    GaanaArtistIE,
+)
 from .gaskrank import GaskrankIE
 from .gazeta import GazetaIE
 from .gdcvault import GDCVaultIE

--- a/youtube_dl/extractor/gaana.py
+++ b/youtube_dl/extractor/gaana.py
@@ -1,0 +1,190 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+from ..aes import aes_cbc_decrypt
+from ..compat import (
+    compat_b64decode,
+)
+
+from .common import InfoExtractor
+from ..utils import (
+    bytes_to_intlist,
+    intlist_to_bytes,
+    int_or_none,
+)
+
+
+class GaanaBaseIE(InfoExtractor):
+    bs = 32
+    _BASE_URL = 'https://gaana.com'
+
+    def _Decrypt(self, data):
+
+        key = 'Z0AxbiEoZjEjci4wJCkmJQ=='
+        iv = 'YXNkIUAjIUAjQCExMjMxMg=='
+
+        stream_url = intlist_to_bytes(aes_cbc_decrypt(
+            bytes_to_intlist(compat_b64decode(data)),
+            bytes_to_intlist(compat_b64decode(key)),
+            bytes_to_intlist(compat_b64decode(iv)))).decode()
+
+        s = stream_url[:-ord(stream_url[len(stream_url) - 1:])]
+        return s
+
+    def _create_entry(self, data, video_id):
+
+        raw_data = self._parse_json(data, video_id)
+
+        video_data = raw_data.get('path')
+        title = raw_data.get('title')
+        if not title:
+            print("No title found.")
+        thumbnail = raw_data.get('atw', '') or raw_data.get('albumartwork', '')
+        duration = raw_data.get('duration')
+
+        formats = []
+        if isinstance(video_data, dict):
+            for value in video_data.keys():
+                # need to skip auto
+                # this format and quaity is too dificult to handle for audio player.
+                # currently, it has been skipped
+                # in future this format also be going to available
+                if not value == 'auto':
+                    content = video_data.get(value)
+                    for k in content:
+                        format_url = self._Decrypt(k.get('message'))
+                        format_id = value
+
+                        formats.append({
+                            'url': format_url,
+                            'format_id': format_id,
+                            'ext': 'mp4'
+                        })
+
+            artist = raw_data.get('artist')
+
+            # Remove unwanted # character from string
+            if not artist:
+                artist = artist.replace(artist, "###", ', ')
+
+            return {
+                'id': video_id,
+                'title': title,
+                'description': raw_data.get('description'),
+                'duration': int_or_none(duration),
+                'formats': formats,
+                'album': raw_data.get('albumtitle'),
+                'thumbnail': thumbnail,
+                'artist': artist,
+                'release_date': raw_data.get('release_date'),
+                'language': raw_data.get('language')
+            }
+        else:
+            # we are here, beacause gaana.com uses cloudfont.com also
+            # alongwith some other sites for storage purpose.
+            # that will be implemented soon.
+            return None
+
+
+class GaanaIE(GaanaBaseIE):
+    IE_NAME = 'gaana'
+    _VALID_URL = r'https?://(?:www\.)?gaana\.com/song/(?P<id>[^/#?]+)'
+    _TESTS = {
+        # contentData
+        'url': 'https://gaana.com/song/jeeye-to-jeeye-kaise',
+        'info_dict': {
+            'id': 'jeeye-to-jeeye-kaise',
+            'ext': 'mp4',
+            'title': 'Jeeye To Jeeye Kaise',
+            'duration': 325,
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        }
+    }
+    _GEO_BYPASS = False
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        webpage = self._download_webpage(url, video_id)
+        raw_data = self._search_regex(
+            r'class="parentnode sourcelist_\d+"> (.*?) </span>',
+            webpage, 'raw data')
+        entry = self._create_entry(raw_data, video_id)
+        if entry:
+            entry
+
+
+class GaanaAlbumIE(GaanaBaseIE):
+    IE_NAME = 'gaana:album'
+    _VALID_URL = r'https?://(?:www\.)?gaana\.com/album/(?P<id>[^/#?]+)'
+    _TESTS = {
+        'url': 'https://gaana.com/album/saajan-hindi',
+        'info_dict': {
+            'id': 'saajan-hindi',
+        },
+        'playlist_mincount': 1,
+    }
+
+    def _real_extract(self, url):
+        playlist_id = self._match_id(url)
+        webpage = self._download_webpage(url, playlist_id)
+        # print(webpage)
+        matchobj = re.findall(r'class="parentnode sourcelist_\d+"> (.*?) </span>', webpage)
+        entries = []
+        for g in matchobj:
+            entry = self._create_entry(g, playlist_id)
+            if entry:
+                entries.append(self._create_entry(g, playlist_id))
+
+        return self.playlist_result(entries, playlist_id)
+
+
+class GaanaArtistIE(GaanaBaseIE):
+    IE_NAME = 'gaana:artist'
+    _VALID_URL = r'https?://(?:www\.)?gaana\.com/artist/(?P<id>[^/#?]+)'
+    _TESTS = {
+        'url': 'https://gaana.com/artist/kumar-sanu',
+        'info_dict': {
+            'id': 'kumar-sanu',
+        },
+        'playlist_mincount': 1,
+    }
+
+    def _real_extract(self, url):
+        playlist_id = self._match_id(url)
+        webpage = self._download_webpage(url, playlist_id)
+        urls = self._read_entry(webpage, playlist_id)
+        entries = []
+
+        for g in urls:
+            video_id = g.replace('https://gaana.com/song/', '')
+            webpage = self._download_webpage(g, video_id)
+
+            raw_data = self._search_regex(
+                r'class="parentnode sourcelist_\d+"> (.*?) </span>',
+                webpage, 'raw data')
+
+            entry = self._create_entry(raw_data, playlist_id)
+
+            if entry:
+                entries.append(entry)
+
+        return self.playlist_result(entries, playlist_id)
+
+    def _read_entry(self, webpage, video_id):
+        entries = []
+        matchobj = re.findall(r'class="parentnode sourcelist_\d+"> (.*?) </span>', webpage)
+
+        for g in matchobj:
+            raw_data = self._parse_json(g, video_id)
+            new_url = raw_data.get('share_url')
+
+            if new_url:
+                new_url = self._BASE_URL + new_url
+                entries.append(new_url)
+
+        return entries


### PR DESCRIPTION
Hi!

As per request of [Gaana Support #12575](https://github.com/rg3/youtube-dl/issues/12575), I have tried to add the support of [gaana.com](https://gaana.com).

It currently support three types of url:

1.     https://gaana.com/song/-------------
2.     https://gaana.com/album/-------------
3.     https://gaana.com/artist/-------------

For single song:
`youtube-dl https://gaana.com/song/mera-dil-bhi-kitna-pagal-hai-1 -f best`

For all songs in the album:
`youtube-dl https://gaana.com/album/saajan-hindi -f best`

For all songs of the artist:
`youtube-dl https://gaana.com/artist/kumar-sanu -f best`

It will download songs in .mp4 format.

Currently, as far I've come to know, Gaana.com stores its .m3u8 in more than 3 server such as akamaihd.net, cloudfront.net, musicnet.com and uses different algorithm to get it.

This code will help to get songs from akamaihd.net only. Support for other severs will be implemented shortly. I am still working on it. I have tested it from INDIA and works fine. I have checked with flake8 also.

One more thing, I am not professional in programing. I try to write for my peace.  I have just coded first time in Python, so the code may be non-smooth. 

**And to all maintainers and moderators of the youtube-dl**, please do not feel bored for the quality of code, please help and guide to make me suitable in this platform.

Thanks all.