### PR TITLE
[raiplay] Add support for MPD format

### DIFF
--- a/youtube_dl/extractor/rai.py
+++ b/youtube_dl/extractor/rai.py
@@ -71,13 +71,16 @@ class RaiBaseIE(InfoExtractor):
                 continue
 
             ext = determine_ext(media_url)
-            if (ext == 'm3u8' and platform != 'mon') or (ext == 'f4m' and platform != 'flash'):
+            if (ext in ['m3u8', 'mpd'] and platform != 'mon') or (ext == 'f4m' and platform != 'flash'):
                 continue
 
             if ext == 'm3u8':
                 formats.extend(self._extract_m3u8_formats(
                     media_url, video_id, 'mp4', 'm3u8_native',
                     m3u8_id='hls', fatal=False))
+            elif ext == 'mpd':
+                formats.extend(self._extract_mpd_formats(
+                    media_url, video_id, mpd_id='dash', fatal=False))
             elif ext == 'f4m':
                 manifest_url = update_url_query(
                     media_url.replace('manifest#live_hds.f4m', 'manifest.f4m'),


### PR DESCRIPTION
I have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

And:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some new 4K content on RaiPlay.it is served using DASH via an MPD manifest, e.g.:
https://www.raiplay.it/video/2018/12/L-amica-geniale-S1E1-Le-bambole--4K-cd5f4664-261c-48d1-bed8-79cce415bea8.html

In these cases youtube-dl was just downloading the manifest but not the video.

Adding support for the MPD format to the raiplay extractor is enough to enable downloading the video.

TBH I am not sure if the change regarding the check on `platform` is needed, the new format works also without it because the format is added as native eventually, but I performed the check anyway because this way the format is added a little earlier.

BTW does anyone know what `platform == 'mon'` means for Rai, and what the difference with `native` is?

Thank you.