### PR TITLE
[putio] Added PutIo extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -894,6 +894,7 @@ from .presstv import PressTVIE
 from .promptfile import PromptFileIE
 from .prosiebensat1 import ProSiebenSat1IE
 from .puls4 import Puls4IE
+from .putio import PutIoIE
 from .pyvideo import PyvideoIE
 from .qqmusic import (
     QQMusicIE,

--- a/youtube_dl/extractor/putio.py
+++ b/youtube_dl/extractor/putio.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+
+from youtube_dl.utils import HEADRequest, UnsupportedError, unified_strdate
+from .common import InfoExtractor
+from ..compat import (
+    compat_str,
+)
+
+
+class PutIoIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?api\.put\.io/v[0-9]+/files/(?P<id>[0-9]+)'
+    _TESTS = [{
+        'url': 'https://app.put.io/files/638463831',
+        'only_matching': True,
+    }, {
+        'url': 'https://api.put.io/v2/files/638474942/download',
+        'only_matching': True,
+    }, {
+        'url': 'https://api.put.io/v2/files/638441619/stream',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        self.to_screen('%s: Getting info for file' % video_id)
+
+        head_req = HEADRequest(url)
+        head_response = self._request_webpage(head_req, video_id, fatal=True)
+        resolved_url = compat_str(head_response.geturl())
+        if url == resolved_url:
+            # we expect a redirect, so if there is none, this URL is invalid
+            raise UnsupportedError(url)
+
+        disposition = head_response.headers.get('Content-Disposition')
+        mobj = re.match(r'.*?filename="(?P<title>[^"]+)".*?', disposition)
+        title = mobj.group('title') or video_id
+
+        info_dict = {
+            'id': video_id,
+            'title': title,
+            'upload_date': unified_strdate(head_response.headers.get('Last-Modified'))
+        }
+
+        # match supported types only, since a URL can point to any type of file
+        content_type = head_response.headers.get('Content-Type', '').lower()
+        m = re.match(
+            r'^(?P<type>audio|video|application(?=/(?:ogg$|(?:vnd\.apple\.|x-)?mpegurl)))/(?P<format_id>[^;\s]+)',
+            content_type)
+        if m:
+            format_id = compat_str(m.group('format_id'))
+            if format_id.endswith('mpegurl'):
+                formats = self._extract_m3u8_formats(resolved_url, video_id, 'mp4')
+            elif format_id == 'f4m':
+                formats = self._extract_f4m_formats(resolved_url, video_id)
+            else:
+                formats = [{
+                    'format_id': format_id,
+                    'url': resolved_url,
+                    'vcodec': 'none' if m.group('type') == 'audio' else None
+                }]
+                info_dict['direct'] = True
+            self._sort_formats(formats)
+            info_dict['formats'] = formats
+            return info_dict
+
+        raise UnsupportedError(url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Added support for [put.io](https://put.io). It supports any kind of file, but it's used primarily for media. Getting additional metadata requires an oauth token with a broader scope, something that the user probably won't have off the bat. A token is provided within the URL, but it is only valid for retrieving files, I think. I made do with the HEAD request.
