### PR TITLE
Allow post processing a file in the same format when post processor args are passed

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -627,6 +627,16 @@ class TestYoutubeDL(unittest.TestCase):
         self.assertTrue(os.path.exists(audiofile), '%s doesn\'t exist' % audiofile)
         os.unlink(audiofile)
 
+        class SameFilePP(PostProcessor):
+            def run(self, info):
+                with open(info['filepath'], 'wt') as f:
+                    f.write('EXAMPLE')
+                return [info['filepath']], info
+
+        run_pp({'keepvideo': False}, SameFilePP)
+        self.assertTrue(os.path.exists(filename), '%s doesn\'t exist' % filename)
+        os.unlink(filename)
+
         class ModifierPP(PostProcessor):
             def run(self, info):
                 with open(info['filepath'], 'wt') as f:

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -605,7 +605,9 @@ class TestYoutubeDL(unittest.TestCase):
             def run(self, info):
                 with open(audiofile, 'wt') as f:
                     f.write('EXAMPLE')
-                return [info['filepath']], info
+                old_file = info['filepath']
+                info['filepath'] = audiofile
+                return [old_file], info
 
         def run_pp(params, PP):
             with open(filename, 'wt') as f:

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2050,11 +2050,13 @@ class YoutubeDL(object):
                 self.report_error(e.msg)
             if files_to_delete and not self.params.get('keepvideo', False):
                 for old_filename in files_to_delete:
-                    self.to_screen('Deleting original file %s (pass -k to keep)' % old_filename)
-                    try:
-                        os.remove(encodeFilename(old_filename))
-                    except (IOError, OSError):
-                        self.report_warning('Unable to remove downloaded original file')
+                    # don't delete the processed file if it happens to be in the same format
+                    if old_filename != info['filepath']:
+                        self.to_screen('Deleting original file %s (pass -k to keep)' % old_filename)
+                        try:
+                            os.remove(encodeFilename(old_filename))
+                        except (IOError, OSError):
+                            self.report_warning('Unable to remove downloaded original file')
 
     def _make_archive_id(self, info_dict):
         # Future-proof against any change in case

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -325,7 +325,8 @@ class FFmpegVideoConvertorPP(FFmpegPostProcessor):
 
     def run(self, information):
         path = information['filepath']
-        if information['ext'] == self._preferedformat:
+        # if the ext is the same and there are no additional postprocessor args
+        if information['ext'] == self._preferedformat and not self._configuration_args():
             self._downloader.to_screen('[ffmpeg] Not converting video file %s - already is in target format %s' % (path, self._preferedformat))
             return [], information
         options = []


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

A small change to allow post processing a downloaded file even if the requested format is the same but with post processor args passed using `--postprocessor-args`, a use case is passing arguments to ffmpeg to cut the downloaded file using these arguments `-ss, -to, -t`, or basically any other arguments that will give more control to the user, for example:

    youtube-dl URL --recode-video mp4 --format mp4 --postprocessor-args "-ss 10 -to 120 -c copy"

Currently if we try to `--recode-video` to the same format we will get this message:

    [ffmpeg] Not converting video file FILE_PATH - already is in target format FILE_FORMAT

So I made a change to the `FFmpegVideoConvertorPP` class, there was a check for the same file extension before showing this message, so I added another check for empty post processor args obtained with `self._configuration_args()` which basically returns the option `postprocessor_args` or an empty list.

I also made a change to `YoutubeDL.post_process` to prevent the processed file from being deleted with a check to see if the file path to be deleted is the same returned from the post processor.
