### PR TITLE
Option to determine extractors ahead of time

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -9,6 +9,7 @@ import codecs
 import io
 import os
 import random
+import re
 import sys
 
 
@@ -123,6 +124,23 @@ def _real_main(argv=None):
         table = [[mso_id, mso_info['name']] for mso_id, mso_info in MSO_INFO.items()]
         write_string('Supported TV Providers:\n' + render_table(['mso', 'mso name'], table) + '\n', out=sys.stdout)
         sys.exit(0)
+    if opts.determine_extractors:
+        status = 1
+        for url in all_urls:
+            if re.match(r'^[^\s/]+\.[^\s/]+/', url):  # generic.py
+                write_string('The url doesn\'t specify the protocol, trying with http\n', out=sys.stderr)
+                url = 'http://' + url
+            for ie in list_extractors(opts.age_limit):
+                if not ie._WORKING or ie.IE_NAME == 'generic':
+                    continue
+                try:
+                    if re.match(getattr(ie, '_VALID_URL'), url):
+                        write_string(ie.IE_NAME + ' ' + url + '\n', out=sys.stdout)
+                        status = 0
+                        break
+                except AttributeError:
+                    pass
+        sys.exit(status)
 
     # Conflicting, missing and erroneous options
     if opts.usenetrc and (opts.username is not None or opts.password is not None):

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -162,6 +162,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='list_extractor_descriptions', default=False,
         help='Output descriptions of all supported extractors')
     general.add_option(
+        '--determine-extractors',
+        action='store_true', dest='determine_extractors', default=False,
+        help='List the extractor that would be used for each URL. Exit status indicates at least one successful match.')
+    general.add_option(
         '--force-generic-extractor',
         action='store_true', dest='force_generic_extractor', default=False,
         help='Force extraction to use the generic extractor')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Sometimes I just want to know whether youtube-dl can be expected to handle a given URL.  This option accomplishes that quickly.  Previously, I would run youtube-dl with --simulate or --skip-download, but these would take 5+ seconds on my system before returning.  The --determine-extractors option of this PR, however, only takes 1.3 to 2.6 seconds.  You can use it, for example, to handle arbitrary URLs intelligently:  If --determine-extractors indicates success, run youtube-dl (or mpv or whatever).  Otherwise, run $BROWSER.

Thank you.