### PR TITLE
README.md: add current Python doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ The `-o` option allows users to indicate a template for the output file names.
 
 **tl;dr:** [navigate me to examples](#output-template-examples).
 
-The basic usage is not to set any template arguments when downloading a single file, like in `youtube-dl -o funny_video.flv "https://some/video"`. However, it may contain special sequences that will be replaced when downloading each video. The special sequences may be formatted according to [Python printf-style string formatting operations](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting) ([Python 2 documentation here](https://docs.python.org/2/library/stdtypes.html#string-formatting)). For example, `%(NAME)s` or `%(NAME)05d`. To clarify, that is a percent symbol followed by a name in parentheses, followed by formatting operations. Allowed names along with sequence type are:
+The basic usage is not to set any template arguments when downloading a single file, like in `youtube-dl -o funny_video.flv "https://some/video"`. However, it may contain special sequences that will be replaced when downloading each video. The special sequences may be formatted according to [Python printf-style string formatting](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting) ([Python 2 documentation here](https://docs.python.org/2/library/stdtypes.html#string-formatting)). For example, `%(NAME)s` or `%(NAME)05d`. To clarify, that is a percent symbol followed by a name in parentheses, followed by a formatting specification. Allowed names along with sequence type are:
 
  - `id` (string): Video identifier
  - `title` (string): Video title


### PR DESCRIPTION
Python 2 is now unsupported by the PSF, so prefer the Python 3 link.

### Prereqs
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
    - I created one before, but I missed that you want full Python 2 compatibility. #32895
- ~~[ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)~~
- ~~[ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them~~
- ~~[ ] Covered the code with tests (note that PRs without tests will be REJECTED)~~
- ~~[ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)~~

### License
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- ~~[ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)~~

### Purpose
- ~~[ ] Bug fix~~
- [x] Improvement
- ~~[ ] New extractor~~
- ~~[ ] New feature~~

---

cc @dirkf