### PR TITLE
[bravotv] fix drupal settings parser (closes rg3#19214)

### DIFF
--- a/youtube_dl/extractor/bravotv.py
+++ b/youtube_dl/extractor/bravotv.py
@@ -12,19 +12,22 @@ from ..utils import (
 class BravoTVIE(AdobePassIE):
     _VALID_URL = r'https?://(?:www\.)?bravotv\.com/(?:[^/]+/)+(?P<id>[^/?#]+)'
     _TESTS = [{
-        'url': 'http://www.bravotv.com/last-chance-kitchen/season-5/videos/lck-ep-12-fishy-finale',
-        'md5': '9086d0b7ef0ea2aabc4781d75f4e5863',
+        'url': 'https://www.bravotv.com/the-real-housewives-of-beverly-hills/season-9/episode-1/videos/lisa-rinna-thinks-denise-richards',
+        'md5': 'f8098a7c034fcb1b52ec8b3631803589',
         'info_dict': {
-            'id': 'zHyk1_HU_mPy',
+            'id': 'PPhoit2pxdh0',
             'ext': 'mp4',
-            'title': 'LCK Ep 12: Fishy Finale',
-            'description': 'S13/E12: Two eliminated chefs have just 12 minutes to cook up a delicious fish dish.',
+            'title': 'Lisa Rinna Thinks Denise Richards Will Fit in Well With This Group',
+            'description': 'Denise goes back a long way with Rinna, and now the other ladies have a chance to meet her.',
             'uploader': 'NBCU-BRAV',
-            'upload_date': '20160302',
-            'timestamp': 1456945320,
+            'upload_date': '20190204',
+            'timestamp': 1549302120,
         }
     }, {
         'url': 'http://www.bravotv.com/below-deck/season-3/ep-14-reunion-part-1',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.bravotv.com/top-chef/season-16/episode-11/videos/lck-ep-12-the-final-knockout',
         'only_matching': True,
     }]
 
@@ -32,30 +35,39 @@ class BravoTVIE(AdobePassIE):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
         settings = self._parse_json(self._search_regex(
-            r'jQuery\.extend\(Drupal\.settings\s*,\s*({.+?})\);', webpage, 'drupal settings'),
+            r'<script[^>]+?data-drupal-selector="drupal-settings-json"[^>]*?>({.+?})</script>', webpage, 'drupal settings'),
             display_id)
         info = {}
         query = {
             'mbr': 'true',
         }
         account_pid, release_pid = [None] * 2
-        tve = settings.get('sharedTVE')
+        tve = settings.get('ls_tve')
         if tve:
             query['manifest'] = 'm3u'
             account_pid = 'HNK2IC'
             release_pid = tve['release_pid']
             if tve.get('entitlement') == 'auth':
-                adobe_pass = settings.get('adobePass', {})
+                adobe_pass = settings.get('tve_adobe_auth', {})
                 resource = self._get_mvpd_resource(
                     adobe_pass.get('adobePassResourceId', 'bravo'),
                     tve['title'], release_pid, tve.get('rating'))
                 query['auth'] = self._extract_mvpd_auth(
                     url, release_pid, adobe_pass.get('adobePassRequestorId', 'bravo'), resource)
+            url = smuggle_url(update_url_query(
+                'http://link.theplatform.com/s/%s/media/%s' % (account_pid, release_pid),
+                query), {'force_smil_url': True})
         else:
-            shared_playlist = settings['shared_playlist']
-            account_pid = shared_playlist['account_pid']
-            metadata = shared_playlist['video_metadata'][shared_playlist['default_clip']]
+            ls_playlist = settings['ls_playlist']
+            account_pid = ls_playlist['account_pid']
+            metadata = ls_playlist['video_metadata'][ls_playlist['default_clip']]
             release_pid = metadata['release_pid']
+            if release_pid:
+                url = smuggle_url(update_url_query(
+                    'http://link.theplatform.com/s/%s/media/%s' % (account_pid, release_pid),
+                    query), {'force_smil_url': True})
+            else:
+                url = ls_playlist['player_base_url']
             info.update({
                 'title': metadata['title'],
                 'description': metadata.get('description'),
@@ -66,9 +78,7 @@ class BravoTVIE(AdobePassIE):
         info.update({
             '_type': 'url_transparent',
             'id': release_pid,
-            'url': smuggle_url(update_url_query(
-                'http://link.theplatform.com/s/%s/%s' % (account_pid, release_pid),
-                query), {'force_smil_url': True}),
+            'url': url,
             'ie_key': 'ThePlatform',
         })
         return info


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This fixes BravoTV by adding the new drupal-settings-json format which fixes #19213
