### PR TITLE
[radiocanada] Relax DRM check

### DIFF
--- a/youtube_dl/extractor/radiocanada.py
+++ b/youtube_dl/extractor/radiocanada.py
@@ -51,7 +51,7 @@ class RadioCanadaIE(InfoExtractor):
             },
         },
         {
-            # url from toutv that triggers false DRM validation
+            # with protectionType but not actually DRM protected
             'url': 'radiocanada:toutv:140872',
             'info_dict': {
                 'id': '140872',

--- a/youtube_dl/extractor/radiocanada.py
+++ b/youtube_dl/extractor/radiocanada.py
@@ -49,6 +49,14 @@ class RadioCanadaIE(InfoExtractor):
                 # m3u8 download
                 'skip_download': True,
             },
+        },
+        {
+            'url': 'radiocanada:toutv:140872',
+            'info_dict': {
+                'id': '140872',
+                'title': 'Épisode 1',
+                'series': 'District 31'
+            }
         }
     ]
 

--- a/youtube_dl/extractor/radiocanada.py
+++ b/youtube_dl/extractor/radiocanada.py
@@ -67,8 +67,10 @@ class RadioCanadaIE(InfoExtractor):
             el = find_xpath_attr(metadata, './/Meta', 'name', name)
             return el.text if el is not None else None
 
+        # IsDrm does not necessarily mean the video is DRM protected (see
+        # https://github.com/rg3/youtube-dl/issues/13994).
         if get_meta('protectionType'):
-            raise ExtractorError('This video is DRM protected.', expected=True)
+            self.report_warning('This video is probably DRM protected.')
 
         device_types = ['ipad']
         if not smuggled_data:

--- a/youtube_dl/extractor/radiocanada.py
+++ b/youtube_dl/extractor/radiocanada.py
@@ -51,12 +51,14 @@ class RadioCanadaIE(InfoExtractor):
             },
         },
         {
+            # url from toutv that triggers false DRM validation
             'url': 'radiocanada:toutv:140872',
             'info_dict': {
                 'id': '140872',
                 'title': 'Épisode 1',
-                'series': 'District 31'
-            }
+                'series': 'District 31',
+            },
+            'only_matching': True,
         }
     ]
 
@@ -75,7 +77,7 @@ class RadioCanadaIE(InfoExtractor):
             el = find_xpath_attr(metadata, './/Meta', 'name', name)
             return el.text if el is not None else None
 
-        # IsDrm does not necessarily mean the video is DRM protected (see
+        # protectionType does not necessarily mean the video is DRM protected (see
         # https://github.com/rg3/youtube-dl/issues/13994).
         if get_meta('protectionType'):
             self.report_warning('This video is probably DRM protected.')

--- a/youtube_dl/extractor/radiocanada.py
+++ b/youtube_dl/extractor/radiocanada.py
@@ -78,7 +78,7 @@ class RadioCanadaIE(InfoExtractor):
             return el.text if el is not None else None
 
         # protectionType does not necessarily mean the video is DRM protected (see
-        # https://github.com/rg3/youtube-dl/issues/13994).
+        # https://github.com/rg3/youtube-dl/pull/18609).
         if get_meta('protectionType'):
             self.report_warning('This video is probably DRM protected.')
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Relax the DRM validation as it gives false positive DRM validations. It was the same issue that happened on the toutv extractor. (toutv is a brand of radiocanada) [toutv original commit] (https://github.com/rg3/youtube-dl/commit/8d7a24aff60a57e651bab40f16a81eb7dffb405c#diff-b0b3d3dea05a5c80aca484e9eca2af64)
