### PR TITLE
pastebin to make typing -f commands shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
     --merge-output-format FORMAT     If a merge is required (e.g.
                                      bestvideo+bestaudio), output to given
                                      container format. One of mkv, mp4, ogg,
-                                     webm, flv. Ignored if no merge is required
+                                     webm, flv. Ignored if no merge is required                  
+Note: Want to make typing -f and -F commands shorter? https://pastebin.com/w13bhrSw
 
 ## Subtitle Options:
     --write-sub                      Write subtitle file


### PR DESCRIPTION
Want to make typing -f and -F commands shorter? https://pastebin.com/w13bhrSw

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Adds a link to the readme to a pastebin of a windows batch file (.bat) that makes typing -f and -F commands shorter.
