### PR TITLE
[toutv] fixes #16398 - accounts don't work after site redesign.

### DIFF
--- a/youtube_dl/extractor/toutv.py
+++ b/youtube_dl/extractor/toutv.py
@@ -6,7 +6,6 @@ import re
 from .common import InfoExtractor
 from ..utils import (
     int_or_none,
-    js_to_json,
     urlencode_postdata,
     extract_attributes,
     smuggle_url,
@@ -46,14 +45,13 @@ class TouTvIE(InfoExtractor):
         email, password = self._get_login_info()
         if email is None:
             return
-        state = 'http://ici.tou.tv/'
-        webpage = self._download_webpage(state, None, 'Downloading homepage')
-        toutvlogin = self._parse_json(self._search_regex(
-            r'(?s)toutvlogin\s*=\s*({.+?});', webpage, 'toutvlogin'), None, js_to_json)
-        authorize_url = toutvlogin['host'] + '/auth/oauth/v2/authorize'
+        state = 'http://ici.tou.tv/app.js'
+        webpage = self._download_webpage(state, None, 'Downloading app.js script')
+        client_id = self._search_regex(r'document\.URL:{clientId:"(.+?)"', webpage, 'toutvclientid')
+        authorize_url = 'https://services.radio-canada.ca/auth/oauth/v2/authorize'
         login_webpage = self._download_webpage(
             authorize_url, None, 'Downloading login page', query={
-                'client_id': toutvlogin['clientId'],
+                'client_id': client_id,
                 'redirect_uri': 'https://ici.tou.tv/login/loginCallback',
                 'response_type': 'token',
                 'scope': 'media-drmt openid profile email id.write media-validation.read.privileged',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
fixes #16398 
Tou.tv was redesign with react and the login url was moved into JS. The code was not able to find the clientID needed.
My fix browses through the app.js file to extract the clientID needed for the login form. 
