### PR TITLE
[PostProcessing] Crop mp3 thumbnails

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -287,7 +287,8 @@ def _real_main(argv=None):
         already_have_thumbnail = opts.writethumbnail or opts.write_all_thumbnails
         postprocessors.append({
             'key': 'EmbedThumbnail',
-            'already_have_thumbnail': already_have_thumbnail
+            'already_have_thumbnail': already_have_thumbnail,
+            'crop_thumbnail': opts.cropthumbnail,
         })
         if not already_have_thumbnail:
             opts.writethumbnail = True

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -815,6 +815,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='embedthumbnail', default=False,
         help='Embed thumbnail in the audio as cover art')
     postproc.add_option(
+        '--crop-thumbnail',
+        action='store_true', dest='cropthumbnail', default=False,
+        help='Crop the thumbnail to an square; No effect without --embed-thumbnail')
+    postproc.add_option(
         '--add-metadata',
         action='store_true', dest='addmetadata', default=False,
         help='Write metadata to the video file')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Allow users to square-crop mp3 thumbnails, so they look correctly as an album cover.

Resolves #20011 
