### PR TITLE
[Question] How to create a new parameter?

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -788,9 +788,28 @@ class YoutubeDL(object):
             if not ie.working():
                 self.report_warning('The program functionality for this site has been marked as broken, '
                                     'and will probably not work.')
-
             try:
-                ie_result = ie.extract(url)
+                if str(ie_key) == "Youtube":
+                    video_metadata_directory = "/data/video_metadata"
+                    # Check if we already have metadata downloaded for this file.
+                    metadata_path = os.path.join(video_metadata_directory, str(ie_key) + "." + str(url))
+                    if os.path.isfile(metadata_path):
+                        with open(metadata_path, 'r') as content_file:
+                            try:
+                                ie_result = json.loads(content_file.read())
+                            except:
+                                ie_result = ie.extract(url)
+                    else:
+                        ie_result = ie.extract(url)
+                        # Write the result here for future use.
+                        with open(metadata_path, 'w') as content_file:
+                            try:
+                                content_file.write(json.dumps(ie_result,indent=4))
+                            except:
+                                pass
+                else:
+                    ie_result = ie.extract(url)
+
                 if ie_result is None:  # Finished already (backwards compatibility; listformats and friends should be moved here)
                     break
                 if isinstance(ie_result, list):


### PR DESCRIPTION
Hi,

I've added some extra code to download all video metadata information for 'Youtube' ie_res types. I can't figure out how to safely determine if the ie_res is fully resolved or not (i.e. not a playlist). Also, I'm unsure about how to add `--video-metadata-directory` as a parameter. Help with those two things is appreciated.

My use case is: I want to download today's videos for certain Youtube channels - and not ever download the entire Youtube channel for space reasons.

My problem is: yotube_dl downloads metadata information for ever video, every time, just to determine if it should download or not based on date match. With each video taking a second - and  being many thousands of videos for all the channels, it takes a really long time to run.

The solution I want: Specify a video metadata directory that all video metadata gets stored to, regardless of if the video is downloaded or not. If the metadata for a video already exists, use that instead of downloading. 

Thanks,
Wayne

The code changes I've already added in my fork have exponentially sped up the process for me. I just want to formalize these changes and 'give back' to the project. Any help with this is greatly appreciated. I'm willing to do all the coding, I just need some advice.