### PR TITLE
[YouPorn] Make title regex more specific.

### DIFF
--- a/youtube_dl/extractor/youporn.py
+++ b/youtube_dl/extractor/youporn.py
@@ -68,13 +68,7 @@ class YouPornIE(InfoExtractor):
         request.add_header('Cookie', 'age_verified=1')
         webpage = self._download_webpage(request, display_id)
 
-        title = self._search_regex([
-                r'[=:]\s*(["\'])video[\._-]titles?\1[^>]*>\s*<\s*h1[^>]+class=["\']heading\d?["\'][^>]*>(?P<title>[^<]+)<',
-                r'(?:video_titles|videoTitle)\s*[:=]\s*(["\'])(?P<title>(?:(?!\1).)+)\1',
-                #r'<h1[^>]+class=["\']heading\d?["\'][^>]*>(?P<title>[^<]+)<',
-            ], webpage, 'title', group='title', default=None) \
-            or self._og_search_title(webpage, default=None) \
-            or self._html_search_meta('title', webpage, fatal=True)
+        title = self._og_search_title(webpage, default=None) or self._html_search_meta('title', webpage, fatal=True)
 
         links = []
 

--- a/youtube_dl/extractor/youporn.py
+++ b/youtube_dl/extractor/youporn.py
@@ -68,13 +68,13 @@ class YouPornIE(InfoExtractor):
         request.add_header('Cookie', 'age_verified=1')
         webpage = self._download_webpage(request, display_id)
 
-        title = self._search_regex(
-            [r'(?:video_titles|videoTitle)\s*[:=]\s*(["\'])(?P<title>(?:(?!\1).)+)\1',
-             r'<h1[^>]+class=["\']heading\d?["\'][^>]*>(?P<title>[^<]+)<'],
-            webpage, 'title', group='title',
-            default=None) or self._og_search_title(
-            webpage, default=None) or self._html_search_meta(
-            'title', webpage, fatal=True)
+        title = self._search_regex([
+                r'[=:]\s*(["\'])video[\._-]titles?\1[^>]*>\s*<\s*h1[^>]+class=["\']heading\d?["\'][^>]*>(?P<title>[^<]+)<',
+                r'(?:video_titles|videoTitle)\s*[:=]\s*(["\'])(?P<title>(?:(?!\1).)+)\1',
+                #r'<h1[^>]+class=["\']heading\d?["\'][^>]*>(?P<title>[^<]+)<',
+            ], webpage, 'title', group='title', default=None) \
+            or self._og_search_title(webpage, default=None) \
+            or self._html_search_meta('title', webpage, fatal=True)
 
         links = []
 


### PR DESCRIPTION
Currently the title regex matches too many blocks, and finds `Recommended Categories For You` in stead of the actual title.

Safe to drop `_search_regex`? `_og_search_title` also finds the correct title.

---

```
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
```