### PR TITLE
[abc] iView: add support for downloading the latest episode of a show

### DIFF
--- a/youtube_dl/extractor/abc.py
+++ b/youtube_dl/extractor/abc.py
@@ -191,3 +191,38 @@ class ABCIViewIE(InfoExtractor):
             'subtitles': subtitles,
             'is_live': is_live,
         }
+
+
+class ABCIViewShowLatestEpisodeIE(InfoExtractor):
+    IE_NAME = 'abc.net.au:iview:show:latest-episode'
+    _VALID_URL = r'https?://iview\.abc\.net\.au/show/(?P<id>[^/]+)$'
+    _GEO_COUNTRIES = ['AU']
+
+    _TESTS = [{
+        'url': 'https://iview.abc.net.au/show/aussie-rangers',
+        'md5': 'd0ef57fb44165e5947f04b06ad30205f',
+        'info_dict': {
+            'id': 'IP1502W001S00',
+            'ext': 'mp4',
+            'title': 'Episode 1',
+            'series': "Aussie Rangers",
+            'description': 'md5:b2b899da064bdec43c3a291314ade444',
+            'upload_date': '20171204',
+            'uploader_id': 'abc2',
+            'timestamp': 1512354840,
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }]
+
+    def _real_extract(self, url):
+        show_id = self._match_id(url)
+        webpage = self._download_webpage(url, show_id)
+        webpage_data = self._search_regex(
+            r'window\.__INITIAL_STATE__\s*=\s*"(.+)"\s*;',
+            webpage, 'initial state')
+        json_data = unescapeHTML(webpage_data).encode('utf-8').decode('unicode_escape')
+        video_data = self._parse_json(json_data, show_id)
+        url = video_data['page']['pageData']['_embedded']['highlightVideo']['shareUrl']
+        return self.url_result(url)

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from .abc import (
     ABCIE,
     ABCIViewIE,
+    ABCIViewShowLatestEpisodeIE,
 )
 from .abcnews import (
     AbcNewsIE,


### PR DESCRIPTION
This allows to download using only the show URL instead of
having to find out the latest episode URL manually.

Test using Aussie Rangers which doesn't have an expiry date and
is quite old so it is unlikely to get a new episode, which would
cause the test to fail. The show and latest video URLs are:

https://iview.abc.net.au/show/aussie-rangers
https://iview.abc.net.au/show/aussie-rangers/series/0/video/IP1502W001S00

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I usually browse the recently added videos on ABC iView, click through, view the source, try to find the URL of the latest video and then pass that to youtube-dl. The commit allows me to just copy links to shows off the recently added videos and pass them directly to youtube-dl, which then automates getting the id of the latest video, saving a few clicks.

https://iview.abc.net.au/collection/recently-added