### PR TITLE
[doc] Explain that the opposite of --no-overwrites is --no-continue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,12 +255,15 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
     --restrict-filenames                 Restrict filenames to only ASCII
                                          characters, and avoid "&" and spaces in
                                          filenames
-    -w, --no-overwrites                  Do not overwrite files
+    -w, --no-overwrites                  Do not overwrite files. (For the
+                                         opposite, see --no-continue.)
     -c, --continue                       Force resume of partially downloaded
                                          files. By default, youtube-dl will
                                          resume downloads if possible.
     --no-continue                        Do not resume partially downloaded
-                                         files (restart from beginning)
+                                         files: Instead, restart from the
+                                         beginning and ruthlessly overwrite
+                                         existing files.
     --no-part                            Do not use .part files - write directly
                                          into output file
     --no-mtime                           Do not use the Last-modified header to

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -724,7 +724,7 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '-w', '--no-overwrites',
         action='store_true', dest='nooverwrites', default=False,
-        help='Do not overwrite files')
+        help='Do not overwrite files. (For the opposite, see --no-continue.)')
     filesystem.add_option(
         '-c', '--continue',
         action='store_true', dest='continue_dl', default=True,
@@ -732,7 +732,7 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '--no-continue',
         action='store_false', dest='continue_dl',
-        help='Do not resume partially downloaded files (restart from beginning)')
+        help='Do not resume partially downloaded files: Instead, restart from the beginning and ruthlessly overwrite existing files.')
     filesystem.add_option(
         '--no-part',
         action='store_true', dest='nopart', default=False,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Helps users understand `--no-continue` and thereby maybe solves #32783.