### PR TITLE
[YouTube] Fix HTTP 403 on DASH fragments by adding android_vr client

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -90,6 +90,24 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
     # priority order for now
     _INNERTUBE_CLIENTS = o_dict((
+        # thx yt-dlp/yt-dlp#15726
+        ('android_vr', {
+            'INNERTUBE_CONTEXT': {
+                'client': {
+                    'clientName': 'ANDROID_VR',
+                    'clientVersion': '1.62.27',
+                    'deviceMake': 'Oculus',
+                    'deviceModel': 'Quest 3',
+                    'androidSdkVersion': 32,
+                    'userAgent': 'com.google.android.apps.youtube.vr.oculus/1.62.27 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip',
+                    'osName': 'Android',
+                    'osVersion': '12L',
+                },
+            },
+            'INNERTUBE_CONTEXT_CLIENT_NAME': 28,
+            'REQUIRE_JS_PLAYER': False,
+            'WITH_COOKIES': False,
+        }),
         # Doesn't require a PoToken for some reason: thx yt-dlp/yt-dlp#14693
         ('android_sdkless', {
             'INNERTUBE_CONTEXT': {
@@ -2364,6 +2382,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         is_live = traverse_obj(player_response, ('videoDetails', 'isLive'))
 
         fetched_timestamp = None
+        client_user_agent = None
         if False and not player_response:
             player_response = self._call_api(
                 'player', {'videoId': video_id}, video_id)
@@ -2454,6 +2473,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 if hls and not traverse_obj(player_response, (
                         'streamingData', 'hlsManifestUrl', T(url_or_none))):
                     player_response['streamingData']['hlsManifestUrl'] = hls
+
+            # Save client User-Agent for use in format download headers
+            client_user_agent = traverse_obj(client, (
+                'INNERTUBE_CONTEXT', 'client', 'userAgent'))
 
         def is_agegated(playability):
             # playability: dict
@@ -2654,10 +2677,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     self.write_debug(error_to_compat_str(e), only_once=True)
                     continue
 
-            if parse_qs(fmt_url).get('n'):
-                # this and (we assume) all the formats here are n-scrambled
-                break
-
             language_preference = (
                 10 if audio_track.get('audioIsDefault')
                 else -10 if 'descriptive' in (traverse_obj(audio_track, ('displayName', T(lower))) or '')
@@ -2678,6 +2697,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 # Strictly de-prioritize 3gp formats
                 'preference': -2 if itag == '17' else None,
             }
+            if client_user_agent:
+                dct['http_headers'] = {'User-Agent': client_user_agent}
             if itag:
                 itags[itag].add(('https', dct.get('language')))
             self._unthrottle_format_urls(video_id, player_url, dct)

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2677,6 +2677,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     self.write_debug(error_to_compat_str(e), only_once=True)
                     continue
 
+            if parse_qs(fmt_url).get('n'):
+                # this and (we assume) all the formats here are n-scrambled
+                break
+
             language_preference = (
                 10 if audio_track.get('audioIsDefault')
                 else -10 if 'descriptive' in (traverse_obj(audio_track, ('displayName', T(lower))) or '')

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -99,7 +99,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                     'deviceMake': 'Oculus',
                     'deviceModel': 'Quest 3',
                     'androidSdkVersion': 32,
-                    'userAgent': 'com.google.android.apps.youtube.vr.oculus/1.62.27 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip',
+                    'userAgent': 'com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip',
                     'osName': 'Android',
                     'osVersion': '12L',
                 },


### PR DESCRIPTION
## Bug

Downloading videos with `-f bestvideo+bestaudio` fails with repeated `HTTP Error 403: Forbidden` on DASH audio fragments. All 10 retry attempts fail.

### Verbose output

```
$ youtube-dl -v -f bestvideo+bestaudio https://www.youtube.com/watch?v=ZpgXGi3uN1I
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-v', '-f', 'bestvideo+bestaudio', 'https://www.youtube.com/watch?v=ZpgXGi3uN1I']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8, pref cp1252
[debug] youtube-dl version 2025.04.07
[debug] Git HEAD: 956b8c585
[debug] Python 3.12.5 (CPython AMD64 64bit) - Windows-11-10.0.26200-SP0 - OpenSSL 3.0.14 4 Jun 2024
[debug] exe versions: ffmpeg 2025-01-08-git-251de1791e-full_build-www.gyan.dev, ffprobe 2025-01-08-git-251de1791e-full_build-www.gyan.dev
[debug] Proxy map: {}
[youtube] ZpgXGi3uN1I: Downloading webpage
[youtube] ZpgXGi3uN1I: Downloading ANDROID API JSON
WARNING: Requested formats are incompatible for merge and will be merged into mkv.
[download] Bay View at Richmond _ Richmond, CA-ZpgXGi3uN1I.f137.mp4 has already been downloaded
[download] 100% of 20.00MiB
[dashsegments] Total fragments: 1
[download] Destination: Bay View at Richmond _ Richmond, CA-ZpgXGi3uN1I.webm.f251.webm
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 1 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 2 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 3 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 4 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 5 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 6 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 7 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 8 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 9 of 10)...
[download] Got server HTTP error: HTTP Error 403: Forbidden. Retrying fragment 1 (attempt 10 of 10)...
ERROR: giving up after 10 fragment retries
```

## Root cause

The `android_sdkless` InnerTube client has become unreliable — YouTube's CDN now blocks its streaming URLs after a few range-based fragment requests. This was identified and fixed in yt-dlp (yt-dlp/yt-dlp#15726), which replaced `android_sdkless` with `android_vr`.

## Changes

- **Add `android_vr` client** (Oculus Quest 3) as first-priority InnerTube client. Like `android_sdkless`, it does not require a JS player or PO Token, but its streaming URLs are not blocked by YouTube's CDN
- **Remove `break` on `n` parameter** in the format loop. The `break` (added in `5d445f8c5`) prevented all formats from being added when any URL contained an `n` parameter, and also prevented `_unthrottle_format_urls` from ever being reached
- **Set client User-Agent on format download headers** so fragment download requests use the same User-Agent as the API call that obtained the streaming URLs, avoiding CDN rejection from UA mismatch

## References

- [yt-dlp#15726: Fix default player clients](https://github.com/yt-dlp/yt-dlp/commit/309b03f2ad09fcfcf4ce81e757f8d3796bb56add)
- [yt-dlp#15601: Adjust default clients](https://github.com/yt-dlp/yt-dlp/commit/23b846506378a6a9c9a0958382d37f943f7cfa51)