### PR TITLE
Convert archive.org thumbnail url to absolute (Closes #18892)

### DIFF
--- a/youtube_dl/extractor/archiveorg.py
+++ b/youtube_dl/extractor/archiveorg.py
@@ -51,8 +51,7 @@ class ArchiveOrgIE(InfoExtractor):
             return metadata.get(field, [None])[0]
 
         def convert_relative_to_absolute_thumbnail(metadata):
-            if not metadata['thumbnail'].startswith('http'):
-                metadata.update({'thumbnail': urljoin('http://archive.org', metadata.get('thumbnail'))})
+            metadata.update({'thumbnail': urljoin('http://archive.org', metadata.get('thumbnail'))})
 
         metadata = self._download_json(
             'http://archive.org/details/' + video_id, video_id, query={


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Thumbnail URL from archive.org is no longer absolute path as detailed in #18892 . This PR checks for the path and convert it into absolute.
