### PR TITLE
[utils] Only invite error reports from competent users

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2321,7 +2321,11 @@ def bug_reports_message():
         update_cmd = 'type  youtube-dl -U  to update'
     else:
         update_cmd = 'see  https://yt-dl.org/update  on how to update'
-    msg = '; please report this issue on https://yt-dl.org/bug .'
+    msg = '; if you did not run the failing \'youtube-dl\' command yourself, '
+    msg += 'either directly or from a script that you control, please report '
+    msg += 'this issue to the owner of the application, service or script in '
+    msg += 'which this instance of \'youtube-dl\' is embedded; otherwise '
+    msg += 'please report this issue on https://yt-dl.org/bug .'
     msg += ' Make sure you are using the latest version; %s.' % update_cmd
     msg += ' Be sure to call youtube-dl with the --verbose flag and include its complete output.'
     return msg


### PR DESCRIPTION
## Please follow the guide below

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Various other applications and services embed youtube-dl and its forks, in way that may present error messages designed for direct users of youtube-dl to the users of such embedding applications and services. Since such users ran the embedding application or connected to the embedding service, they are generally not competent to respond to an error message that asks them to run youtube-dl with certain command-line options and therefore cannot be helped to solve the issue. They should instead turn to the support channel for the embedding application and service.

Examples: #30140, https://github.com/ytdl-org/youtube-dl/issues?q=is%3Aissue+telegram.

This PR rewords the default postfix message for errors to direct consumers of embedding applications and services away from the youtube-dl bug tracker and towards the support channel for the embedding application and service.